### PR TITLE
Chore: jdk 버전 변경(21 -> 17) 및 하위 모듈 settings.gradle 파일 삭제

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ group = 'kernel.jdon'
 version = '0.0.1-SNAPSHOT'
 
 java {
-    sourceCompatibility = '21'
+    sourceCompatibility = '17'
 }
 
 repositories {

--- a/module-api/build.gradle
+++ b/module-api/build.gradle
@@ -8,7 +8,7 @@ group = 'kernel.jdon'
 version = '0.0.1-SNAPSHOT'
 
 java {
-    sourceCompatibility = '21'
+    sourceCompatibility = '17'
 }
 
 configurations {

--- a/module-api/settings.gradle
+++ b/module-api/settings.gradle
@@ -1,1 +1,0 @@
-rootProject.name = 'module-api'

--- a/module-common/build.gradle
+++ b/module-common/build.gradle
@@ -8,7 +8,7 @@ group = 'kernel.jdon'
 version = '0.0.1-SNAPSHOT'
 
 java {
-    sourceCompatibility = '21'
+    sourceCompatibility = '17'
 }
 
 configurations {

--- a/module-common/settings.gradle
+++ b/module-common/settings.gradle
@@ -1,1 +1,0 @@
-rootProject.name = 'module-common'

--- a/module-domain/build.gradle
+++ b/module-domain/build.gradle
@@ -8,7 +8,7 @@ group = 'kernel.jdon'
 version = '0.0.1-SNAPSHOT'
 
 java {
-    sourceCompatibility = '21'
+    sourceCompatibility = '17'
 }
 
 configurations {

--- a/module-domain/settings.gradle
+++ b/module-domain/settings.gradle
@@ -1,1 +1,0 @@
-rootProject.name = 'module-domain'


### PR DESCRIPTION
## 개요
- jdk 17로 변경
- 하위 모듈들에서 settings.gradle 삭제

### 변경한 부분
- 수동 빌드 시 gradle과 jdk 21이 호환되지 않아 jdk 17로 다운 그레이션 진행
  - Project Structure 에서 project setting내 SDK를 17로 변경이 필요합니다. 
  - 모든 build.gradle 파일에서 sourceCompatibility 를 17로 수정했습니다.
 
- root module이 아닌 하위 module에 settings.gradle 파일이 있으면 빌드시에 오류가 발생하여 삭제

### 이슈

- closes: #41 

---

## PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경, 주석 변경)
- [ ] 코드 리팩토링
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [x] 파일 혹은 폴더명 수정, 삭제
- [ ] 배포 관련