### PR TITLE
BugFix: skill, job_category 테이블 수정

### DIFF
--- a/module-domain/src/main/java/kernel/jdon/jobcategory/domain/JobCategory.java
+++ b/module-domain/src/main/java/kernel/jdon/jobcategory/domain/JobCategory.java
@@ -20,7 +20,7 @@ public class JobCategory extends BaseEntity {
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
 
-	@Column(name = "name", columnDefinition = "VARCHAR(255)", nullable = false)
+	@Column(name = "name", columnDefinition = "VARCHAR(255)", nullable = false, unique = true)
 	private String name;
 
 	@Column(name = "parent_id", columnDefinition = "BIGINT")

--- a/module-domain/src/main/java/kernel/jdon/skill/domain/Skill.java
+++ b/module-domain/src/main/java/kernel/jdon/skill/domain/Skill.java
@@ -14,8 +14,13 @@ import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import kernel.jdon.jobcategory.domain.JobCategory;
 import kernel.jdon.wantedskill.domain.WantedJdSkill;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
+@Getter
+@NoArgsConstructor
 @Table(name = "skill")
 public class Skill {
 
@@ -25,6 +30,9 @@ public class Skill {
 
 	@Column(name = "keyword", columnDefinition = "VARCHAR(50)", nullable = false)
 	private String keyword;
+
+	@Column(name = "count", columnDefinition = "BIGINT", nullable = false)
+	private Long count;
 
 	@OneToMany(mappedBy = "skill")
 	private ArrayList<WantedJdSkill> wantedJdSkillList = new ArrayList<>();


### PR DESCRIPTION
## 개요

### 요약
- skill 테이블 count컬럼 추가
- job_category 테이블 name 컬럼 unique 제약조건 추가
### 변경한 부분
- 원티드에서 추출한 skill의 빈도 수를 확인하기 위한 skill 테이블 count컬럼 추가
- 직무, 직군 데이터를 저장하는 job_category 테이블 name 컬럼에 unique 제약조건 추가

### 이슈

- closes: #62 

---

## PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경, 주석 변경)
- [ ] 코드 리팩토링
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 파일 혹은 폴더명 수정, 삭제
- [ ] 배포 관련