### PR TITLE
fix: Exception.class 예외처리 제거

### DIFF
--- a/module-common/src/main/java/kernel/jdon/error/exception/GlobalExceptionHandler.java
+++ b/module-common/src/main/java/kernel/jdon/error/exception/GlobalExceptionHandler.java
@@ -1,6 +1,5 @@
 package kernel.jdon.error.exception;
 
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -11,13 +10,6 @@ import kernel.jdon.error.exception.api.ApiException;
 
 @RestControllerAdvice
 public class GlobalExceptionHandler {
-
-	@ExceptionHandler(Exception.class)
-	public ResponseEntity<ErrorResponse> handlerException(Exception e, HttpServletRequest request) {
-		final HttpStatus internalServerError = HttpStatus.INTERNAL_SERVER_ERROR;
-		return ResponseEntity.status(internalServerError.value())
-			.body(ErrorResponse.of(internalServerError, request));
-	}
 
 	@ExceptionHandler(ApiException.class)
 	public ResponseEntity<ErrorResponse> handlerApiException(ApiException e, HttpServletRequest request) {


### PR DESCRIPTION
## 개요

### 요약
-  Exception.class 예외 처리 제거

### 변경한 부분
GlobalExceptionHandler에서 모든 예외의 부모인 Exception.class를 핸들링 하는 부분을 제거 하였습니다.
개발 및 서버 배포 시 어떠한 에러가 발생했는지 알 수 없어서 임시로 제거하였습니다.
추후 Exception.class가 발생했을 경우 어떤 예외가 발생했는지 로깅작업을 하는 리팩토링이 필요하며 리팩토링 시 삭제한 코드를 다시 작성해야합니다.

### 이슈

- closes: #

---

## PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경, 주석 변경)
- [ ] 코드 리팩토링
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 파일 혹은 폴더명 수정, 삭제
- [ ] 배포 관련