### PR TITLE
fix: WantedJd 엔티티 복합 유니크키 설정

### DIFF
--- a/module-domain/src/main/java/kernel/jdon/wanted/domain/WantedJd.java
+++ b/module-domain/src/main/java/kernel/jdon/wanted/domain/WantedJd.java
@@ -9,6 +9,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import kernel.jdon.jobcategory.domain.JobCategory;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -18,7 +19,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Table(name = "wanted_jd")
+@Table(name = "wanted_jd", uniqueConstraints = @UniqueConstraint(columnNames = {"detail_id", "job_category_id"}))
 public class WantedJd {
 
 	@Id
@@ -28,7 +29,7 @@ public class WantedJd {
 	@Column(name = "company_name", columnDefinition = "VARCHAR(50)", nullable = false)
 	private String companyName;
 
-	@Column(name = "detail_id", columnDefinition = "BIGINT", nullable = false, unique = true)
+	@Column(name = "detail_id", columnDefinition = "BIGINT", nullable = false)
 	private Long detailId;
 
 	@Column(name = "detail_url", columnDefinition = "VARCHAR(255)", nullable = false)


### PR DESCRIPTION
## 개요

### 요약
- WantedJd 엔티티 복합 유니크키 설정

### 변경한 부분
원티드에서 같은 공고를 프론트엔드, 서버개발자 공고로 이중 설정 할 수 있기 때문에 기존과 같이 원티드 공고 식별자 컬럼만 유니크키로 설정했을 때 sql 에러가 발생합니다.
따라서, 직군, 원티드 공고 식별자를 복합 유니크키로 설정했습니다.
- 기존 WantedJd 엔티티 detail_id 컬럼 유니크 제약조건 제거
- 기존 WantedJd 엔티티 detail_id 컬럼, job_category_id 컬럼을 복합 유니크 키로 설정


### 변경한 결과

### 이슈

- closes: #78 

---

## PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경, 주석 변경)
- [ ] 코드 리팩토링
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 파일 혹은 폴더명 수정, 삭제
- [ ] 배포 관련