### PR TITLE
BugFix: add column title, scrapingDate at WantedJd table

### DIFF
--- a/module-crawler/src/main/java/kernel/jdon/crawler/wanted/converter/EntityConverter.java
+++ b/module-crawler/src/main/java/kernel/jdon/crawler/wanted/converter/EntityConverter.java
@@ -21,6 +21,7 @@ public class EntityConverter {
 		return WantedJd.builder()
 			.jobCategory(wantedJobDetailResponse.getJobCategory())
 			.companyName(wantedJobDetailResponse.getJob().getCompany().getName())
+			.title(wantedJobDetailResponse.getJob().getTitle())
 			.detailId(wantedJobDetailResponse.getJob().getId())
 			.detailUrl(wantedJobDetailResponse.getDetailUrl())
 			.imageUrl(wantedJobDetailResponse.getJob().getCompanyImages())

--- a/module-crawler/src/main/java/kernel/jdon/crawler/wanted/dto/response/WantedJobDetailResponse.java
+++ b/module-crawler/src/main/java/kernel/jdon/crawler/wanted/dto/response/WantedJobDetailResponse.java
@@ -29,6 +29,8 @@ public class WantedJobDetailResponse {
 	@NoArgsConstructor(access = AccessLevel.PRIVATE)
 	public static class JobDetail {
 		private Long id;
+		@JsonProperty("position")
+		private String title;
 		private Detail detail;
 		private Company company;
 		@JsonProperty("skill_tags")

--- a/module-crawler/src/main/java/kernel/jdon/crawler/wanted/service/WantedCrawlerService.java
+++ b/module-crawler/src/main/java/kernel/jdon/crawler/wanted/service/WantedCrawlerService.java
@@ -36,14 +36,14 @@ import lombok.RequiredArgsConstructor;
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class WantedCrawlerService {
+	private static final int MAX_FETCH_JD_LIST_SIZE = 10; // 1000
+	private static final int MAX_FETCH_JD_LIST_OFFSET = 5; // 100
 	private final RestTemplate restTemplate;
 	private final UrlConfig urlConfig;
 	private final WantedJdRepository wantedJdRepository;
 	private final WantedJdSkillRepository wantedJdSkillRepository;
 	private final SkillRepository skillRepository;
 	private final JobCategoryRepository jobCategoryRepository;
-	private static final int MAX_FETCH_JD_LIST_SIZE = 100; // 1000
-	private static final int MAX_FETCH_JD_LIST_OFFSET = 50; // 100
 
 	@Transactional
 	public void fetchJd() {
@@ -72,7 +72,7 @@ public class WantedCrawlerService {
 			}
 			/** 원티드 JD 상세 정보 등록 **/
 			WantedJobDetailResponse jobDetailResponse = fetchJobDetail(detailId);
-			jobDetailResponse.setDetailUrl(joinToString(urlConfig.getWantedJobDetailUrl(),detailId));
+			jobDetailResponse.setDetailUrl(joinToString(urlConfig.getWantedJobDetailUrl(), detailId));
 			jobDetailResponse.setJobCategory(jobCategory);
 			WantedJd savedWantedJd = wantedJdRepository.save(EntityConverter.createWantedJd(jobDetailResponse));
 
@@ -82,7 +82,8 @@ public class WantedCrawlerService {
 			for (WantedJobDetailResponse.WantedSkill wantedSkill : jobDetailResponse.getJob().getSkill()) {
 				wantedSkillAndCountMap.put(
 					new SkillVo(jobCategory.getId(), wantedSkill.getKeyword()),
-					wantedSkillAndCountMap.getOrDefault(new SkillVo(jobCategory.getId(), wantedSkill.getKeyword()),0L)+1L
+					wantedSkillAndCountMap.getOrDefault(new SkillVo(jobCategory.getId(), wantedSkill.getKeyword()), 0L)
+						+ 1L
 				);
 			}
 		}
@@ -104,7 +105,7 @@ public class WantedCrawlerService {
 		/** 원티드 JD 상세 - 기술 중간테이블 저장 **/
 		for (Map.Entry<WantedJd, List<WantedJobDetailResponse.WantedSkill>> entry : wantedJdDetailSkillMap.entrySet()) {
 			WantedJd wantedJd = entry.getKey();
-			List<WantedJobDetailResponse.WantedSkill> targetJdSkillList= entry.getValue();
+			List<WantedJobDetailResponse.WantedSkill> targetJdSkillList = entry.getValue();
 			for (WantedJobDetailResponse.WantedSkill skill : targetJdSkillList) {
 				Skill findSkill = findByJobCategoryIdAndKeyword(jobCategory.getId(), skill.getKeyword());
 				wantedJdSkillRepository.save(EntityConverter.createWantedJdSkill(wantedJd, findSkill));

--- a/module-domain/src/main/java/kernel/jdon/wanted/domain/WantedJd.java
+++ b/module-domain/src/main/java/kernel/jdon/wanted/domain/WantedJd.java
@@ -1,7 +1,11 @@
 package kernel.jdon.wanted.domain;
 
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -19,6 +23,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
 @Table(name = "wanted_jd", uniqueConstraints = @UniqueConstraint(columnNames = {"detail_id", "job_category_id"}))
 public class WantedJd {
 
@@ -29,6 +34,9 @@ public class WantedJd {
 	@Column(name = "company_name", columnDefinition = "VARCHAR(50)", nullable = false)
 	private String companyName;
 
+	@Column(name = "title", columnDefinition = "VARCHAR(255)", nullable = false)
+	private String title;
+
 	@Column(name = "detail_id", columnDefinition = "BIGINT", nullable = false)
 	private Long detailId;
 
@@ -38,16 +46,24 @@ public class WantedJd {
 	@Column(name = "image_url", columnDefinition = "TEXT", nullable = false)
 	private String imageUrl;
 
+	@CreatedDate
+	@Column(name = "scraping_date", columnDefinition = "TEXT", nullable = false)
+	private String scrapingDate;
+
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "job_category_id", columnDefinition = "BIGINT")
 	private JobCategory jobCategory;
 
 	@Builder
-	public WantedJd(String companyName, Long detailId, String detailUrl, String imageUrl, JobCategory jobCategory) {
+	public WantedJd(String companyName, String title, Long detailId, String detailUrl, String imageUrl,
+		String scrapingDate,
+		JobCategory jobCategory) {
 		this.companyName = companyName;
+		this.title = title;
 		this.detailId = detailId;
 		this.detailUrl = detailUrl;
 		this.imageUrl = imageUrl;
+		this.scrapingDate = scrapingDate;
 		this.jobCategory = jobCategory;
 	}
 }


### PR DESCRIPTION
## 개요

### 요약
- wanted 엔티티 누락 컬럼 추가

### 변경한 부분
- 스크래핑 일자, 원티드 jd의 제목 컬럼 추가 하였습니다.
- 원티드 공고 스크래핑 시 스크래핑 및 원티드 jd의 제목 데이터를 저장하도록 수정하였습니다.

### 변경한 결과
- 아래와 같이 금일 스크래핑한 원티드 데이터부터 스크래핑 일자, 원티드 jd의 제목 컬럼에 데이터가 들어가는 것을 확인하였습니다.
![image](https://github.com/Kernel360/f1-JDON-Backend/assets/59242594/e6da2602-3b84-41df-acf0-1009642d9967)


### 이슈

- closes: #80 

---

## PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경, 주석 변경)
- [ ] 코드 리팩토링
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 파일 혹은 폴더명 수정, 삭제
- [ ] 배포 관련