### PR TITLE
Fix: Add faqId at FindFaqListResponse

### DIFF
--- a/module-api/src/test/java/kernel/jdon/moduleapi/domain/faq/service/FaqServiceTest.java
+++ b/module-api/src/test/java/kernel/jdon/moduleapi/domain/faq/service/FaqServiceTest.java
@@ -127,10 +127,11 @@ public class FaqServiceTest {
 
 		// then
 		assertNotNull(findListFaqResponse);
+		assertThat(savedFaq1.getId()).isEqualTo(findListFaqResponse.getFaqList().get(0).getFaqId());
 		assertThat(createTitle1).isEqualTo(findListFaqResponse.getFaqList().get(0).getTitle());
 		assertThat(createContent1).isEqualTo(findListFaqResponse.getFaqList().get(0).getContent());
+		assertThat(savedFaq2.getId()).isEqualTo(findListFaqResponse.getFaqList().get(1).getFaqId());
 		assertThat(createTitle2).isEqualTo(findListFaqResponse.getFaqList().get(1).getTitle());
 		assertThat(createContent2).isEqualTo(findListFaqResponse.getFaqList().get(1).getContent());
-
 	}
 }

--- a/module-domain/src/main/java/kernel/jdon/faq/dto/response/FindFaqResponse.java
+++ b/module-domain/src/main/java/kernel/jdon/faq/dto/response/FindFaqResponse.java
@@ -9,11 +9,13 @@ import lombok.Getter;
 @Builder
 @AllArgsConstructor
 public class FindFaqResponse {
+	private Long faqId;
 	private String title;
 	private String content;
 
 	public static FindFaqResponse of(Faq faq) {
 		return FindFaqResponse.builder()
+			.faqId(faq.getId())
 			.title(faq.getTitle())
 			.content(faq.getContent())
 			.build();


### PR DESCRIPTION
## 개요

### 요약
faq 목록 조회 API의 응답에 faqId를 추가하였습니다. 

### 변경한 부분
- FindFaqResponse 에 faqId 필드를 추가했습니다. 
- FaqServiceTest에 id를 확인하는 코드를 추가했습니다. 

### 변경한 결과
이제 faq 목록 조회를 하면 id, title, content가 같이 옵니다. 
<img width="362" alt="스크린샷 2023-12-19 오후 5 30 43" src="https://github.com/Kernel360/f1-JDON-Backend/assets/68376744/683cb1c5-008e-4fd8-b843-7255bbf1e3a0">

### 이슈

- closes: #39 

---

## PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [X] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경, 주석 변경)
- [ ] 코드 리팩토링
- [ ] 문서 수정
- [X] 테스트 추가, 테스트 리팩토링
- [ ] 파일 혹은 폴더명 수정, 삭제
- [ ] 배포 관련