### PR TITLE
Chore: module-api 빌드설정 수정(plain.jar 생성X)

### DIFF
--- a/module-api/build.gradle
+++ b/module-api/build.gradle
@@ -38,6 +38,14 @@ dependencies {
     testImplementation 'com.h2database:h2'
 }
 
+tasks.bootJar {
+    enabled = true
+}
+
+tasks.jar {
+    enabled = false
+}
+
 tasks.named('test') {
     useJUnitPlatform()
 }


### PR DESCRIPTION
### 요약
api 모듈 빌드시 plain.jar 생성하지 않도록 build.gradle 수정

plain.jar를 생성하지 않도록 tasks.jar를 false로 변경했습니다.
실행가능한 jar 파일을 생성하는 bootJar옵션은 디폴트가 true이나 명시적으로 추가했습니다

### 변경한 부분
moudle-api내 build.gradle
### 변경한 결과
빌드시 plain.jar를 더 이상 생성하지 않고 .jar 파일만 생성

### 이슈

- closes: #47 

---

## PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경, 주석 변경)
- [ ] 코드 리팩토링
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 파일 혹은 폴더명 수정, 삭제
- [x] 배포 관련