### PR TITLE
Feature: 원티드 jd 스크래핑 구현

### DIFF
--- a/module-common/src/main/java/kernel/jdon/util/StringUtil.java
+++ b/module-common/src/main/java/kernel/jdon/util/StringUtil.java
@@ -1,0 +1,20 @@
+package kernel.jdon.util;
+
+import java.util.Arrays;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class StringUtil {
+	public static String createQueryString(String key, String value) {
+		return joinToString(key, "=", value, "&");
+	}
+
+	public static String joinToString(Object... args) {
+		StringBuilder sb = new StringBuilder();
+		Arrays.stream(args).forEach(sb::append);
+		return sb.toString();
+	}
+
+}

--- a/module-crawler/src/main/java/kernel/jdon/config/AppConfig.java
+++ b/module-crawler/src/main/java/kernel/jdon/config/AppConfig.java
@@ -1,0 +1,13 @@
+package kernel.jdon.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class AppConfig {
+	@Bean
+	public RestTemplate restTemplate() {
+		return new RestTemplate();
+	}
+}

--- a/module-crawler/src/main/java/kernel/jdon/config/UrlConfig.java
+++ b/module-crawler/src/main/java/kernel/jdon/config/UrlConfig.java
@@ -1,0 +1,19 @@
+package kernel.jdon.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.PropertySource;
+
+import lombok.Getter;
+
+@Getter
+@Configuration
+@PropertySource("classpath:url.properties")
+public class UrlConfig {
+	@Value("${url.wanted.detail}")
+	private String wantedJobDetailUrl;
+	@Value("${url.wanted.api.list}")
+	private String wantedApiJobListUrl;
+	@Value("${url.wanted.api.detail}")
+	private String wantedApiJobDetailUrl;
+}

--- a/module-crawler/src/main/java/kernel/jdon/crawler/wanted/controller/WantedCrawlerController.java
+++ b/module-crawler/src/main/java/kernel/jdon/crawler/wanted/controller/WantedCrawlerController.java
@@ -1,0 +1,21 @@
+package kernel.jdon.crawler.wanted.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import kernel.jdon.crawler.wanted.service.WantedCrawlerService;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+public class WantedCrawlerController {
+
+	private final WantedCrawlerService wantedCrawlerService;
+
+	@GetMapping("/api/v1/crawler/wanted")
+	public ResponseEntity<Object> getWantedData() {
+		wantedCrawlerService.fetchJd();
+		return ResponseEntity.noContent().build();
+	}
+}

