### PR TITLE
Feature: 가데이터 반환 Skill API 구현

### DIFF
--- a/module-api/src/main/java/kernel/jdon/skill/controller/SkillController.java
+++ b/module-api/src/main/java/kernel/jdon/skill/controller/SkillController.java
@@ -1,0 +1,130 @@
+package kernel.jdon.skill.controller;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import kernel.jdon.dto.response.CommonResponse;
+import kernel.jdon.skill.dto.FindHotSkillResponse;
+import kernel.jdon.skill.dto.FindJdResponse;
+import kernel.jdon.skill.dto.FindJobCategorySkillResponse;
+import kernel.jdon.skill.dto.FindLectureResponse;
+import kernel.jdon.skill.dto.FindListDataBySkillResponse;
+import kernel.jdon.skill.dto.FindListHotSkillResponse;
+import kernel.jdon.skill.dto.FindListJobCategorySkillResponse;
+import kernel.jdon.skill.dto.FindListMemberSkillResponse;
+import kernel.jdon.skill.dto.FindMemberSkillResponse;
+
+@RestController
+public class SkillController {
+
+	@GetMapping("/api/v1/skills/hot")
+	public ResponseEntity<CommonResponse> getHotSkillList() {
+		List<FindHotSkillResponse> findHotSkillResponseList = new ArrayList<>();
+		for (long i = 1; i <= 10; i++) {
+			FindHotSkillResponse findHotSkillResponse =
+				FindHotSkillResponse.builder()
+					.skillId(i)
+					.keyword("skill_" + i)
+					.build();
+
+			findHotSkillResponseList.add(findHotSkillResponse);
+		}
+
+		FindListHotSkillResponse findListHotSkillResponse =
+			FindListHotSkillResponse.builder()
+				.skillList(findHotSkillResponseList)
+				.build();
+
+		return ResponseEntity.ok(CommonResponse.of(findListHotSkillResponse));
+	}
+
+	@GetMapping("/api/v1/skills/member")
+	public ResponseEntity<CommonResponse> getMemberSkillList() {
+
+		List<FindMemberSkillResponse> findMemberSkillResponseList = new ArrayList<>();
+		for (long i = 1; i <= 5; i++) {
+			FindMemberSkillResponse findMemberSkillResponse = FindMemberSkillResponse.builder()
+				.skillId(i)
+				.keyword("member_skill_" + i)
+				.build();
+
+			findMemberSkillResponseList.add(findMemberSkillResponse);
+		}
+
+		FindListMemberSkillResponse findListMemberSkillResponse =
+			FindListMemberSkillResponse.builder()
+				.skillList(findMemberSkillResponseList)
+				.build();
+
+		return ResponseEntity.ok(CommonResponse.of(findListMemberSkillResponse));
+	}
+
+	@GetMapping("/api/v1/skills/job-category/{jobCategoryId}")
+	public ResponseEntity<CommonResponse> getJobCategorySkillList(@PathVariable Long jobCategoryId) {
+
+		List<FindJobCategorySkillResponse> findJobCategorySkillResponseList = new ArrayList<>();
+		for (long i = 1; i <= 5; i++) {
+			FindJobCategorySkillResponse findJobCategorySkillResponse = FindJobCategorySkillResponse.builder()
+				.skillId(i)
+				.keyword("jobCategory_skill_" + i)
+				.build();
+
+			findJobCategorySkillResponseList.add(findJobCategorySkillResponse);
+		}
+
+		FindListJobCategorySkillResponse findListJobCategorySkillResponse =
+			FindListJobCategorySkillResponse.builder()
+				.skillList(findJobCategorySkillResponseList)
+				.build();
+
+		return ResponseEntity.ok(CommonResponse.of(findListJobCategorySkillResponse));
+	}
+
+	@GetMapping("/api/v1/skills/search")
+	public ResponseEntity<CommonResponse> getDataListBySkill(
+		@RequestParam(name = "keyword", defaultValue = "") String keyword) {
+
+		List<FindLectureResponse> findLectureResponseList = new ArrayList<>();
+		List<FindJdResponse> findJdResponseList = new ArrayList<>();
+		for (long i = 1; i <= 3; i++) {
+			FindLectureResponse findLectureResponse = FindLectureResponse.builder()
+				.lectureId(i)
+				.title("스프링부트 고급편_" + i)
+				.lectureUrl("www.inflearn.com/we234")
+				.imageUrl(
+					"https://cdn.inflearn.com/public/courses/327260/cover/a51a5154-c375-4210-9fb1-0b716fd4ac73/327260-eng.png")
+				.instructor("김영한")
+				.studentCount(5332)
+				.price(180000)
+				.isFavorite(false)
+				.build();
+
+			findLectureResponseList.add(findLectureResponse);
+		}
+
+		for (long i = 1; i <= 6; i++) {
+			FindJdResponse findJdResponse = FindJdResponse.builder()
+				.company("트렌비_" + i)
+				.title("백엔드개발자_" + i)
+				.imageUrl("https://www.amazon.s3.sdkjfhwk.dkjfhwkjdh")
+				.jdUrl("https://www.wanted.co.kr/wd/196444")
+				.build();
+
+			findJdResponseList.add(findJdResponse);
+		}
+
+		FindListDataBySkillResponse findListDataBySkillResponse =
+			FindListDataBySkillResponse.builder()
+				.lectureList(findLectureResponseList)
+				.jdList(findJdResponseList)
+				.build();
+
+		return ResponseEntity.ok(CommonResponse.of(findListDataBySkillResponse));
+	}
+}

