### PR TITLE
Feature: api모듈 logback 적용 및 common, domain 모듈 prepareKotlinBuildScriptModel 적용

### DIFF
--- a/module-api/src/main/resources/application.yml
+++ b/module-api/src/main/resources/application.yml
@@ -15,6 +15,7 @@ spring:
         format_sql: true
 
 logging.level:
+  root: info
+
   org.hibernate.SQL: debug
   #  org.hibernate.type: trace
-  org.springframework.security: debug

--- a/module-api/src/main/resources/logback-spring.xml
+++ b/module-api/src/main/resources/logback-spring.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <!-- 로그 패턴에 색상 적용 %clr(pattern){color} -->
+    <conversionRule conversionWord="clr" converterClass="org.springframework.boot.logging.logback.ColorConverter" />
+
+    <!-- log 변수 값 설정 -->
+    <property name="CONSOLE_LOG_PATTERN"
+              value="[%d{yyyy-MM-dd HH:mm:ss}:%-3relative]  %clr(%-5level) %clr(${PID:-}){magenta} %clr(---){faint} %clr([%15.15thread]){faint} %clr(%-40.40logger{36}){cyan} %clr(:){faint} %msg%n"/>
+
+    <!-- 콘솔(STDOUT) -->
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <layout class="ch.qos.logback.classic.PatternLayout">
+            <Pattern>${CONSOLE_LOG_PATTERN}</Pattern>
+        </layout>
+    </appender>
+
+    <!-- log root 레벨 설정 (logging.level.root=info)-->
+    <root level="info">
+        <!-- 참조할 appender 설정 - STDOUT -->
+        <appender-ref ref="STDOUT" />
+    </root>
+
+</configuration>

--- a/module-common/build.gradle
+++ b/module-common/build.gradle
@@ -30,6 +30,8 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok'
 }
 
+tasks.register("prepareKotlinBuildScriptModel") {}
+
 tasks.named('test') {
     useJUnitPlatform()
 }

--- a/module-domain/build.gradle
+++ b/module-domain/build.gradle
@@ -31,6 +31,8 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }
 
+tasks.register("prepareKotlinBuildScriptModel") {}
+
 tasks.named('test') {
     useJUnitPlatform()
 }


### PR DESCRIPTION
## 개요
- logback-spring.xml 추가
- common, domain 모듈 build.gradle에 prepareKotlinBuildScriptModel 옵션 추가
### 요약

### 변경한 부분
- module-api에 logback-spring.xml을 생성하고 application.yml 파일에서 로그레벨을 info로 설정했습니다.
- module-common, module-domain 빌드 시 다음과 같은 에러가 발생했습니다.
![image](https://github.com/Kernel360/f1-JDON-Backend/assets/59242594/568c4e80-5f1c-4779-8587-aae0e472d47c)

### 변경한 결과
프로젝트에서 Kotlin 코드를 포함하고 있지 않기 때문에 tasks.register("prepareKotlinBuildScriptModel") {} 을 설정하여 정상빌드 되도록 변경했습니다.
![image](https://github.com/Kernel360/f1-JDON-Backend/assets/59242594/3b5afd3a-a74b-4477-be77-c4c3b3ddbccd)


### 이슈

- closes: #45 

---

## PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [x] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경, 주석 변경)
- [ ] 코드 리팩토링
- [x] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 파일 혹은 폴더명 수정, 삭제
- [ ] 배포 관련