### PR TITLE
Feature: ErrorCode, FaqErrorCode 생성 및 적용

### DIFF
--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/faq/service/FaqService.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/faq/service/FaqService.java
@@ -13,6 +13,8 @@ import kernel.jdon.moduleapi.domain.faq.dto.response.FindListFaqResponse;
 import kernel.jdon.moduleapi.domain.faq.dto.response.UpdateFaqResponse;
 import kernel.jdon.moduleapi.domain.faq.entity.Faq;
 import kernel.jdon.moduleapi.domain.faq.repository.FaqRepository;
+import kernel.jdon.modulecommon.error.code.FaqErrorCode;
+import kernel.jdon.modulecommon.error.exception.api.ApiException;
 import lombok.RequiredArgsConstructor;
 
 @Service
@@ -23,7 +25,7 @@ public class FaqService {
 
 	private Faq findById(Long faqId) {
 		return faqRepository.findById(faqId)
-			.orElseThrow(() -> new IllegalArgumentException("존재하지 않는 Faq 입니다."));
+			.orElseThrow(() -> new ApiException(FaqErrorCode.NOT_FOUND_FAQ));
 	}
 
 	@Transactional

--- a/module-common/build.gradle
+++ b/module-common/build.gradle
@@ -23,6 +23,7 @@ repositories {
 
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
 
     compileOnly 'org.projectlombok:lombok'
 
@@ -34,3 +35,8 @@ dependencies {
 tasks.named('test') {
     useJUnitPlatform()
 }
+
+jar {
+    enabled = true
+}
+

--- a/module-common/src/main/java/kernel/jdon/modulecommon/error/code/ErrorCode.java
+++ b/module-common/src/main/java/kernel/jdon/modulecommon/error/code/ErrorCode.java
@@ -1,0 +1,8 @@
+package kernel.jdon.modulecommon.error.code;
+
+import org.springframework.http.HttpStatus;
+
+public interface ErrorCode {
+	HttpStatus getHttpStatus();
+	String getMessage();
+}

--- a/module-common/src/main/java/kernel/jdon/modulecommon/error/code/FaqErrorCode.java
+++ b/module-common/src/main/java/kernel/jdon/modulecommon/error/code/FaqErrorCode.java
@@ -1,0 +1,23 @@
+package kernel.jdon.modulecommon.error.code;
+
+import org.springframework.http.HttpStatus;
+
+import lombok.AllArgsConstructor;
+
+@AllArgsConstructor
+public enum FaqErrorCode implements ErrorCode {
+	NOT_FOUND_FAQ(HttpStatus.NOT_FOUND, "존재하지 않는 FAQ 입니다.");
+
+	private final HttpStatus httpStatus;
+	private final String message;
+
+	@Override
+	public HttpStatus getHttpStatus() {
+		return httpStatus;
+	}
+
+	@Override
+	public String getMessage() {
+		return message;
+	}
+}

--- a/module-common/src/main/java/kernel/jdon/modulecommon/error/exception/api/ApiException.java
+++ b/module-common/src/main/java/kernel/jdon/modulecommon/error/exception/api/ApiException.java
@@ -3,7 +3,7 @@ package kernel.jdon.modulecommon.error.exception.api;
 import kernel.jdon.modulecommon.error.code.ErrorCode;
 
 public class ApiException extends RuntimeException {
-	private ErrorCode errorCode;
+	private transient ErrorCode errorCode;
 
 	public ApiException(ErrorCode errorCode) {
 		this.errorCode = errorCode;

--- a/module-common/src/main/java/kernel/jdon/modulecommon/error/exception/api/ApiException.java
+++ b/module-common/src/main/java/kernel/jdon/modulecommon/error/exception/api/ApiException.java
@@ -1,0 +1,11 @@
+package kernel.jdon.modulecommon.error.exception.api;
+
+import kernel.jdon.modulecommon.error.code.ErrorCode;
+
+public class ApiException extends RuntimeException {
+	private ErrorCode errorCode;
+
+	public ApiException(ErrorCode errorCode) {
+		this.errorCode = errorCode;
+	}
+}


### PR DESCRIPTION
## 개요

### 요약
- module-common
  - ErrorCode 및 ApiException 구현
  - FaqErrorCode 구현
  - build.gradle 
    - spring-boot-starter-web 의존성 추가
    - module-common은 jar 파일이 필요 없기 때문에 아래 설정부분 추가
```
jar {
    enabled = true
}
```

- module-api
  - FaqErrorCode 적용

### 변경한 부분
- module-common
  - 도메인 별 ErrorCode(ex.FaqErrorCode)에서 HTTPStatus 클래스를 필요로하여 spring-boot-starter-web 의존성 추가하였습니다.
  - ErrorCode interface 및 module-api 모듈에서만 사용하는 RuntimeException을 상속받은 ApiException을 생성하였습니다.
  - 구현된 FAQ 도메인에서 사용할 FaqErrorCode를 생성하였습니다.

- module-api
  - 기존 임시로 적용했던 IllegalArgumentException을 제거하고 FaqErrorCode를 적용함에 따라 FaqService, FaqServiceTest를 수정하였습니다.


### 이슈

- closes: #31

---

## PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경, 주석 변경)
- [ ] 코드 리팩토링
- [ ] 문서 수정
- [x] 테스트 추가, 테스트 리팩토링
- [ ] 파일 혹은 폴더명 수정, 삭제
- [ ] 배포 관련