--- a/module-crawler/src/main/java/kernel/jdon/crawler/wanted/converter/EntityConverter.java
+++ b/module-crawler/src/main/java/kernel/jdon/crawler/wanted/converter/EntityConverter.java
@@ -9,8 +9,7 @@ import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
-public class EntityFactory {
-
+public class EntityConverter {
 	public static WantedJdSkill createWantedJdSkill(WantedJd wantedJd, Skill skill) {
 		return WantedJdSkill.builder()
 			.wantedJd(wantedJd)

--- a/module-crawler/src/main/java/kernel/jdon/crawler/wanted/converter/EntityFactory.java
+++ b/module-crawler/src/main/java/kernel/jdon/crawler/wanted/converter/EntityFactory.java
@@ -1,0 +1,38 @@
+package kernel.jdon.crawler.wanted.converter;
+
+import kernel.jdon.crawler.wanted.dto.object.CreateSkillDto;
+import kernel.jdon.crawler.wanted.dto.response.WantedJobDetailResponse;
+import kernel.jdon.skill.domain.Skill;
+import kernel.jdon.wanted.domain.WantedJd;
+import kernel.jdon.wantedskill.domain.WantedJdSkill;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class EntityFactory {
+
+	public static WantedJdSkill createWantedJdSkill(WantedJd wantedJd, Skill skill) {
+		return WantedJdSkill.builder()
+			.wantedJd(wantedJd)
+			.skill(skill)
+			.build();
+	}
+
+	public static WantedJd createWantedJd(WantedJobDetailResponse wantedJobDetailResponse) {
+		return WantedJd.builder()
+			.jobCategory(wantedJobDetailResponse.getJobCategory())
+			.companyName(wantedJobDetailResponse.getJob().getCompany().getName())
+			.detailId(wantedJobDetailResponse.getJob().getId())
+			.detailUrl(wantedJobDetailResponse.getDetailUrl())
+			.imageUrl(wantedJobDetailResponse.getJob().getCompanyImages())
+			.build();
+	}
+
+	public static Skill createSkill(CreateSkillDto createSkillDto) {
+		return Skill.builder()
+			.keyword(createSkillDto.getKeyword())
+			.count(createSkillDto.getCount())
+			.jobCategory(createSkillDto.getJobCategory())
+			.build();
+	}
+}

--- a/module-crawler/src/main/java/kernel/jdon/crawler/wanted/dto/object/CreateSkillDto.java
+++ b/module-crawler/src/main/java/kernel/jdon/crawler/wanted/dto/object/CreateSkillDto.java
@@ -1,0 +1,17 @@
+package kernel.jdon.crawler.wanted.dto.object;
+
+import kernel.jdon.jobcategory.domain.JobCategory;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class CreateSkillDto {
+	private JobCategory jobCategory;
+	private String keyword;
+	private Long count;
+}

--- a/module-crawler/src/main/java/kernel/jdon/crawler/wanted/dto/response/WantedJobDetailResponse.java
+++ b/module-crawler/src/main/java/kernel/jdon/crawler/wanted/dto/response/WantedJobDetailResponse.java
@@ -1,0 +1,75 @@
+package kernel.jdon.crawler.wanted.dto.response;
+
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import kernel.jdon.jobcategory.domain.JobCategory;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class WantedJobDetailResponse {
+
+	private JobDetail job;
+	private String detailUrl;
+	private JobCategory jobCategory;
+
+	public void setDetailUrl(String detailUrl) {
+		this.detailUrl = detailUrl;
+	}
+
+	public void setJobCategory(JobCategory jobCategory) {
+		this.jobCategory = jobCategory;
+	}
+
+	@Getter
+	@NoArgsConstructor(access = AccessLevel.PRIVATE)
+	public static class JobDetail {
+		private Long id;
+		private Detail detail;
+		private Company company;
+		@JsonProperty("skill_tags")
+		private List<WantedSkill> skill;
+		@JsonProperty("company_images")
+		private List<CompanyImages> companyImages;
+
+		public String getCompanyImages() {
+			return String.valueOf(companyImages.get(0).url);
+		}
+	}
+
+	@Getter
+	@NoArgsConstructor(access = AccessLevel.PRIVATE)
+	public static class Detail {
+		private String requirements;
+		@JsonProperty("main_tasks")
+		private String mainTasks;
+		private String intro;
+		private String benefits;
+		@JsonProperty("preferred_points")
+		private String preferredPoints;
+	}
+
+	@Getter
+	@NoArgsConstructor(access = AccessLevel.PRIVATE)
+	public static class WantedSkill {
+		@JsonProperty("title")
+		private String keyword;
+	}
+
+	@Getter
+	@NoArgsConstructor(access = AccessLevel.PRIVATE)
+	public static class Company {
+		private String id;
+		private String name;
+	}
+
+	@Getter
+	@NoArgsConstructor(access = AccessLevel.PRIVATE)
+	public static class CompanyImages {
+		private String url;
+	}
+}

--- a/module-crawler/src/main/java/kernel/jdon/crawler/wanted/dto/response/WantedJobListResponse.java
+++ b/module-crawler/src/main/java/kernel/jdon/crawler/wanted/dto/response/WantedJobListResponse.java
@@ -1,0 +1,20 @@
+package kernel.jdon.crawler.wanted.dto.response;
+
+import java.util.List;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class WantedJobListResponse {
+
+	private List<Data> data;
+
+	@Getter
+	@NoArgsConstructor(access = AccessLevel.PRIVATE)
+	public static class Data {
+		private Long id;
+	}
+}

--- a/module-crawler/src/main/java/kernel/jdon/crawler/wanted/repository/JobCategoryRepository.java
+++ b/module-crawler/src/main/java/kernel/jdon/crawler/wanted/repository/JobCategoryRepository.java
@@ -1,0 +1,11 @@
+package kernel.jdon.crawler.wanted.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import kernel.jdon.jobcategory.domain.JobCategory;
+
+public interface JobCategoryRepository extends JpaRepository<JobCategory, Long> {
+	Optional<JobCategory> findByWantedCode(String wantedCode);
+}

--- a/module-crawler/src/main/java/kernel/jdon/crawler/wanted/repository/SkillRepository.java
+++ b/module-crawler/src/main/java/kernel/jdon/crawler/wanted/repository/SkillRepository.java
@@ -1,0 +1,12 @@
+package kernel.jdon.crawler.wanted.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import kernel.jdon.skill.domain.Skill;
+
+public interface SkillRepository extends JpaRepository<Skill, Long> {
+	Optional<Skill> findByJobCategoryIdAndKeyword(Long jobCategoryId, String keyword);
+	boolean existsByJobCategoryIdAndKeyword(Long jobCategoryId, String keyword);
+}

--- a/module-crawler/src/main/java/kernel/jdon/crawler/wanted/repository/WantedJdRepository.java
+++ b/module-crawler/src/main/java/kernel/jdon/crawler/wanted/repository/WantedJdRepository.java
@@ -1,0 +1,11 @@
+package kernel.jdon.crawler.wanted.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import kernel.jdon.jobcategory.domain.JobCategory;
+import kernel.jdon.wanted.domain.WantedJd;
+
+public interface WantedJdRepository extends JpaRepository<WantedJd, Long> {
+	boolean existsByJobCategoryAndDetailId(JobCategory jobCategory, Long detailId);
+
+}

--- a/module-crawler/src/main/java/kernel/jdon/crawler/wanted/repository/WantedJdSkillRepository.java
+++ b/module-crawler/src/main/java/kernel/jdon/crawler/wanted/repository/WantedJdSkillRepository.java
@@ -1,0 +1,8 @@
+package kernel.jdon.crawler.wanted.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import kernel.jdon.wantedskill.domain.WantedJdSkill;
+
+public interface WantedJdSkillRepository extends JpaRepository<WantedJdSkill, Long> {
+}

--- a/module-crawler/src/main/java/kernel/jdon/crawler/wanted/search/JobSearchCondition.java
+++ b/module-crawler/src/main/java/kernel/jdon/crawler/wanted/search/JobSearchCondition.java
@@ -1,0 +1,6 @@
+package kernel.jdon.crawler.wanted.search;
+
+public interface JobSearchCondition {
+	String getSearchValue();
+	String getDescription();
+}

--- a/module-crawler/src/main/java/kernel/jdon/crawler/wanted/search/JobSearchExperience.java
+++ b/module-crawler/src/main/java/kernel/jdon/crawler/wanted/search/JobSearchExperience.java
@@ -3,7 +3,7 @@ package kernel.jdon.crawler.wanted.search;
 import lombok.AllArgsConstructor;
 
 @AllArgsConstructor
-public enum JobSearchExperience implements JobSearchCondition{
+public enum JobSearchExperience implements JobSearchCondition {
 	EXPERIENCE_ALL("-1", "전체");
 
 	public final static String SEARCH_KEY = "years";

--- a/module-crawler/src/main/java/kernel/jdon/crawler/wanted/search/JobSearchExperience.java
+++ b/module-crawler/src/main/java/kernel/jdon/crawler/wanted/search/JobSearchExperience.java
@@ -1,0 +1,23 @@
+package kernel.jdon.crawler.wanted.search;
+
+import lombok.AllArgsConstructor;
+
+@AllArgsConstructor
+public enum JobSearchExperience implements JobSearchCondition{
+	EXPERIENCE_ALL("-1", "전체");
+
+	public final static String SEARCH_KEY = "years";
+	private final String searchValue;
+	private final String description;
+
+
+	@Override
+	public String getDescription() {
+		return this.description;
+	}
+
+	@Override
+	public String getSearchValue() {
+		return this.searchValue;
+	}
+}

--- a/module-crawler/src/main/java/kernel/jdon/crawler/wanted/search/JobSearchJobCategory.java
+++ b/module-crawler/src/main/java/kernel/jdon/crawler/wanted/search/JobSearchJobCategory.java
@@ -3,7 +3,7 @@ package kernel.jdon.crawler.wanted.search;
 import lombok.AllArgsConstructor;
 
 @AllArgsConstructor
-public enum JobSearchJobCategory implements JobSearchCondition{
+public enum JobSearchJobCategory implements JobSearchCondition {
 	JOB_DEVELOPER("518", "개발");
 
 	public final static String SEARCH_KEY = "job_group_id";

--- a/module-crawler/src/main/java/kernel/jdon/crawler/wanted/search/JobSearchJobCategory.java
+++ b/module-crawler/src/main/java/kernel/jdon/crawler/wanted/search/JobSearchJobCategory.java
@@ -1,0 +1,22 @@
+package kernel.jdon.crawler.wanted.search;
+
+import lombok.AllArgsConstructor;
+
+@AllArgsConstructor
+public enum JobSearchJobCategory implements JobSearchCondition{
+	JOB_DEVELOPER("518", "개발");
+
+	public final static String SEARCH_KEY = "job_group_id";
+	private final String searchValue;
+	private final String description;
+
+	@Override
+	public String getDescription() {
+		return this.description;
+	}
+
+	@Override
+	public String getSearchValue() {
+		return this.searchValue;
+	}
+}

--- a/module-crawler/src/main/java/kernel/jdon/crawler/wanted/search/JobSearchJobPosition.java
+++ b/module-crawler/src/main/java/kernel/jdon/crawler/wanted/search/JobSearchJobPosition.java
@@ -3,7 +3,7 @@ package kernel.jdon.crawler.wanted.search;
 import lombok.AllArgsConstructor;
 
 @AllArgsConstructor
-public enum JobSearchJobPosition implements JobSearchCondition{
+public enum JobSearchJobPosition implements JobSearchCondition {
 	JOB_POSITION_FRONTEND("669", "프론트엔드 개발자"),
 	JOB_POSITION_SERVER("872", "서버 개발자");
 

--- a/module-crawler/src/main/java/kernel/jdon/crawler/wanted/search/JobSearchJobPosition.java
+++ b/module-crawler/src/main/java/kernel/jdon/crawler/wanted/search/JobSearchJobPosition.java
@@ -1,0 +1,23 @@
+package kernel.jdon.crawler.wanted.search;
+
+import lombok.AllArgsConstructor;
+
+@AllArgsConstructor
+public enum JobSearchJobPosition implements JobSearchCondition{
+	JOB_POSITION_FRONTEND("669", "프론트엔드 개발자"),
+	JOB_POSITION_SERVER("872", "서버 개발자");
+
+	public final static String SEARCH_KEY = "job_ids";
+	private final String searchValue;
+	private final String description;
+
+	@Override
+	public String getDescription() {
+		return this.description;
+	}
+
+	@Override
+	public String getSearchValue() {
+		return this.searchValue;
+	}
+}

--- a/module-crawler/src/main/java/kernel/jdon/crawler/wanted/search/JobSearchLocation.java
+++ b/module-crawler/src/main/java/kernel/jdon/crawler/wanted/search/JobSearchLocation.java
@@ -1,0 +1,22 @@
+package kernel.jdon.crawler.wanted.search;
+
+import lombok.AllArgsConstructor;
+
+@AllArgsConstructor
+public enum JobSearchLocation implements JobSearchCondition{
+	LOCATIONS_ALL("all", "전체");
+
+	public final static String SEARCH_KEY = "locations";
+	private final String searchValue;
+	private final String description;
+
+	@Override
+	public String getDescription() {
+		return this.description;
+	}
+
+	@Override
+	public String getSearchValue() {
+		return this.searchValue;
+	}
+}

--- a/module-crawler/src/main/java/kernel/jdon/crawler/wanted/search/JobSearchLocation.java
+++ b/module-crawler/src/main/java/kernel/jdon/crawler/wanted/search/JobSearchLocation.java
@@ -3,7 +3,7 @@ package kernel.jdon.crawler.wanted.search;
 import lombok.AllArgsConstructor;
 
 @AllArgsConstructor
-public enum JobSearchLocation implements JobSearchCondition{
+public enum JobSearchLocation implements JobSearchCondition {
 	LOCATIONS_ALL("all", "전체");
 
 	public final static String SEARCH_KEY = "locations";

--- a/module-crawler/src/main/java/kernel/jdon/crawler/wanted/search/JobSearchSort.java
+++ b/module-crawler/src/main/java/kernel/jdon/crawler/wanted/search/JobSearchSort.java
@@ -1,0 +1,23 @@
+package kernel.jdon.crawler.wanted.search;
+
+import lombok.AllArgsConstructor;
+
+@AllArgsConstructor
+public enum JobSearchSort implements JobSearchCondition{
+	SORT_LATEST("job.latest_order", "최신순"),
+	SORT_POPULARITY("job.popularity_order", "인기순");
+
+	public final static String SEARCH_KEY = "job_sort";
+	private final String searchValue;
+	private final String description;
+
+	@Override
+	public String getDescription() {
+		return this.description;
+	}
+
+	@Override
+	public String getSearchValue() {
+		return this.searchValue;
+	}
+}

--- a/module-crawler/src/main/java/kernel/jdon/crawler/wanted/search/JobSearchSort.java
+++ b/module-crawler/src/main/java/kernel/jdon/crawler/wanted/search/JobSearchSort.java
@@ -3,7 +3,7 @@ package kernel.jdon.crawler.wanted.search;
 import lombok.AllArgsConstructor;
 
 @AllArgsConstructor
-public enum JobSearchSort implements JobSearchCondition{
+public enum JobSearchSort implements JobSearchCondition {
 	SORT_LATEST("job.latest_order", "최신순"),
 	SORT_POPULARITY("job.popularity_order", "인기순");
 

--- a/module-crawler/src/main/java/kernel/jdon/crawler/wanted/service/WantedCrawlerService.java
+++ b/module-crawler/src/main/java/kernel/jdon/crawler/wanted/service/WantedCrawlerService.java
@@ -13,7 +13,7 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.client.RestTemplate;
 
 import kernel.jdon.config.UrlConfig;
-import kernel.jdon.crawler.wanted.converter.EntityFactory;
+import kernel.jdon.crawler.wanted.converter.EntityConverter;
 import kernel.jdon.crawler.wanted.dto.object.CreateSkillDto;
 import kernel.jdon.crawler.wanted.dto.response.WantedJobDetailResponse;
 import kernel.jdon.crawler.wanted.dto.response.WantedJobListResponse;
@@ -74,7 +74,7 @@ public class WantedCrawlerService {
 			WantedJobDetailResponse jobDetailResponse = fetchJobDetail(detailId);
 			jobDetailResponse.setDetailUrl(joinToString(urlConfig.getWantedJobDetailUrl(),detailId));
 			jobDetailResponse.setJobCategory(jobCategory);
-			WantedJd savedWantedJd = wantedJdRepository.save(EntityFactory.createWantedJd(jobDetailResponse));
+			WantedJd savedWantedJd = wantedJdRepository.save(EntityConverter.createWantedJd(jobDetailResponse));
 
 			wantedJdDetailSkillMap.put(savedWantedJd, jobDetailResponse.getJob().getSkill());
 
@@ -96,7 +96,8 @@ public class WantedCrawlerService {
 				Skill findSkill = findByJobCategoryIdAndKeyword(jobCategory.getId(), skillKeyword);
 				findSkill.countPlus(skillCount);
 			} else {
-				skillRepository.save(EntityFactory.createSkill(new CreateSkillDto(jobCategory, skillKeyword, skillCount)));
+				skillRepository.save(
+					EntityConverter.createSkill(new CreateSkillDto(jobCategory, skillKeyword, skillCount)));
 			}
 		}
 
@@ -106,7 +107,7 @@ public class WantedCrawlerService {
 			List<WantedJobDetailResponse.WantedSkill> targetJdSkillList= entry.getValue();
 			for (WantedJobDetailResponse.WantedSkill skill : targetJdSkillList) {
 				Skill findSkill = findByJobCategoryIdAndKeyword(jobCategory.getId(), skill.getKeyword());
-				wantedJdSkillRepository.save(EntityFactory.createWantedJdSkill(wantedJd, findSkill));
+				wantedJdSkillRepository.save(EntityConverter.createWantedJdSkill(wantedJd, findSkill));
 			}
 		}
 	}

--- a/module-crawler/src/main/java/kernel/jdon/crawler/wanted/service/WantedCrawlerService.java
+++ b/module-crawler/src/main/java/kernel/jdon/crawler/wanted/service/WantedCrawlerService.java
@@ -1,0 +1,158 @@
+package kernel.jdon.crawler.wanted.service;
+
+import static kernel.jdon.util.StringUtil.*;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.client.RestTemplate;
+
+import kernel.jdon.config.UrlConfig;
+import kernel.jdon.crawler.wanted.converter.EntityFactory;
+import kernel.jdon.crawler.wanted.dto.object.CreateSkillDto;
+import kernel.jdon.crawler.wanted.dto.response.WantedJobDetailResponse;
+import kernel.jdon.crawler.wanted.dto.response.WantedJobListResponse;
+import kernel.jdon.crawler.wanted.repository.JobCategoryRepository;
+import kernel.jdon.crawler.wanted.repository.SkillRepository;
+import kernel.jdon.crawler.wanted.repository.WantedJdRepository;
+import kernel.jdon.crawler.wanted.repository.WantedJdSkillRepository;
+import kernel.jdon.crawler.wanted.search.JobSearchExperience;
+import kernel.jdon.crawler.wanted.search.JobSearchJobCategory;
+import kernel.jdon.crawler.wanted.search.JobSearchJobPosition;
+import kernel.jdon.crawler.wanted.search.JobSearchLocation;
+import kernel.jdon.crawler.wanted.search.JobSearchSort;
+import kernel.jdon.crawler.wanted.vo.SkillVo;
+import kernel.jdon.jobcategory.domain.JobCategory;
+import kernel.jdon.skill.domain.Skill;
+import kernel.jdon.wanted.domain.WantedJd;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class WantedCrawlerService {
+	private final RestTemplate restTemplate;
+	private final UrlConfig urlConfig;
+	private final WantedJdRepository wantedJdRepository;
+	private final WantedJdSkillRepository wantedJdSkillRepository;
+	private final SkillRepository skillRepository;
+	private final JobCategoryRepository jobCategoryRepository;
+	private static final int MAX_FETCH_JD_LIST_SIZE = 100; // 1000
+	private static final int MAX_FETCH_JD_LIST_OFFSET = 50; // 100
+
+	@Transactional
+	public void fetchJd() {
+		JobSearchJobPosition[] jobPositions = {
+			JobSearchJobPosition.JOB_POSITION_FRONTEND,
+			JobSearchJobPosition.JOB_POSITION_SERVER
+		};
+
+		for (JobSearchJobPosition jobPosition : jobPositions) {
+			Set<Long> fetchJobIds = fetchJobIdList(jobPosition);
+
+			JobCategory findJobCategory = jobCategoryRepository.findByWantedCode(jobPosition.getSearchValue())
+				.orElseThrow(() -> new IllegalArgumentException("존재하지 않는 직군 또는 직무 입니다."));
+
+			fetchJobDetail(findJobCategory, fetchJobIds);
+		}
+	}
+
+	private void fetchJobDetail(JobCategory jobCategory, Set<Long> fetchJobIds) {
+		HashMap<SkillVo, Long> wantedSkillAndCountMap = new HashMap<>();
+		HashMap<WantedJd, List<WantedJobDetailResponse.WantedSkill>> wantedJdDetailSkillMap = new HashMap<>();
+		for (Long detailId : fetchJobIds) {
+			boolean isJobDetailExist = wantedJdRepository.existsByJobCategoryAndDetailId(jobCategory, detailId);
+			if (isJobDetailExist) {
+				continue;
+			}
+			/** 원티드 JD 상세 정보 등록 **/
+			WantedJobDetailResponse jobDetailResponse = fetchJobDetail(detailId);
+			jobDetailResponse.setDetailUrl(joinToString(urlConfig.getWantedJobDetailUrl(),detailId));
+			jobDetailResponse.setJobCategory(jobCategory);
+			WantedJd savedWantedJd = wantedJdRepository.save(EntityFactory.createWantedJd(jobDetailResponse));
+
+			wantedJdDetailSkillMap.put(savedWantedJd, jobDetailResponse.getJob().getSkill());
+
+			/** 원티드 JD 상세에서 추출된 기술스택 및 count를 임시 저장 **/
+			for (WantedJobDetailResponse.WantedSkill wantedSkill : jobDetailResponse.getJob().getSkill()) {
+				wantedSkillAndCountMap.put(
+					new SkillVo(jobCategory.getId(), wantedSkill.getKeyword()),
+					wantedSkillAndCountMap.getOrDefault(new SkillVo(jobCategory.getId(), wantedSkill.getKeyword()),0L)+1L
+				);
+			}
+		}
+
+		/** 원티드 JD 상세에서 추출된 기술스택 저장 **/
+		for (Map.Entry<SkillVo, Long> entry : wantedSkillAndCountMap.entrySet()) {
+			String skillKeyword = entry.getKey().getKeyword();
+			Long skillCount = entry.getValue();
+			boolean isKeywordExist = skillRepository.existsByJobCategoryIdAndKeyword(jobCategory.getId(), skillKeyword);
+			if (isKeywordExist) {
+				Skill findSkill = findByJobCategoryIdAndKeyword(jobCategory.getId(), skillKeyword);
+				findSkill.countPlus(skillCount);
+			} else {
+				skillRepository.save(EntityFactory.createSkill(new CreateSkillDto(jobCategory, skillKeyword, skillCount)));
+			}
+		}
+
+		/** 원티드 JD 상세 - 기술 중간테이블 저장 **/
+		for (Map.Entry<WantedJd, List<WantedJobDetailResponse.WantedSkill>> entry : wantedJdDetailSkillMap.entrySet()) {
+			WantedJd wantedJd = entry.getKey();
+			List<WantedJobDetailResponse.WantedSkill> targetJdSkillList= entry.getValue();
+			for (WantedJobDetailResponse.WantedSkill skill : targetJdSkillList) {
+				Skill findSkill = findByJobCategoryIdAndKeyword(jobCategory.getId(), skill.getKeyword());
+				wantedJdSkillRepository.save(EntityFactory.createWantedJdSkill(wantedJd, findSkill));
+			}
+		}
+	}
+
+	private Skill findByJobCategoryIdAndKeyword(Long jobCategoryId, String skillKeyword) {
+		return skillRepository.findByJobCategoryIdAndKeyword(jobCategoryId, skillKeyword)
+			.orElseThrow(() -> new IllegalArgumentException("존재하지 않는 기술스택 입니다."));
+	}
+
+	private WantedJobDetailResponse fetchJobDetail(Long jobId) {
+		String jobDetailUrl = joinToString(urlConfig.getWantedApiJobDetailUrl(), jobId);
+		return restTemplate.getForObject(jobDetailUrl, WantedJobDetailResponse.class);
+	}
+
+	private Set<Long> fetchJobIdList(JobSearchJobPosition jobPosition) {
+		int offset = 0;
+		Set<Long> fetchJobIds = new HashSet<>();
+
+		while (fetchJobIds.size() < MAX_FETCH_JD_LIST_SIZE) {
+			WantedJobListResponse jobListResponse = fetchJobList(jobPosition, offset);
+
+			jobListResponse.getData().stream()
+				.forEach(detail -> fetchJobIds.add(detail.getId()));
+
+			offset += MAX_FETCH_JD_LIST_OFFSET;
+		}
+
+		return fetchJobIds;
+	}
+
+	private WantedJobListResponse fetchJobList(JobSearchJobPosition jobPosition, int offset) {
+		String jobListUrl = createJobListUrl(jobPosition, offset);
+		return restTemplate.getForObject(jobListUrl, WantedJobListResponse.class);
+	}
+
+	private String createJobListUrl(JobSearchJobPosition jobPosition, int offset) {
+		return joinToString(
+			urlConfig.getWantedApiJobListUrl(),
+			createQueryString(JobSearchJobCategory.SEARCH_KEY, JobSearchJobCategory.JOB_DEVELOPER.getSearchValue()),
+			createQueryString(JobSearchJobPosition.SEARCH_KEY, jobPosition.getSearchValue()),
+			createQueryString(JobSearchSort.SEARCH_KEY, JobSearchSort.SORT_LATEST.getSearchValue()),
+			createQueryString(JobSearchLocation.SEARCH_KEY, JobSearchLocation.LOCATIONS_ALL.getSearchValue()),
+			createQueryString(JobSearchExperience.SEARCH_KEY, JobSearchExperience.EXPERIENCE_ALL.getSearchValue()),
+			createQueryString("limit", String.valueOf(MAX_FETCH_JD_LIST_OFFSET)),
+			createQueryString("offset", String.valueOf(offset))
+		);
+	}
+
+}

--- a/module-crawler/src/main/java/kernel/jdon/crawler/wanted/vo/SkillVo.java
+++ b/module-crawler/src/main/java/kernel/jdon/crawler/wanted/vo/SkillVo.java
@@ -1,0 +1,13 @@
+package kernel.jdon.crawler.wanted.vo;
+
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+
+@Getter
+@EqualsAndHashCode
+@AllArgsConstructor
+public class SkillVo {
+	private Long jobCategoryId;
+	private String keyword;
+}

--- a/module-crawler/src/main/resources/url.properties
+++ b/module-crawler/src/main/resources/url.properties
@@ -1,0 +1,6 @@
+url.wanted.detail=https://www.wanted.co.kr/wd/
+url.wanted.api.detail=https://www.wanted.co.kr/api/v4/jobs/
+url.wanted.api.list=https://www.wanted.co.kr/api/chaos/navigation/v1/results?country=kr&
+url.inflearn.detail=https://www.wanted.co.kr/api/v4/jobs/
+url.inflearn.list=https://www.wanted.co.kr/api/v4/jobs?country=kr&
+

--- a/module-domain/src/main/java/kernel/jdon/jobcategory/domain/JobCategory.java
+++ b/module-domain/src/main/java/kernel/jdon/jobcategory/domain/JobCategory.java
@@ -1,6 +1,7 @@
 package kernel.jdon.jobcategory.domain;
 
 import java.util.ArrayList;
+import java.util.List;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -11,8 +12,13 @@ import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import kernel.jdon.base.BaseEntity;
 import kernel.jdon.skill.domain.Skill;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "job_category")
 public class JobCategory extends BaseEntity {
 
@@ -26,6 +32,9 @@ public class JobCategory extends BaseEntity {
 	@Column(name = "parent_id", columnDefinition = "BIGINT")
 	private Long parentId;
 
+	@Column(name = "wanted_code", columnDefinition = "VARCHAR(255)", nullable = false)
+	private String wantedCode;
+
 	@OneToMany(mappedBy = "jobCategory")
-	private ArrayList<Skill> skillList = new ArrayList<>();
+	private List<Skill> skillList = new ArrayList<>();
 }

--- a/module-domain/src/main/java/kernel/jdon/skill/domain/Skill.java
+++ b/module-domain/src/main/java/kernel/jdon/skill/domain/Skill.java
@@ -1,6 +1,7 @@
 package kernel.jdon.skill.domain;
 
 import java.util.ArrayList;
+import java.util.List;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -14,11 +15,15 @@ import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import kernel.jdon.jobcategory.domain.JobCategory;
 import kernel.jdon.wantedskill.domain.WantedJdSkill;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 @NoArgsConstructor
 @Table(name = "skill")
@@ -35,9 +40,21 @@ public class Skill {
 	private Long count;
 
 	@OneToMany(mappedBy = "skill")
-	private ArrayList<WantedJdSkill> wantedJdSkillList = new ArrayList<>();
+	private List<WantedJdSkill> wantedJdSkillList = new ArrayList<>();
 
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "job_category_id", columnDefinition = "BIGINT")
 	private JobCategory jobCategory;
+
+	public void countPlus(Long plus) {
+		this.count += plus;
+	}
+	@Builder
+	public Skill(Long id, String keyword, Long count, JobCategory jobCategory) {
+		this.id = id;
+		this.keyword = keyword;
+		this.count = count;
+		this.jobCategory = jobCategory;
+	}
+
 }

--- a/module-domain/src/main/java/kernel/jdon/wanted/domain/WantedJd.java
+++ b/module-domain/src/main/java/kernel/jdon/wanted/domain/WantedJd.java
@@ -10,8 +10,14 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import kernel.jdon.jobcategory.domain.JobCategory;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "wanted_jd")
 public class WantedJd {
 
@@ -19,8 +25,11 @@ public class WantedJd {
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
 
-	@Column(name = "company", columnDefinition = "VARCHAR(50)", nullable = false)
-	private String company;
+	@Column(name = "company_name", columnDefinition = "VARCHAR(50)", nullable = false)
+	private String companyName;
+
+	@Column(name = "detail_id", columnDefinition = "BIGINT", nullable = false, unique = true)
+	private Long detailId;
 
 	@Column(name = "detail_url", columnDefinition = "VARCHAR(255)", nullable = false)
 	private String detailUrl;
@@ -32,4 +41,12 @@ public class WantedJd {
 	@JoinColumn(name = "job_category_id", columnDefinition = "BIGINT")
 	private JobCategory jobCategory;
 
+	@Builder
+	public WantedJd(String companyName, Long detailId, String detailUrl, String imageUrl, JobCategory jobCategory) {
+		this.companyName = companyName;
+		this.detailId = detailId;
+		this.detailUrl = detailUrl;
+		this.imageUrl = imageUrl;
+		this.jobCategory = jobCategory;
+	}
 }

--- a/module-domain/src/main/java/kernel/jdon/wantedskill/domain/WantedJdSkill.java
+++ b/module-domain/src/main/java/kernel/jdon/wantedskill/domain/WantedJdSkill.java
@@ -10,8 +10,12 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import kernel.jdon.skill.domain.Skill;
 import kernel.jdon.wanted.domain.WantedJd;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
 
 @Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "wanted_jd_skill")
 public class WantedJdSkill {
 
@@ -27,4 +31,9 @@ public class WantedJdSkill {
 	@JoinColumn(name = "wanted_jd_id", columnDefinition = "BIGINT", nullable = false)
 	private WantedJd wantedJd;
 
+	@Builder
+	public WantedJdSkill(Skill skill, WantedJd wantedJd) {
+		this.skill = skill;
+		this.wantedJd = wantedJd;
+	}
 }


### PR DESCRIPTION
## 개요

### 요약
- 원티드 채용공고 조회 api를 스크래핑 해와서 JD 목록을 추출
- 상세 JD의 내용, 기술스택을 추출
- StringUtil 클래스 생성

### 변경한 부분
- Controller, Service, Repository 생성
  - 구현하면서 수동으로 API를 호출해서 스크래핑 정상 작동 유무를 테스트하기 위해 테스트 API를 구현해두었습니다. 추후 스케줄링 방식으로 리팩토링 할 예정입니다.
  - Service 또한 리팩토링 시 패키지구조 및 클래스명을 어떠한 방향으로 가져갈지 상의해야합니다.
  - Repository는 module-crawler에서 해당 엔티티를 접근하기위한 객체로, 추후 리팩토링 시 변경사항 없습니다.

- WantedCrawlerService 클래스
  - **기능 위주로 절차지향으로 구현된 코드로 추후 리팩토링이 필요합니다 !!!**

- dto 패키지 생성
  - dto/object 패키지 : 메서드 내 파라미터가 많아져 메서드 간의 이동을 위한 클래스를 보관하는 패키지
  - dto/response 패키지 : 원티드 api에서 스크래핑하여 응답받은 객체를 저장하는 패키지

- DTO 및 객체를 엔티티로 형변환하는 역할을 담당하는 EntityFactory 생성

- 쿼리파라미터를 생성할 때 원티드 검색조건을 관리할 수 있는 interface를 생성
  - JobSearchCondition
  
- JobSearchCondition을 구현한 각각의 enum class를 생성
  - JobSearchExperience : 경력 검색조건
  - JobSearchJobCategory : 직군 검색조건
  - JobSearchJobPosition : 직무 검색조건
  - JobSearchLocation : 지역 검색조건
  - JobSearchSort : 정렬 검색조건
> 경력: 전체, 직군: 개발, 지역: 전국, 정렬: 최신순, 직무: 프론트엔드개발자, 서버개발자
> 로 가져오도록 설정해두었습니다.

- StringUtil 클래스 생성
  - createQueryString() : 쿼리메서드를 생성하여 문자열로 반환하는 메서드
  - joinToString() : 인자로 받은 Object를 String으로 캐스팅하여 붙힌 문자열을 반환하는 메서드

### 변경한 결과
> 스크래핑한 데이터 입니다.
#### 원티드 JD 정보 데이터
![image](https://github.com/Kernel360/f1-JDON-Backend/assets/59242594/b4246670-9ae0-4e96-bd85-29019e01db66)

#### 원티드 각각의 JD의 기술스택과 추출횟수 데이터
![image](https://github.com/Kernel360/f1-JDON-Backend/assets/59242594/445c4efb-141d-4889-8a15-270b23b34515)

#### 원티드 JD 정보와 기술스택 매핑 데이터
![image](https://github.com/Kernel360/f1-JDON-Backend/assets/59242594/4199a49c-085c-4bac-9895-96e6158f4fdd)


### 이슈

- closes: #59 

---

## PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경, 주석 변경)
- [ ] 코드 리팩토링
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 파일 혹은 폴더명 수정, 삭제
- [ ] 배포 관련