### PR TITLE
Chore: 모듈 별 config 파일 이동

### DIFF
--- a/module-domain/src/main/java/kernel/jdon/config/JpaAuditingConfig.java
+++ b/module-domain/src/main/java/kernel/jdon/config/JpaAuditingConfig.java
@@ -5,5 +5,5 @@ import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @Configuration
 @EnableJpaAuditing
-public class JpaAuditingConfig {  
+public class JpaAuditingConfig {
 }


### PR DESCRIPTION
## 개요

### 요약
- config/JpaAuditingConfig.java 파일 및 패키지의 모듈 위치 변경

### 변경한 부분
- module-common에 위치한 config 패키지를 특정 모듈에서 사용하는 config 별로 분리하였습니다.
  - module-common에 위치한 JpaAuditingConfig 파일은 module-domain에 종속된 config 파일이기 때문에 module-domain으로 config 패키지 생성 후 이동 시켰습니다.

### 이슈

- closes: #57 

---

## PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경, 주석 변경)
- [ ] 코드 리팩토링
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 파일 혹은 폴더명 수정, 삭제
- [ ] 배포 관련