### PR TITLE
Refactor: delete @Builder from CreateFaqRequest and use reflection me…

### DIFF
--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/faq/dto/request/CreateFaqRequest.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/faq/dto/request/CreateFaqRequest.java
@@ -1,11 +1,9 @@
 package kernel.jdon.moduleapi.domain.faq.dto.request;
 
 import kernel.jdon.moduleapi.domain.faq.entity.Faq;
-import lombok.Builder;
 import lombok.Getter;
 
 @Getter
-@Builder
 public class CreateFaqRequest {
 	private String title;
 	private String content;

--- a/module-api/src/test/java/kernel/jdon/moduleapi/domain/faq/service/FaqServiceTest.java
+++ b/module-api/src/test/java/kernel/jdon/moduleapi/domain/faq/service/FaqServiceTest.java
@@ -2,6 +2,7 @@ package kernel.jdon.moduleapi.domain.faq.service;
 
 import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.*;
+import static org.springframework.test.util.ReflectionTestUtils.*;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
@@ -49,11 +50,9 @@ public class FaqServiceTest {
 		String createTitle = "FAQ 제목 생성 테스트";
 		String createContent = "FAQ content 생성 테스트";
 
-		CreateFaqRequest createFaqRequest = CreateFaqRequest.builder()
-			.title(createTitle)
-			.content(createContent)
-			.build();
-
+		CreateFaqRequest createFaqRequest = new CreateFaqRequest();
+		setField(createFaqRequest, "title", createTitle);
+		setField(createFaqRequest, "content", createContent);
 		// when
 		CreateFaqResponse createFaqResponse = faqService.create(createFaqRequest);
 		Long faqId = createFaqResponse.getId();


### PR DESCRIPTION
## 개요
- CreateFaqRequest.java 파일은 테스트 코드를 작성하기 위해 다음과 같았습니다.
- 하지만 test코드에 CreateFaqRequest 객체를 만들어주기 위해 @Builder를 추가했었습니다.


자바의 reflection API를 사용하여 CreateFaqRequest 클래스의 인스턴스에 대한 private 필드들 (title, content)에 값을 설정하였습니다. Reflection을 여기에서 사용한 이유는 해당 필드들이 private이고, 클래스에 public setter 메소드로 필드 값을 설정하는 방식을 지양했기 때문입니다.

통상적으로 클래스 외부에서 그 클래스의 private 필드에 직접 접근할 수 없습니다. 
하지만, Reflection API는 이러한 접근 제한을 우회하여 어떤 필드에든 접근할 수 있게 해줍니다.

결론적으로 요약하자면, 여기서 제가 사용한 setField() 메소드는 reflection API를 사용하여 주어진 객체의 특정 필드에 값을 설정합니다.

- 자바 reflection에 대한 좋은 글이 있어서 공유드립니다.
https://hudi.blog/java-reflection/

### 요약
테스트 코드를 작성하기 위해 개발 코드를 변경하는 것이 좋지 않다는 생각이 들었습니다.
따라서, @Builder를 붙이지 않고 테스트 하도록 코드를 변경하였습니다.
### 변경한 부분
- CreateFaqRequest의 @Builder 제거
- FaqServiceTest의 createFaqTest 메소드에서 CreateFaqRequest를 builder로 생성하던 부분을 reflection을 사용하여 객체의 private 필드에 값을 설정하는 setField 메서드로 바꿈
### 변경한 결과




### 이슈

- closes: #19 

---

## PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경, 주석 변경)
- [x] 코드 리팩토링
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 파일 혹은 폴더명 수정, 삭제
- [ ] 배포 관련