### PR TITLE
Fix: 폼 로그인 설계 변경으로 인한 Member 엔티티 수정

### DIFF
--- a/module-domain/src/main/java/kernel/jdon/member/domain/Member.java
+++ b/module-domain/src/main/java/kernel/jdon/member/domain/Member.java
@@ -31,13 +31,10 @@ public class Member {
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
 
-	@Column(name = "email", columnDefinition = "VARCHAR(255)", nullable = false)
+	@Column(name = "email", columnDefinition = "VARCHAR(255)", nullable = false, unique = true)
 	private String email;
 
-	@Column(name = "password", columnDefinition = "VARCHAR(255)", nullable = false)
-	private String password;
-
-	@Column(name = "nickname", columnDefinition = "VARCHAR(255)", nullable = false)
+	@Column(name = "nickname", columnDefinition = "VARCHAR(255)", nullable = false, unique = true)
 	private String nickname;
 
 	@Column(name = "birth", columnDefinition = "VARCHAR(11)", nullable = false)
@@ -64,6 +61,9 @@ public class Member {
 
 	@Column(name = "withdraw_date", columnDefinition = "DATETIME")
 	private LocalDateTime withdrawDate;
+
+	@Column(name = "social_provider", columnDefinition = "VARCHAR(20)", nullable = false)
+	private String socialProvider;
 
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "job_category_id", columnDefinition = "BIGINT")


### PR DESCRIPTION
## 개요

### 요약
Member entity 수정

### 변경한 부분
- `nickname`, `email` 필드에 `unique=true` 옵션이 누락되어 추가했습니다.
- 어느 경로에서 `소셜 회원가입`을 했는지 `식별`할 수 있는 `social_provider` 컬럼 추가했습니다.
- 설계 단계에서 폼 로그인 기능이 삭제되어 불필요한 컬럼인 `password` `제거`했습니다.

### 이슈

- closes: #49 

---

## PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [X] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경, 주석 변경)
- [ ] 코드 리팩토링
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 파일 혹은 폴더명 수정, 삭제
- [ ] 배포 관련