### PR TITLE
Feature: inflearn crawling

### DIFF
--- a/module-common/src/main/java/kernel/jdon/util/StringUtil.java
+++ b/module-common/src/main/java/kernel/jdon/util/StringUtil.java
@@ -11,6 +11,10 @@ public class StringUtil {
 		return joinToString(key, "=", value, "&");
 	}
 
+	public static String createPathString(String value) {
+		return joinToString("/", value);
+	}
+
 	public static String joinToString(Object... args) {
 		StringBuilder sb = new StringBuilder();
 		Arrays.stream(args).forEach(sb::append);

--- a/module-crawler/build.gradle
+++ b/module-crawler/build.gradle
@@ -1,53 +1,55 @@
 plugins {
-	id 'java'
-	id 'org.springframework.boot' version '3.2.0'
-	id 'io.spring.dependency-management' version '1.1.4'
+    id 'java'
+    id 'org.springframework.boot' version '3.2.0'
+    id 'io.spring.dependency-management' version '1.1.4'
 }
 
 group = 'kernel.jdon'
 version = '0.0.1-SNAPSHOT'
 
 java {
-	sourceCompatibility = '17'
+    sourceCompatibility = '17'
 }
 
 configurations {
-	compileOnly {
-		extendsFrom annotationProcessor
-	}
+    compileOnly {
+        extendsFrom annotationProcessor
+    }
 }
 
 repositories {
-	mavenCentral()
+    mavenCentral()
 }
 
 dependencies {
-	implementation project(':module-common')
-	implementation project(':module-domain')
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation project(':module-common')
+    implementation project(':module-domain')
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
 
-	runtimeOnly 'com.mysql:mysql-connector-j'
+    runtimeOnly 'com.mysql:mysql-connector-j'
 
-	compileOnly 'org.projectlombok:lombok'
+    compileOnly 'org.projectlombok:lombok'
 
-	annotationProcessor 'org.projectlombok:lombok'
+    annotationProcessor 'org.projectlombok:lombok'
 
-	// test
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	testImplementation 'com.h2database:h2'
+    implementation group: 'org.jsoup', name: 'jsoup', version: '1.17.1'
+
+    // test
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'com.h2database:h2'
 }
 
 tasks.register("prepareKotlinBuildScriptModel") {}
 
 tasks.bootJar {
-	enabled = true
+    enabled = true
 }
 
 tasks.jar {
-	enabled = false
+    enabled = false
 }
 
 tasks.named('test') {
-	useJUnitPlatform()
+    useJUnitPlatform()
 }

--- a/module-crawler/src/main/java/kernel/jdon/config/UrlConfig.java
+++ b/module-crawler/src/main/java/kernel/jdon/config/UrlConfig.java
@@ -16,4 +16,6 @@ public class UrlConfig {
 	private String wantedApiJobListUrl;
 	@Value("${url.wanted.api.detail}")
 	private String wantedApiJobDetailUrl;
+	@Value("https://www.inflearn.com/courses")
+	private String inflearnCourseListUrl;
 }

--- a/module-crawler/src/main/java/kernel/jdon/crawler/common/repository/SkillRepository.java
+++ b/module-crawler/src/main/java/kernel/jdon/crawler/common/repository/SkillRepository.java
@@ -1,4 +1,4 @@
-package kernel.jdon.crawler.wanted.repository;
+package kernel.jdon.crawler.common.repository;
 
 import java.util.Optional;
 
@@ -8,5 +8,8 @@ import kernel.jdon.skill.domain.Skill;
 
 public interface SkillRepository extends JpaRepository<Skill, Long> {
 	Optional<Skill> findByJobCategoryIdAndKeyword(Long jobCategoryId, String keyword);
+
 	boolean existsByJobCategoryIdAndKeyword(Long jobCategoryId, String keyword);
+
+	Optional<Skill> findByKeyword(String keyword);
 }

--- a/module-crawler/src/main/java/kernel/jdon/crawler/common/repository/WantedJdSkillRepository.java
+++ b/module-crawler/src/main/java/kernel/jdon/crawler/common/repository/WantedJdSkillRepository.java
@@ -1,0 +1,16 @@
+package kernel.jdon.crawler.common.repository;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import kernel.jdon.skill.domain.Skill;
+import kernel.jdon.wantedskill.domain.WantedJdSkill;
+
+@Repository
+public interface WantedJdSkillRepository extends JpaRepository<WantedJdSkill, Long> {
+
+	List<WantedJdSkill> findBySkill(Skill skill);
+
+}

--- a/module-crawler/src/main/java/kernel/jdon/crawler/common/repository/WantedJdSkillRepository.java
+++ b/module-crawler/src/main/java/kernel/jdon/crawler/common/repository/WantedJdSkillRepository.java
@@ -3,12 +3,10 @@ package kernel.jdon.crawler.common.repository;
 import java.util.List;
 
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
 
 import kernel.jdon.skill.domain.Skill;
 import kernel.jdon.wantedskill.domain.WantedJdSkill;
 
-@Repository
 public interface WantedJdSkillRepository extends JpaRepository<WantedJdSkill, Long> {
 
 	List<WantedJdSkill> findBySkill(Skill skill);

--- a/module-crawler/src/main/java/kernel/jdon/crawler/common/search/SearchCondition.java
+++ b/module-crawler/src/main/java/kernel/jdon/crawler/common/search/SearchCondition.java
@@ -1,0 +1,7 @@
+package kernel.jdon.crawler.common.search;
+
+public interface SearchCondition {
+	String getSearchValue();
+
+	String getDescription();
+}

--- a/module-crawler/src/main/java/kernel/jdon/crawler/inflearn/controller/InflearnCrawlerController.java
+++ b/module-crawler/src/main/java/kernel/jdon/crawler/inflearn/controller/InflearnCrawlerController.java
@@ -14,7 +14,7 @@ public class InflearnCrawlerController {
 	private final CrawlerService crawlerService;
 
 	@GetMapping("/api/v1/crawler/inflearn")
-	public ResponseEntity<Object> getInflearnData() {
+	public ResponseEntity<Void> getInflearnData() {
 		crawlerService.fetchCourseInfo();
 
 		return ResponseEntity.noContent().build();

--- a/module-crawler/src/main/java/kernel/jdon/crawler/inflearn/controller/InflearnCrawlerController.java
+++ b/module-crawler/src/main/java/kernel/jdon/crawler/inflearn/controller/InflearnCrawlerController.java
@@ -1,0 +1,23 @@
+package kernel.jdon.crawler.inflearn.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import kernel.jdon.crawler.inflearn.service.InflearnCrawlerService;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+public class InflearnCrawlerController {
+
+	private final InflearnCrawlerService inflearnCrawlerService;
+
+	@GetMapping("/api/v1/crawler/inflearn")
+	public ResponseEntity<Object> getInflearnData() {
+		inflearnCrawlerService.fetchCourseInfo();
+
+		return ResponseEntity.noContent().build();
+	}
+
+}

--- a/module-crawler/src/main/java/kernel/jdon/crawler/inflearn/controller/InflearnCrawlerController.java
+++ b/module-crawler/src/main/java/kernel/jdon/crawler/inflearn/controller/InflearnCrawlerController.java
@@ -4,18 +4,18 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import kernel.jdon.crawler.inflearn.service.InflearnCrawlerService;
+import kernel.jdon.crawler.inflearn.service.CrawlerService;
 import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequiredArgsConstructor
 public class InflearnCrawlerController {
 
-	private final InflearnCrawlerService inflearnCrawlerService;
+	private final CrawlerService crawlerService;
 
 	@GetMapping("/api/v1/crawler/inflearn")
 	public ResponseEntity<Object> getInflearnData() {
-		inflearnCrawlerService.fetchCourseInfo();
+		crawlerService.fetchCourseInfo();
 
 		return ResponseEntity.noContent().build();
 	}

--- a/module-crawler/src/main/java/kernel/jdon/crawler/inflearn/converter/EntityBuilder.java
+++ b/module-crawler/src/main/java/kernel/jdon/crawler/inflearn/converter/EntityBuilder.java
@@ -1,0 +1,27 @@
+package kernel.jdon.crawler.inflearn.converter;
+
+import kernel.jdon.inflearn.domain.InflearnCourse;
+import kernel.jdon.inflearnJdskill.domain.InflearnJdSkill;
+import kernel.jdon.wantedskill.domain.WantedJdSkill;
+
+public class EntityBuilder {
+	public static InflearnCourse createInflearnCourse(Long courseId, String title, String lectureUrl, String instructor,
+		long studentCount, String imageUrl, int price) {
+		return InflearnCourse.builder()
+			.courseId(courseId)
+			.title(title)
+			.lectureUrl(lectureUrl)
+			.instructor(instructor)
+			.studentCount(studentCount)
+			.imageUrl(imageUrl)
+			.price(price)
+			.build();
+	}
+
+	public static InflearnJdSkill createInflearnJdSkill(InflearnCourse course, WantedJdSkill wantedJdSkill) {
+		return InflearnJdSkill.builder()
+			.inflearnCourse(course)
+			.wantedJdSkill(wantedJdSkill)
+			.build();
+	}
+}

--- a/module-crawler/src/main/java/kernel/jdon/crawler/inflearn/converter/EntityConverter.java
+++ b/module-crawler/src/main/java/kernel/jdon/crawler/inflearn/converter/EntityConverter.java
@@ -3,8 +3,11 @@ package kernel.jdon.crawler.inflearn.converter;
 import kernel.jdon.inflearn.domain.InflearnCourse;
 import kernel.jdon.inflearnJdskill.domain.InflearnJdSkill;
 import kernel.jdon.wantedskill.domain.WantedJdSkill;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
 
-public class EntityBuilder {
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class EntityConverter {
 	public static InflearnCourse createInflearnCourse(Long courseId, String title, String lectureUrl, String instructor,
 		long studentCount, String imageUrl, int price) {
 		return InflearnCourse.builder()

--- a/module-crawler/src/main/java/kernel/jdon/crawler/inflearn/dto/CourseAndSkillsDto.java
+++ b/module-crawler/src/main/java/kernel/jdon/crawler/inflearn/dto/CourseAndSkillsDto.java
@@ -1,0 +1,12 @@
+package kernel.jdon.crawler.inflearn.dto;
+
+import kernel.jdon.inflearn.domain.InflearnCourse;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class CourseAndSkillsDto {
+	private final InflearnCourse course;
+	private final String skillTags;
+}

--- a/module-crawler/src/main/java/kernel/jdon/crawler/inflearn/repository/InflearnCourseRepository.java
+++ b/module-crawler/src/main/java/kernel/jdon/crawler/inflearn/repository/InflearnCourseRepository.java
@@ -1,0 +1,14 @@
+package kernel.jdon.crawler.inflearn.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import kernel.jdon.inflearn.domain.InflearnCourse;
+
+@Repository
+public interface InflearnCourseRepository extends JpaRepository<InflearnCourse, Long> {
+
+	Optional<InflearnCourse> findByCourseId(Long courseId);
+}

--- a/module-crawler/src/main/java/kernel/jdon/crawler/inflearn/repository/InflearnCourseRepository.java
+++ b/module-crawler/src/main/java/kernel/jdon/crawler/inflearn/repository/InflearnCourseRepository.java
@@ -3,11 +3,9 @@ package kernel.jdon.crawler.inflearn.repository;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
 
 import kernel.jdon.inflearn.domain.InflearnCourse;
 
-@Repository
 public interface InflearnCourseRepository extends JpaRepository<InflearnCourse, Long> {
 
 	Optional<InflearnCourse> findByCourseId(Long courseId);

--- a/module-crawler/src/main/java/kernel/jdon/crawler/inflearn/repository/InflearnJdSkillRepository.java
+++ b/module-crawler/src/main/java/kernel/jdon/crawler/inflearn/repository/InflearnJdSkillRepository.java
@@ -1,0 +1,14 @@
+package kernel.jdon.crawler.inflearn.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import kernel.jdon.inflearn.domain.InflearnCourse;
+import kernel.jdon.inflearnJdskill.domain.InflearnJdSkill;
+import kernel.jdon.wantedskill.domain.WantedJdSkill;
+
+@Repository
+public interface InflearnJdSkillRepository extends JpaRepository<InflearnJdSkill, Long> {
+
+	boolean existsByInflearnCourseAndWantedJdSkill(InflearnCourse inflearnCourse, WantedJdSkill wantedJdSkill);
+}

--- a/module-crawler/src/main/java/kernel/jdon/crawler/inflearn/repository/InflearnJdSkillRepository.java
+++ b/module-crawler/src/main/java/kernel/jdon/crawler/inflearn/repository/InflearnJdSkillRepository.java
@@ -1,13 +1,11 @@
 package kernel.jdon.crawler.inflearn.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
 
 import kernel.jdon.inflearn.domain.InflearnCourse;
 import kernel.jdon.inflearnJdskill.domain.InflearnJdSkill;
 import kernel.jdon.wantedskill.domain.WantedJdSkill;
 
-@Repository
 public interface InflearnJdSkillRepository extends JpaRepository<InflearnJdSkill, Long> {
 
 	boolean existsByInflearnCourseAndWantedJdSkill(InflearnCourse inflearnCourse, WantedJdSkill wantedJdSkill);

--- a/module-crawler/src/main/java/kernel/jdon/crawler/inflearn/search/CourseDomain.java
+++ b/module-crawler/src/main/java/kernel/jdon/crawler/inflearn/search/CourseDomain.java
@@ -1,0 +1,32 @@
+package kernel.jdon.crawler.inflearn.search;
+
+import kernel.jdon.crawler.common.search.SearchCondition;
+import lombok.AllArgsConstructor;
+
+@AllArgsConstructor
+public enum CourseDomain implements SearchCondition {
+	DEVELOPMENT_PROGRAMMING("it-programming", "개발 프로그래밍"),
+	GAME_DEVELOPMENT("game-dev-all", "게임 개발"),
+	DATA_SCIENCE("data-science", "데이터 사이언스"),
+	SECURITY_NETWORK("it", "보안 네트워크"),
+	BUSINESS_MARKETING("business", "비즈니스 마케팅"),
+	HARDWARE("hardware", "하드웨어"),
+	DESIGN("design", "디자인"),
+	ACADEMIC_LANGUAGE("academics", "학문 외국어"),
+	CAREER("career", "커리어"),
+	SELF_DEVELOPMENT("life", "자기계발");
+
+	private final String searchValue;
+	private final String description;
+
+	@Override
+	public String getSearchValue() {
+		return this.searchValue;
+	}
+
+	@Override
+	public String getDescription() {
+		return this.description;
+	}
+
+}

--- a/module-crawler/src/main/java/kernel/jdon/crawler/inflearn/search/CourseSearchSort.java
+++ b/module-crawler/src/main/java/kernel/jdon/crawler/inflearn/search/CourseSearchSort.java
@@ -1,0 +1,28 @@
+package kernel.jdon.crawler.inflearn.search;
+
+import kernel.jdon.crawler.common.search.SearchCondition;
+import lombok.AllArgsConstructor;
+
+@AllArgsConstructor
+public enum CourseSearchSort implements SearchCondition {
+
+	SORT_RECOMMMENDED("seq", "추천순"),
+	SORT_POPULARITY("popular", "인기순"),
+	SORT_LATEST("recent", "최신순"),
+	SORT_RATING("rating", "별점순"),
+	SORT_LIKE("famous", "좋아요순");
+
+	public final static String SEARCH_KEY = "order";
+	private final String searchValue;
+	private final String description;
+
+	@Override
+	public String getSearchValue() {
+		return this.searchValue;
+	}
+
+	@Override
+	public String getDescription() {
+		return this.description;
+	}
+}

--- a/module-crawler/src/main/java/kernel/jdon/crawler/inflearn/search/DevelopmentProgrammingCategory.java
+++ b/module-crawler/src/main/java/kernel/jdon/crawler/inflearn/search/DevelopmentProgrammingCategory.java
@@ -1,0 +1,39 @@
+package kernel.jdon.crawler.inflearn.search;
+
+import kernel.jdon.crawler.common.search.SearchCondition;
+import lombok.AllArgsConstructor;
+
+@AllArgsConstructor
+public enum DevelopmentProgrammingCategory implements SearchCondition {
+	WEB_DEVELOPMENT("web-dev", "웹 개발"),
+	FRONTEND("front-end", "프론트엔드"),
+	BACKEND("back-end", "백엔드"),
+	FULL_STACK("full-stack", "풀스택"),
+	MOBILE_APP_DEVELOPMENT("mobile-app", "모바일 앱 개발"),
+	PROGRAMMING_LANGUAGE("programming-lang", "프로그래밍 언어"),
+	ALGORITHM_DATA_STRUCTURE("algorithm", "알고리즘 자료구조"),
+	DATABASE("database-dev", "데이터베이스"),
+	DEVOPS_INFRA("devops-infra", "데브옵스 인프라"),
+	CERTIFICATION("certificate-programming", "자격증"),
+	DEVELOPMENT_TOOL("programming-tool", "개발 도구"),
+	WEB_PUBLISHING("web-publishing", "웹 퍼블리싱"),
+	VR_AR("vr-ar", "VR/AR"),
+	DESKTOP_APP_DEVELOPMENT("desktop-application", "데스크톱 앱 개발"),
+	GAME_DEVELOPMENT("game-dev", "게임 개발"),
+	DATA_SCIENCE("dev-data-science", "데이터 사이언스"),
+	GENERAL_KNOWLEDGE("dev-besides", "교양 기타");
+
+	private final String searchValue;
+	private final String description;
+
+	@Override
+	public String getSearchValue() {
+		return this.searchValue;
+	}
+
+	@Override
+	public String getDescription() {
+		return this.description;
+	}
+
+}

--- a/module-crawler/src/main/java/kernel/jdon/crawler/inflearn/service/CourseDuplicationCheckerService.java
+++ b/module-crawler/src/main/java/kernel/jdon/crawler/inflearn/service/CourseDuplicationCheckerService.java
@@ -11,7 +11,7 @@ public class CourseDuplicationCheckerService {
 
 	private final InflearnCourseRepository inflearnCourseRepository;
 
-	public boolean isDuplicate(Long courseId) {
+	protected boolean isDuplicate(Long courseId) {
 		if (courseId == null) {
 			return false;
 		}

--- a/module-crawler/src/main/java/kernel/jdon/crawler/inflearn/service/CourseDuplicationCheckerService.java
+++ b/module-crawler/src/main/java/kernel/jdon/crawler/inflearn/service/CourseDuplicationCheckerService.java
@@ -1,0 +1,21 @@
+package kernel.jdon.crawler.inflearn.service;
+
+import org.springframework.stereotype.Service;
+
+import kernel.jdon.crawler.inflearn.repository.InflearnCourseRepository;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class CourseDuplicationCheckerService {
+
+	private final InflearnCourseRepository inflearnCourseRepository;
+
+	public boolean isDuplicate(Long courseId) {
+		if (courseId == null) {
+			return false;
+		}
+
+		return inflearnCourseRepository.findByCourseId(courseId).isPresent();
+	}
+}

--- a/module-crawler/src/main/java/kernel/jdon/crawler/inflearn/service/CourseParserService.java
+++ b/module-crawler/src/main/java/kernel/jdon/crawler/inflearn/service/CourseParserService.java
@@ -4,7 +4,7 @@ import org.jsoup.nodes.Element;
 import org.jsoup.select.Elements;
 import org.springframework.stereotype.Service;
 
-import kernel.jdon.crawler.inflearn.converter.EntityBuilder;
+import kernel.jdon.crawler.inflearn.converter.EntityConverter;
 import kernel.jdon.crawler.inflearn.dto.CourseAndSkillsDto;
 import kernel.jdon.crawler.inflearn.util.SkillStandardizer;
 import kernel.jdon.inflearn.domain.InflearnCourse;
@@ -24,7 +24,7 @@ public class CourseParserService {
 		String skillTags = getText(courseElement, "div.course_skills > span");
 		String standardizedSkillTags = SkillStandardizer.standardize(skillTags);
 
-		InflearnCourse inflearnCourse = EntityBuilder.createInflearnCourse(courseId, title, lectureUrl, instructor,
+		InflearnCourse inflearnCourse = EntityConverter.createInflearnCourse(courseId, title, lectureUrl, instructor,
 			studentCount, imageUrl, price);
 
 		return new CourseAndSkillsDto(inflearnCourse, standardizedSkillTags);

--- a/module-crawler/src/main/java/kernel/jdon/crawler/inflearn/service/CourseParserService.java
+++ b/module-crawler/src/main/java/kernel/jdon/crawler/inflearn/service/CourseParserService.java
@@ -1,0 +1,53 @@
+package kernel.jdon.crawler.inflearn.service;
+
+import org.jsoup.nodes.Element;
+import org.jsoup.select.Elements;
+import org.springframework.stereotype.Service;
+
+import kernel.jdon.crawler.inflearn.converter.EntityBuilder;
+import kernel.jdon.crawler.inflearn.dto.CourseAndSkillsDto;
+import kernel.jdon.crawler.inflearn.util.SkillStandardizer;
+import kernel.jdon.inflearn.domain.InflearnCourse;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class CourseParserService {
+
+	public CourseAndSkillsDto parseCourse(Element courseElement, String lectureUrl) {
+		Long courseId = Long.parseLong(courseElement.attr("data-productId"));
+		String title = getText(courseElement, "div.course_title");
+		long studentCount = parseStudentCount(courseElement);
+		String instructor = getText(courseElement, "div.instructor");
+		String imageUrl = courseElement.select("img").attr("src");
+		int price = Integer.parseInt(parsePrice(courseElement));
+		String skillTags = getText(courseElement, "div.course_skills > span");
+		String standardizedSkillTags = SkillStandardizer.standardize(skillTags);
+
+		InflearnCourse inflearnCourse = EntityBuilder.createInflearnCourse(courseId, title, lectureUrl, instructor,
+			studentCount, imageUrl, price);
+
+		return new CourseAndSkillsDto(inflearnCourse, standardizedSkillTags);
+	}
+
+	private String getText(Element element, String cssQuery) {
+
+		return element.select(cssQuery).text();
+	}
+
+	private long parseStudentCount(Element element) {
+		String studentCountText = element.select("div.tags span.tag:contains(명)").text();
+		String parsedText = studentCountText.replaceAll("[^\\d]", "");
+
+		return parsedText.isEmpty() ? 0 : Long.parseLong(parsedText);
+	}
+
+	private String parsePrice(Element element) {
+		Elements priceElement = element.select("div.price");
+		String priceText =
+			priceElement.select("del").isEmpty() ? priceElement.text() : priceElement.select("del").first().text();
+		String parsedText = priceText.replaceAll("[^\\d]", "");
+
+		return parsedText.isEmpty() ? "0" : parsedText;
+	}
+}

--- a/module-crawler/src/main/java/kernel/jdon/crawler/inflearn/service/CourseParserService.java
+++ b/module-crawler/src/main/java/kernel/jdon/crawler/inflearn/service/CourseParserService.java
@@ -14,7 +14,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class CourseParserService {
 
-	public CourseAndSkillsDto parseCourse(Element courseElement, String lectureUrl) {
+	protected CourseAndSkillsDto parseCourse(Element courseElement, String lectureUrl) {
 		Long courseId = Long.parseLong(courseElement.attr("data-productId"));
 		String title = getText(courseElement, "div.course_title");
 		long studentCount = parseStudentCount(courseElement);

--- a/module-crawler/src/main/java/kernel/jdon/crawler/inflearn/service/CourseScraperService.java
+++ b/module-crawler/src/main/java/kernel/jdon/crawler/inflearn/service/CourseScraperService.java
@@ -10,7 +10,7 @@ import org.springframework.stereotype.Service;
 @Service
 public class CourseScraperService {
 
-	public Elements scrapeCourses(String url) {
+	protected Elements scrapeCourses(String url) {
 		// TODO: CrawlerException 커스텀 예러를 던져줘서 GlobalExceptionHandler에서 처리할 수 있도록 리팩토링 필요, 한꺼번에 리팩토링할 수 있도록 남겨뒀습니다
 		try {
 			Document doc = Jsoup.connect(url).get();

--- a/module-crawler/src/main/java/kernel/jdon/crawler/inflearn/service/CourseScraperService.java
+++ b/module-crawler/src/main/java/kernel/jdon/crawler/inflearn/service/CourseScraperService.java
@@ -1,0 +1,22 @@
+package kernel.jdon.crawler.inflearn.service;
+
+import java.io.IOException;
+
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.select.Elements;
+import org.springframework.stereotype.Service;
+
+@Service
+public class CourseScraperService {
+
+	public Elements scrapeCourses(String url) {
+		// TODO: CrawlerException 커스텀 예러를 던져줘서 GlobalExceptionHandler에서 처리할 수 있도록 리팩토링 필요, 한꺼번에 리팩토링할 수 있도록 남겨뒀습니다
+		try {
+			Document doc = Jsoup.connect(url).get();
+			return doc.select("div.card.course");
+		} catch (IOException e) {
+			throw new IllegalArgumentException("강의 데이터를 가져오지 못한 url: " + url, e);
+		}
+	}
+}

--- a/module-crawler/src/main/java/kernel/jdon/crawler/inflearn/service/CourseStorageService.java
+++ b/module-crawler/src/main/java/kernel/jdon/crawler/inflearn/service/CourseStorageService.java
@@ -1,0 +1,78 @@
+package kernel.jdon.crawler.inflearn.service;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.stereotype.Service;
+
+import kernel.jdon.crawler.common.repository.SkillRepository;
+import kernel.jdon.crawler.common.repository.WantedJdSkillRepository;
+import kernel.jdon.crawler.inflearn.converter.EntityBuilder;
+import kernel.jdon.crawler.inflearn.repository.InflearnCourseRepository;
+import kernel.jdon.crawler.inflearn.repository.InflearnJdSkillRepository;
+import kernel.jdon.inflearn.domain.InflearnCourse;
+import kernel.jdon.inflearnJdskill.domain.InflearnJdSkill;
+import kernel.jdon.skill.domain.Skill;
+import kernel.jdon.wantedskill.domain.WantedJdSkill;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class CourseStorageService {
+
+	private final InflearnCourseRepository inflearnCourseRepository;
+	private final InflearnJdSkillRepository inflearnJdSkillRepository;
+	private final WantedJdSkillRepository wantedJdSkillRepository;
+	private final SkillRepository skillRepository;
+
+	public void createInflearnCourseAndInflearnJdSkill(InflearnCourse inflearnCourse, String skillTags) {
+		if (shouldCreateInflearnCourse(skillTags)) {
+			InflearnCourse savedCourse = inflearnCourseRepository.save(inflearnCourse);
+			processAndCreateInflearnJdSKill(savedCourse, skillTags);
+		}
+	}
+
+	private boolean shouldCreateInflearnCourse(String skillTags) {
+		String[] skillList = skillTags.split(", ");
+		for (String skill : skillList) {
+			Optional<Skill> existingSkill = skillRepository.findByKeyword(skill);
+			if (existingSkill.isPresent()) {
+				List<WantedJdSkill> wantedJdSkills = wantedJdSkillRepository.findBySkill(existingSkill.get());
+				if (!wantedJdSkills.isEmpty()) {
+					return true;
+				}
+			}
+		}
+
+		return false;
+	}
+
+	public void processAndCreateInflearnJdSKill(InflearnCourse inflearnCourse, String skillTags) {
+		String[] skillList = skillTags.split(", ");
+		for (String skill : skillList) {
+			associateWantedJdSkillWithInflearnCourse(inflearnCourse, skill);
+		}
+	}
+
+	private void associateWantedJdSkillWithInflearnCourse(InflearnCourse inflearnCourse, String skill) {
+		List<WantedJdSkill> wantedJdSkillList = findWantedJdSkill(skill);
+		wantedJdSkillList.forEach(wantedJdSkill -> createInflearnJdSkillIfNotExists(inflearnCourse, wantedJdSkill));
+	}
+
+	private List<WantedJdSkill> findWantedJdSkill(String keyword) {
+		Optional<Skill> existingSkill = skillRepository.findByKeyword(keyword);
+		if (existingSkill.isPresent()) {
+			return wantedJdSkillRepository.findBySkill(existingSkill.get());
+		}
+
+		return new ArrayList<>();
+	}
+
+	private void createInflearnJdSkillIfNotExists(InflearnCourse inflearnCourse, WantedJdSkill wantedJdSkill) {
+		if (!inflearnJdSkillRepository.existsByInflearnCourseAndWantedJdSkill(inflearnCourse, wantedJdSkill)) {
+			InflearnJdSkill inflearnJdSkill = EntityBuilder.createInflearnJdSkill(inflearnCourse, wantedJdSkill);
+			inflearnJdSkillRepository.save(inflearnJdSkill);
+		}
+	}
+}

--- a/module-crawler/src/main/java/kernel/jdon/crawler/inflearn/service/CourseStorageService.java
+++ b/module-crawler/src/main/java/kernel/jdon/crawler/inflearn/service/CourseStorageService.java
@@ -8,7 +8,7 @@ import org.springframework.stereotype.Service;
 
 import kernel.jdon.crawler.common.repository.SkillRepository;
 import kernel.jdon.crawler.common.repository.WantedJdSkillRepository;
-import kernel.jdon.crawler.inflearn.converter.EntityBuilder;
+import kernel.jdon.crawler.inflearn.converter.EntityConverter;
 import kernel.jdon.crawler.inflearn.repository.InflearnCourseRepository;
 import kernel.jdon.crawler.inflearn.repository.InflearnJdSkillRepository;
 import kernel.jdon.inflearn.domain.InflearnCourse;
@@ -71,7 +71,7 @@ public class CourseStorageService {
 
 	private void createInflearnJdSkillIfNotExists(InflearnCourse inflearnCourse, WantedJdSkill wantedJdSkill) {
 		if (!inflearnJdSkillRepository.existsByInflearnCourseAndWantedJdSkill(inflearnCourse, wantedJdSkill)) {
-			InflearnJdSkill inflearnJdSkill = EntityBuilder.createInflearnJdSkill(inflearnCourse, wantedJdSkill);
+			InflearnJdSkill inflearnJdSkill = EntityConverter.createInflearnJdSkill(inflearnCourse, wantedJdSkill);
 			inflearnJdSkillRepository.save(inflearnJdSkill);
 		}
 	}

--- a/module-crawler/src/main/java/kernel/jdon/crawler/inflearn/service/CourseStorageService.java
+++ b/module-crawler/src/main/java/kernel/jdon/crawler/inflearn/service/CourseStorageService.java
@@ -26,7 +26,7 @@ public class CourseStorageService {
 	private final WantedJdSkillRepository wantedJdSkillRepository;
 	private final SkillRepository skillRepository;
 
-	public void createInflearnCourseAndInflearnJdSkill(InflearnCourse inflearnCourse, String skillTags) {
+	protected void createInflearnCourseAndInflearnJdSkill(InflearnCourse inflearnCourse, String skillTags) {
 		if (shouldCreateInflearnCourse(skillTags)) {
 			InflearnCourse savedCourse = inflearnCourseRepository.save(inflearnCourse);
 			processAndCreateInflearnJdSKill(savedCourse, skillTags);
@@ -48,7 +48,7 @@ public class CourseStorageService {
 		return false;
 	}
 
-	public void processAndCreateInflearnJdSKill(InflearnCourse inflearnCourse, String skillTags) {
+	private void processAndCreateInflearnJdSKill(InflearnCourse inflearnCourse, String skillTags) {
 		String[] skillList = skillTags.split(", ");
 		for (String skill : skillList) {
 			associateWantedJdSkillWithInflearnCourse(inflearnCourse, skill);

--- a/module-crawler/src/main/java/kernel/jdon/crawler/inflearn/service/CrawlerService.java
+++ b/module-crawler/src/main/java/kernel/jdon/crawler/inflearn/service/CrawlerService.java
@@ -1,0 +1,5 @@
+package kernel.jdon.crawler.inflearn.service;
+
+public interface CrawlerService {
+	void fetchCourseInfo();
+}

--- a/module-crawler/src/main/java/kernel/jdon/crawler/inflearn/service/InflearnCrawlerService.java
+++ b/module-crawler/src/main/java/kernel/jdon/crawler/inflearn/service/InflearnCrawlerService.java
@@ -16,6 +16,7 @@ import kernel.jdon.inflearn.domain.InflearnCourse;
 import lombok.RequiredArgsConstructor;
 
 @Service
+@Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class InflearnCrawlerService implements CrawlerService {
 

--- a/module-crawler/src/main/java/kernel/jdon/crawler/inflearn/service/InflearnCrawlerService.java
+++ b/module-crawler/src/main/java/kernel/jdon/crawler/inflearn/service/InflearnCrawlerService.java
@@ -1,0 +1,67 @@
+package kernel.jdon.crawler.inflearn.service;
+
+import static kernel.jdon.util.StringUtil.*;
+
+import org.jsoup.nodes.Element;
+import org.jsoup.select.Elements;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import kernel.jdon.config.UrlConfig;
+import kernel.jdon.crawler.inflearn.dto.CourseAndSkillsDto;
+import kernel.jdon.crawler.inflearn.search.CourseDomain;
+import kernel.jdon.crawler.inflearn.search.CourseSearchSort;
+import kernel.jdon.crawler.inflearn.search.DevelopmentProgrammingCategory;
+import kernel.jdon.inflearn.domain.InflearnCourse;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class InflearnCrawlerService {
+
+	private final UrlConfig urlConfig;
+	private final CourseScraperService courseScraperService;
+	private final CourseParserService courseParserService;
+	private final CourseStorageService courseStorageService;
+	private final CourseDuplicationCheckerService courseDuplicationCheckerService;
+
+	@Transactional
+	public void fetchCourseInfo() {
+		String lectureUrl = createInflearnListUrl(CourseDomain.DEVELOPMENT_PROGRAMMING,
+			DevelopmentProgrammingCategory.WEB_DEVELOPMENT, CourseSearchSort.SORT_POPULARITY, 1);
+		Elements courseElements = courseScraperService.scrapeCourses(lectureUrl);
+		parseAndCreateCourses(courseElements, lectureUrl);
+	}
+
+	public void parseAndCreateCourses(Elements courseElements, String lectureUrl) {
+		for (Element courseElement : courseElements) {
+			CourseAndSkillsDto courseAndSkillsDto = courseParserService.parseCourse(courseElement, lectureUrl);
+			InflearnCourse course = courseAndSkillsDto.getCourse();
+			String skillTags = courseAndSkillsDto.getSkillTags();
+
+			if (!courseDuplicationCheckerService.isDuplicate(course.getCourseId())) {
+				courseStorageService.createInflearnCourseAndInflearnJdSkill(course, skillTags);
+			}
+		}
+	}
+
+	private String createInflearnListUrl(CourseDomain domain, DevelopmentProgrammingCategory category,
+		CourseSearchSort searchSort, int pageNum) {
+		String path = joinToString(
+			urlConfig.getInflearnCourseListUrl(),
+			createPathString(domain.getSearchValue()),
+			createPathString(category.getSearchValue())
+		);
+
+		String queryString = joinToString(
+			createQueryString(CourseSearchSort.SEARCH_KEY, searchSort.getSearchValue()),
+			createQueryString("page", String.valueOf(pageNum))
+		);
+
+		if (queryString.endsWith("&")) {
+			queryString = queryString.substring(0, queryString.length() - 1);
+		}
+
+		return path + "?" + queryString;
+	}
+}

--- a/module-crawler/src/main/java/kernel/jdon/crawler/inflearn/service/InflearnCrawlerService.java
+++ b/module-crawler/src/main/java/kernel/jdon/crawler/inflearn/service/InflearnCrawlerService.java
@@ -17,7 +17,7 @@ import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor
-public class InflearnCrawlerService {
+public class InflearnCrawlerService implements CrawlerService {
 
 	private final UrlConfig urlConfig;
 	private final CourseScraperService courseScraperService;
@@ -26,6 +26,7 @@ public class InflearnCrawlerService {
 	private final CourseDuplicationCheckerService courseDuplicationCheckerService;
 
 	@Transactional
+	@Override
 	public void fetchCourseInfo() {
 		String lectureUrl = createInflearnListUrl(CourseDomain.DEVELOPMENT_PROGRAMMING,
 			DevelopmentProgrammingCategory.WEB_DEVELOPMENT, CourseSearchSort.SORT_POPULARITY, 1);
@@ -33,7 +34,7 @@ public class InflearnCrawlerService {
 		parseAndCreateCourses(courseElements, lectureUrl);
 	}
 
-	public void parseAndCreateCourses(Elements courseElements, String lectureUrl) {
+	private void parseAndCreateCourses(Elements courseElements, String lectureUrl) {
 		for (Element courseElement : courseElements) {
 			CourseAndSkillsDto courseAndSkillsDto = courseParserService.parseCourse(courseElement, lectureUrl);
 			InflearnCourse course = courseAndSkillsDto.getCourse();

--- a/module-crawler/src/main/java/kernel/jdon/crawler/inflearn/util/SkillStandardizer.java
+++ b/module-crawler/src/main/java/kernel/jdon/crawler/inflearn/util/SkillStandardizer.java
@@ -1,0 +1,33 @@
+package kernel.jdon.crawler.inflearn.util;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public class SkillStandardizer {
+
+	private static final Map<String, String> skillAliases = new HashMap<>();
+
+	static {
+		skillAliases.put("Spring Boot", "springboot");
+		skillAliases.put("머신러닝", "ml");
+		skillAliases.put("Java Persistence API", "jpa");
+	}
+
+	public static String standardize(String skill) {
+		if (skill.contains("/")) {
+			return Arrays.stream(skill.split("/"))
+				.map(SkillStandardizer::normalizeAndLookup)
+				.collect(Collectors.joining(", "));
+		} else {
+			return normalizeAndLookup(skill);
+		}
+	}
+
+	private static String normalizeAndLookup(String skill) {
+		String normalizedSkill = skill.toLowerCase().replaceAll("\\s+", "");
+		
+		return skillAliases.getOrDefault(normalizedSkill, skill);
+	}
+}

--- a/module-crawler/src/main/java/kernel/jdon/crawler/wanted/controller/WantedCrawlerController.java
+++ b/module-crawler/src/main/java/kernel/jdon/crawler/wanted/controller/WantedCrawlerController.java
@@ -14,7 +14,7 @@ public class WantedCrawlerController {
 	private final WantedCrawlerService wantedCrawlerService;
 
 	@GetMapping("/api/v1/crawler/wanted")
-	public ResponseEntity<Object> getWantedData() {
+	public ResponseEntity<Void> getWantedData() {
 		wantedCrawlerService.fetchJd();
 		return ResponseEntity.noContent().build();
 	}

--- a/module-crawler/src/main/java/kernel/jdon/crawler/wanted/repository/WantedJdSkillRepository.java
+++ b/module-crawler/src/main/java/kernel/jdon/crawler/wanted/repository/WantedJdSkillRepository.java
@@ -1,8 +1,0 @@
-package kernel.jdon.crawler.wanted.repository;
-
-import org.springframework.data.jpa.repository.JpaRepository;
-
-import kernel.jdon.wantedskill.domain.WantedJdSkill;
-
-public interface WantedJdSkillRepository extends JpaRepository<WantedJdSkill, Long> {
-}

--- a/module-crawler/src/main/java/kernel/jdon/crawler/wanted/search/JobSearchCondition.java
+++ b/module-crawler/src/main/java/kernel/jdon/crawler/wanted/search/JobSearchCondition.java
@@ -1,6 +1,0 @@
-package kernel.jdon.crawler.wanted.search;
-
-public interface JobSearchCondition {
-	String getSearchValue();
-	String getDescription();
-}

--- a/module-crawler/src/main/java/kernel/jdon/crawler/wanted/search/JobSearchExperience.java
+++ b/module-crawler/src/main/java/kernel/jdon/crawler/wanted/search/JobSearchExperience.java
@@ -1,15 +1,15 @@
 package kernel.jdon.crawler.wanted.search;
 
+import kernel.jdon.crawler.common.search.SearchCondition;
 import lombok.AllArgsConstructor;
 
 @AllArgsConstructor
-public enum JobSearchExperience implements JobSearchCondition {
+public enum JobSearchExperience implements SearchCondition {
 	EXPERIENCE_ALL("-1", "전체");
 
 	public final static String SEARCH_KEY = "years";
 	private final String searchValue;
 	private final String description;
-
 
 	@Override
 	public String getDescription() {

--- a/module-crawler/src/main/java/kernel/jdon/crawler/wanted/search/JobSearchJobCategory.java
+++ b/module-crawler/src/main/java/kernel/jdon/crawler/wanted/search/JobSearchJobCategory.java
@@ -1,9 +1,10 @@
 package kernel.jdon.crawler.wanted.search;
 
+import kernel.jdon.crawler.common.search.SearchCondition;
 import lombok.AllArgsConstructor;
 
 @AllArgsConstructor
-public enum JobSearchJobCategory implements JobSearchCondition {
+public enum JobSearchJobCategory implements SearchCondition {
 	JOB_DEVELOPER("518", "개발");
 
 	public final static String SEARCH_KEY = "job_group_id";

--- a/module-crawler/src/main/java/kernel/jdon/crawler/wanted/search/JobSearchJobPosition.java
+++ b/module-crawler/src/main/java/kernel/jdon/crawler/wanted/search/JobSearchJobPosition.java
@@ -1,9 +1,10 @@
 package kernel.jdon.crawler.wanted.search;
 
+import kernel.jdon.crawler.common.search.SearchCondition;
 import lombok.AllArgsConstructor;
 
 @AllArgsConstructor
-public enum JobSearchJobPosition implements JobSearchCondition {
+public enum JobSearchJobPosition implements SearchCondition {
 	JOB_POSITION_FRONTEND("669", "프론트엔드 개발자"),
 	JOB_POSITION_SERVER("872", "서버 개발자");
 

--- a/module-crawler/src/main/java/kernel/jdon/crawler/wanted/search/JobSearchLocation.java
+++ b/module-crawler/src/main/java/kernel/jdon/crawler/wanted/search/JobSearchLocation.java
@@ -1,9 +1,10 @@
 package kernel.jdon.crawler.wanted.search;
 
+import kernel.jdon.crawler.common.search.SearchCondition;
 import lombok.AllArgsConstructor;
 
 @AllArgsConstructor
-public enum JobSearchLocation implements JobSearchCondition {
+public enum JobSearchLocation implements SearchCondition {
 	LOCATIONS_ALL("all", "전체");
 
 	public final static String SEARCH_KEY = "locations";

--- a/module-crawler/src/main/java/kernel/jdon/crawler/wanted/search/JobSearchSort.java
+++ b/module-crawler/src/main/java/kernel/jdon/crawler/wanted/search/JobSearchSort.java
@@ -1,9 +1,10 @@
 package kernel.jdon.crawler.wanted.search;
 
+import kernel.jdon.crawler.common.search.SearchCondition;
 import lombok.AllArgsConstructor;
 
 @AllArgsConstructor
-public enum JobSearchSort implements JobSearchCondition {
+public enum JobSearchSort implements SearchCondition {
 	SORT_LATEST("job.latest_order", "최신순"),
 	SORT_POPULARITY("job.popularity_order", "인기순");
 

--- a/module-crawler/src/main/java/kernel/jdon/crawler/wanted/service/WantedCrawlerService.java
+++ b/module-crawler/src/main/java/kernel/jdon/crawler/wanted/service/WantedCrawlerService.java
@@ -13,14 +13,14 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.client.RestTemplate;
 
 import kernel.jdon.config.UrlConfig;
+import kernel.jdon.crawler.common.repository.SkillRepository;
+import kernel.jdon.crawler.common.repository.WantedJdSkillRepository;
 import kernel.jdon.crawler.wanted.converter.EntityConverter;
 import kernel.jdon.crawler.wanted.dto.object.CreateSkillDto;
 import kernel.jdon.crawler.wanted.dto.response.WantedJobDetailResponse;
 import kernel.jdon.crawler.wanted.dto.response.WantedJobListResponse;
 import kernel.jdon.crawler.wanted.repository.JobCategoryRepository;
-import kernel.jdon.crawler.wanted.repository.SkillRepository;
 import kernel.jdon.crawler.wanted.repository.WantedJdRepository;
-import kernel.jdon.crawler.wanted.repository.WantedJdSkillRepository;
 import kernel.jdon.crawler.wanted.search.JobSearchExperience;
 import kernel.jdon.crawler.wanted.search.JobSearchJobCategory;
 import kernel.jdon.crawler.wanted.search.JobSearchJobPosition;

--- a/module-crawler/src/test/resources/application.yml
+++ b/module-crawler/src/test/resources/application.yml
@@ -8,7 +8,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: create-drop
+      ddl-auto: validate # create-drop
 
     properties:
       hibernate:

--- a/module-domain/src/main/java/kernel/jdon/inflearn/domain/InflearnCourse.java
+++ b/module-domain/src/main/java/kernel/jdon/inflearn/domain/InflearnCourse.java
@@ -8,9 +8,11 @@ import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Builder;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
+@Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "inflearn_course")
 public class InflearnCourse {

--- a/module-domain/src/main/java/kernel/jdon/inflearn/domain/InflearnCourse.java
+++ b/module-domain/src/main/java/kernel/jdon/inflearn/domain/InflearnCourse.java
@@ -1,7 +1,11 @@
 package kernel.jdon.inflearn.domain;
 
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -14,6 +18,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
 @Table(name = "inflearn_course")
 public class InflearnCourse {
 
@@ -42,9 +47,13 @@ public class InflearnCourse {
 	@Column(name = "price", columnDefinition = "INT", nullable = false)
 	private int price;
 
+	@CreatedDate
+	@Column(name = "scraping_date", columnDefinition = "TEXT", nullable = false)
+	private String scrapingDate;
+
 	@Builder
 	public InflearnCourse(Long courseId, String title, String lectureUrl, String instructor, Long studentCount,
-		String imageUrl, int price) {
+		String imageUrl, int price, String scrapingDate) {
 		this.courseId = courseId;
 		this.title = title;
 		this.lectureUrl = lectureUrl;
@@ -52,5 +61,6 @@ public class InflearnCourse {
 		this.studentCount = studentCount;
 		this.imageUrl = imageUrl;
 		this.price = price;
+		this.scrapingDate = scrapingDate;
 	}
 }

--- a/module-domain/src/main/java/kernel/jdon/inflearn/domain/InflearnCourse.java
+++ b/module-domain/src/main/java/kernel/jdon/inflearn/domain/InflearnCourse.java
@@ -1,6 +1,5 @@
 package kernel.jdon.inflearn.domain;
 
-import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import jakarta.persistence.Column;
@@ -10,6 +9,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import kernel.jdon.base.BaseEntity;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -20,7 +20,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @EntityListeners(AuditingEntityListener.class)
 @Table(name = "inflearn_course")
-public class InflearnCourse {
+public class InflearnCourse extends BaseEntity {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -47,13 +47,9 @@ public class InflearnCourse {
 	@Column(name = "price", columnDefinition = "INT", nullable = false)
 	private int price;
 
-	@CreatedDate
-	@Column(name = "scraping_date", columnDefinition = "TEXT", nullable = false)
-	private String scrapingDate;
-
 	@Builder
 	public InflearnCourse(Long courseId, String title, String lectureUrl, String instructor, Long studentCount,
-		String imageUrl, int price, String scrapingDate) {
+		String imageUrl, int price) {
 		this.courseId = courseId;
 		this.title = title;
 		this.lectureUrl = lectureUrl;
@@ -61,6 +57,5 @@ public class InflearnCourse {
 		this.studentCount = studentCount;
 		this.imageUrl = imageUrl;
 		this.price = price;
-		this.scrapingDate = scrapingDate;
 	}
 }

--- a/module-domain/src/main/java/kernel/jdon/inflearn/domain/InflearnCourse.java
+++ b/module-domain/src/main/java/kernel/jdon/inflearn/domain/InflearnCourse.java
@@ -6,14 +6,21 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
 
 @Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "inflearn_course")
 public class InflearnCourse {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
+
+	@Column(name = "course_id", columnDefinition = "BIGINT", nullable = false, unique = true)
+	private Long courseId;
 
 	@Column(name = "title", columnDefinition = "VARCHAR(100)", nullable = false)
 	private String title;
@@ -32,4 +39,16 @@ public class InflearnCourse {
 
 	@Column(name = "price", columnDefinition = "INT", nullable = false)
 	private int price;
+
+	@Builder
+	public InflearnCourse(Long courseId, String title, String lectureUrl, String instructor, Long studentCount,
+		String imageUrl, int price) {
+		this.courseId = courseId;
+		this.title = title;
+		this.lectureUrl = lectureUrl;
+		this.instructor = instructor;
+		this.studentCount = studentCount;
+		this.imageUrl = imageUrl;
+		this.price = price;
+	}
 }

--- a/module-domain/src/main/java/kernel/jdon/inflearnJdskill/domain/InflearnJdSkill.java
+++ b/module-domain/src/main/java/kernel/jdon/inflearnJdskill/domain/InflearnJdSkill.java
@@ -10,8 +10,12 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import kernel.jdon.inflearn.domain.InflearnCourse;
 import kernel.jdon.wantedskill.domain.WantedJdSkill;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
 
 @Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "inflearn_jd_skill")
 public class InflearnJdSkill {
 
@@ -26,4 +30,10 @@ public class InflearnJdSkill {
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "course_id", columnDefinition = "BIGINT")
 	private InflearnCourse inflearnCourse;
+
+	@Builder
+	public InflearnJdSkill(WantedJdSkill wantedJdSkill, InflearnCourse inflearnCourse) {
+		this.wantedJdSkill = wantedJdSkill;
+		this.inflearnCourse = inflearnCourse;
+	}
 }

--- a/module-domain/src/main/java/kernel/jdon/skill/domain/Skill.java
+++ b/module-domain/src/main/java/kernel/jdon/skill/domain/Skill.java
@@ -46,6 +46,7 @@ public class Skill {
 	public void countPlus(Long plus) {
 		this.count += plus;
 	}
+
 	@Builder
 	public Skill(Long id, String keyword, Long count, JobCategory jobCategory) {
 		this.id = id;


### PR DESCRIPTION
## 개요
-------------
### 요약
- 인프런 강의 정보를 긁어와서 `InflearnCourse`와 `InflearnJdSkill` 테이블에 정보 넣음
- 기존의 `WantedJdSKill` 테이블에 존재하는 `skill`을 가지고 있는 `InflearnCourse`만 db에 저장하고
`InflearnCourse`와 `WantedJdSkill` 중간테이블인 `InflearnJdSkill`에 해당되는 정보를 저장

### 변경한 부분
- **Repository**
  - 원티드와 인프런에서 공통으로 사용하는 repository(`SkillRepository`와 `WantedJdSkillRepository`)와 `SearchCondition` 인터페이스는 common 파일 아래 위치 시킴
- **Controller**
  -  `InflearnCrawlerController`를 별도로 생성해놓긴했지만,  `WantedCrawlerController`와 합쳐서 common에 `CrawlerController`로 합쳐도 될 것 같습니다
- **Service**
    - 퍼사드 패턴을 이용하여 Controller에서 직접적으로 사용하는 service는 `InflearnCrawlerService`이고,  `InflearnCrawlerService`에서 사용하는 기능에 따라 별도의 클래스로 분리하였습니다. 
    - 클라이언트( Controller)에서는 통합된 인터페이스(`CrawlerService`)의 fetchCourseInfo()라는 단일한 접점과 상호작용합니다.
    - `CrawlerService`: 외부 클라이언트에게 단일한 접점
    - `InflearnCrawlerService`: `CrawlerService` 인터페이스를 구현한 서비스
    - `CourseScraperService`: 웹 스크래핑을 통해 데이터를 가져오는 작업 담당
    - `CourseParserService`: 수집된 데이터를 파싱하여 구조화된 형식으로 변환
    - `CourseStorageService`: 파싱된 데이터를 db에 저장
    - `CourseDuplicationService`: db에 이미 중복되는` InflearnCourse`가 있는지 확인
- **Util**
  - `StringUtil`: createPathString 메소드로 url 생성 시, /로 추가하는 메소드 추가
  - `SkillStandardizer`를 통해 원티드에서 사용하는 skill과 인프런에서 저장되어있는 skill이 같지만, 다르게 표시되어 있습니다.
  원티드의 skill에 저장되어있는 형식대로 저장하기위해 표준화 작업을 거칩니다.
  - ex)  SpringBoot -> springboot
           HTML/CSS -> html, css


### 변경한 결과
- `InflearnCourse`: 인프런 강의 데이터
![image](https://github.com/Kernel360/f1-JDON-Backend/assets/86637372/1796bc58-bda7-4dd1-bee2-cdf119b9d106)
- `InflearnJdSKill`: `인프런 강의`와 `원티드 Jd정보와 기술스택 매핑 데이터`에 대한 매핑 데이터
![image](https://github.com/Kernel360/f1-JDON-Backend/assets/86637372/23d35209-b85d-4b55-874a-b92aa16c3d47)


### 이슈

- closes: #55 

---

## PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경, 주석 변경)
- [ ] 코드 리팩토링
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 파일 혹은 폴더명 수정, 삭제
- [ ] 배포 관련