--- a/module-api/src/test/resources/application.yml
+++ b/module-api/src/test/resources/application.yml
@@ -8,7 +8,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: create-drop
+      ddl-auto: update
 
     properties:
       hibernate:

--- a/module-domain/src/main/java/kernel/jdon/skill/dto/FindHotSkillResponse.java
+++ b/module-domain/src/main/java/kernel/jdon/skill/dto/FindHotSkillResponse.java
@@ -1,0 +1,16 @@
+package kernel.jdon.skill.dto;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor
+public class FindHotSkillResponse {
+	private Long skillId;
+	private String keyword;
+}

--- a/module-domain/src/main/java/kernel/jdon/skill/dto/FindJdResponse.java
+++ b/module-domain/src/main/java/kernel/jdon/skill/dto/FindJdResponse.java
@@ -1,0 +1,18 @@
+package kernel.jdon.skill.dto;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor
+public class FindJdResponse {
+	private String company;
+	private String title;
+	private String imageUrl;
+	private String jdUrl;
+}

--- a/module-domain/src/main/java/kernel/jdon/skill/dto/FindJobCategorySkillResponse.java
+++ b/module-domain/src/main/java/kernel/jdon/skill/dto/FindJobCategorySkillResponse.java
@@ -1,0 +1,16 @@
+package kernel.jdon.skill.dto;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor
+public class FindJobCategorySkillResponse {
+	private Long skillId;
+	private String keyword;
+}

--- a/module-domain/src/main/java/kernel/jdon/skill/dto/FindLectureResponse.java
+++ b/module-domain/src/main/java/kernel/jdon/skill/dto/FindLectureResponse.java
@@ -1,0 +1,22 @@
+package kernel.jdon.skill.dto;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor
+public class FindLectureResponse {
+	private Long lectureId;
+	private String title;
+	private String lectureUrl;
+	private String imageUrl;
+	private String instructor;
+	private Integer studentCount;
+	private Integer price;
+	private Boolean isFavorite;
+}

--- a/module-domain/src/main/java/kernel/jdon/skill/dto/FindListDataBySkillResponse.java
+++ b/module-domain/src/main/java/kernel/jdon/skill/dto/FindListDataBySkillResponse.java
@@ -1,0 +1,18 @@
+package kernel.jdon.skill.dto;
+
+import java.util.List;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor
+public class FindListDataBySkillResponse {
+	private List<FindLectureResponse> lectureList;
+	private List<FindJdResponse> jdList;
+}

