### PR TITLE
Hotfix: NoArgsConstructor 어노테이션 제거

### DIFF
--- a/module-domain/src/main/java/kernel/jdon/skill/domain/Skill.java
+++ b/module-domain/src/main/java/kernel/jdon/skill/domain/Skill.java
@@ -17,15 +17,12 @@ import kernel.jdon.jobcategory.domain.JobCategory;
 import kernel.jdon.wantedskill.domain.WantedJdSkill;
 import lombok.AccessLevel;
 import lombok.Builder;
-import lombok.NoArgsConstructor;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
-@NoArgsConstructor
 @Table(name = "skill")
 public class Skill {
 


### PR DESCRIPTION
## 개요

### 요약
Skill 엔티티에 ``NoArgsConstructor`` 어노테이션이 중복되어 컴파일시 에러 발생
![image](https://github.com/Kernel360/f1-JDON-Backend/assets/59242594/891d46eb-9644-4c2e-8de4-3b22df573c3d)


### 변경한 부분
- Skill 엔티티에서 중복되있던 ``NoArgsConstructor`` 어노테이션 제거

### 변경한 결과
컴파일 후 서버 정상 구동되는 것을 확인하였습니다.
![image](https://github.com/Kernel360/f1-JDON-Backend/assets/59242594/743ad6c1-61a0-4d7d-a1cf-7315c61433e2)


### 이슈

- closes: #

---

## PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경, 주석 변경)
- [ ] 코드 리팩토링
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 파일 혹은 폴더명 수정, 삭제
- [ ] 배포 관련