--- a/module-domain/src/main/java/kernel/jdon/skill/dto/FindListHotSkillResponse.java
+++ b/module-domain/src/main/java/kernel/jdon/skill/dto/FindListHotSkillResponse.java
@@ -1,0 +1,17 @@
+package kernel.jdon.skill.dto;
+
+import java.util.List;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor
+public class FindListHotSkillResponse {
+	private List<FindHotSkillResponse> skillList;
+}

--- a/module-domain/src/main/java/kernel/jdon/skill/dto/FindListJobCategorySkillResponse.java
+++ b/module-domain/src/main/java/kernel/jdon/skill/dto/FindListJobCategorySkillResponse.java
@@ -1,0 +1,17 @@
+package kernel.jdon.skill.dto;
+
+import java.util.List;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor
+public class FindListJobCategorySkillResponse {
+	private List<FindJobCategorySkillResponse> skillList;
+}

--- a/module-domain/src/main/java/kernel/jdon/skill/dto/FindListMemberSkillResponse.java
+++ b/module-domain/src/main/java/kernel/jdon/skill/dto/FindListMemberSkillResponse.java
@@ -1,0 +1,17 @@
+package kernel.jdon.skill.dto;
+
+import java.util.List;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor
+public class FindListMemberSkillResponse {
+	private List<FindMemberSkillResponse> skillList;
+}

--- a/module-domain/src/main/java/kernel/jdon/skill/dto/FindMemberSkillResponse.java
+++ b/module-domain/src/main/java/kernel/jdon/skill/dto/FindMemberSkillResponse.java
@@ -1,0 +1,16 @@
+package kernel.jdon.skill.dto;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor
+public class FindMemberSkillResponse {
+	private Long skillId;
+	private String keyword;
+}


### PR DESCRIPTION
## 개요

### 요약
- 가데이터를 반환하는 Skill 관련 API 구현

### 변경한 부분
- 프론트엔드 요청에 따라 API 명세서 규격에 맞는 요청받고 데이터를 응답하도록 API를 구현하였습니다.
  - 요즘 뜨는 기술 스택 조회 API : https://www.notion.so/6bb63a7d4c034e4fba1062f0f0b1f12e?pvs=4
  - 회원 맞춤 기술 스택 조회 API : https://www.notion.so/a6f53af68e9844c8a83c3e24b742a0d9?pvs=4
  - 기술 스택에 맞는 강의 및 JD 조회 API : https://www.notion.so/52bfd0c650d34a929f5e76884f93e065?pvs=4
  - 직군별 기술 스택 조회 API : https://www.notion.so/d7734d2eeb364296b7aaf66a1b06bb3e?pvs=4

### 변경한 결과
#### 요즘 뜨는 기술 스택 조회 API
- /api/v1/skills/hot
<img width="409" alt="image" src="https://github.com/Kernel360/f1-JDON-Backend/assets/59242594/f06af439-faf6-4723-bbcc-bb8c5529909a">

#### 회원 맞춤 기술 스택 조회 API
- /api/v1/skills/member
<img width="453" alt="image" src="https://github.com/Kernel360/f1-JDON-Backend/assets/59242594/d7232c1e-50de-4233-8827-24f33d9441de">

#### 기술 스택에 맞는 강의 및 JD 조회 API
- /api/v1/skills/search?keyword={keyword}
<img width="931" alt="image" src="https://github.com/Kernel360/f1-JDON-Backend/assets/59242594/ac65a59b-a453-4c73-ac28-599cd207453c">

#### 직군별 기술 스택 조회 API
- /api/v1/skills/job-category/{jobCategoryId}
<img width="469" alt="image" src="https://github.com/Kernel360/f1-JDON-Backend/assets/59242594/6f1ef66c-8b61-44be-9fa7-b7e472048231">


### 이슈

- closes: #67 

---

## PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경, 주석 변경)
- [ ] 코드 리팩토링
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 파일 혹은 폴더명 수정, 삭제
- [ ] 배포 관련