### PR TITLE
Feature: 커피챗 등록, 상세조회 API 구현

### DIFF
--- a/module-api/src/main/java/kernel/jdon/coffeechat/controller/CoffeeChatController.java
+++ b/module-api/src/main/java/kernel/jdon/coffeechat/controller/CoffeeChatController.java
@@ -1,0 +1,37 @@
+package kernel.jdon.coffeechat.controller;
+
+import java.net.URI;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import kernel.jdon.coffeechat.dto.request.CreateCoffeeChatRequest;
+import kernel.jdon.coffeechat.dto.response.CreateCoffeeChatResponse;
+import kernel.jdon.coffeechat.service.CoffeeChatService;
+import kernel.jdon.dto.response.CommonResponse;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api")
+@RequiredArgsConstructor
+public class CoffeeChatController {
+
+	private final CoffeeChatService coffeeChatService;
+
+	@GetMapping("/v1/coffeechats/{id}")
+	public ResponseEntity<CommonResponse> get(@PathVariable(name = "id") Long coffeeChatId) {
+		return ResponseEntity.ok().body(CommonResponse.of(coffeeChatService.find(coffeeChatId)));
+	}
+
+	@PostMapping("/v1/coffeechats")
+	public ResponseEntity<CommonResponse> save(@RequestBody CreateCoffeeChatRequest request) {
+		CreateCoffeeChatResponse response = coffeeChatService.create(request);
+		URI uri = URI.create("/v1/coffeechats/" + response.getCoffeeChatId());
+		return ResponseEntity.created(uri).body(CommonResponse.of(response));
+	}
+}

--- a/module-api/src/main/java/kernel/jdon/coffeechat/controller/CoffeeChatController.java
+++ b/module-api/src/main/java/kernel/jdon/coffeechat/controller/CoffeeChatController.java
@@ -25,6 +25,7 @@ public class CoffeeChatController {
 
 	@GetMapping("/v1/coffeechats/{id}")
 	public ResponseEntity<CommonResponse> get(@PathVariable(name = "id") Long coffeeChatId) {
+
 		return ResponseEntity.ok().body(CommonResponse.of(coffeeChatService.find(coffeeChatId)));
 	}
 
@@ -32,6 +33,7 @@ public class CoffeeChatController {
 	public ResponseEntity<CommonResponse> save(@RequestBody CreateCoffeeChatRequest request) {
 		CreateCoffeeChatResponse response = coffeeChatService.create(request);
 		URI uri = URI.create("/v1/coffeechats/" + response.getCoffeeChatId());
+
 		return ResponseEntity.created(uri).body(CommonResponse.of(response));
 	}
 }

--- a/module-api/src/main/java/kernel/jdon/coffeechat/controller/CoffeeChatController.java
+++ b/module-api/src/main/java/kernel/jdon/coffeechat/controller/CoffeeChatController.java
@@ -17,19 +17,18 @@ import kernel.jdon.dto.response.CommonResponse;
 import lombok.RequiredArgsConstructor;
 
 @RestController
-@RequestMapping("/api")
 @RequiredArgsConstructor
 public class CoffeeChatController {
 
 	private final CoffeeChatService coffeeChatService;
 
-	@GetMapping("/v1/coffeechats/{id}")
+	@GetMapping("/api/v1/coffeechats/{id}")
 	public ResponseEntity<CommonResponse> get(@PathVariable(name = "id") Long coffeeChatId) {
 
 		return ResponseEntity.ok().body(CommonResponse.of(coffeeChatService.find(coffeeChatId)));
 	}
 
-	@PostMapping("/v1/coffeechats")
+	@PostMapping("/api/v1/coffeechats")
 	public ResponseEntity<CommonResponse> save(@RequestBody CreateCoffeeChatRequest request) {
 		CreateCoffeeChatResponse response = coffeeChatService.create(request);
 		URI uri = URI.create("/v1/coffeechats/" + response.getCoffeeChatId());

--- a/module-api/src/main/java/kernel/jdon/coffeechat/repository/CoffeeChatRepository.java
+++ b/module-api/src/main/java/kernel/jdon/coffeechat/repository/CoffeeChatRepository.java
@@ -1,0 +1,8 @@
+package kernel.jdon.coffeechat.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import kernel.jdon.coffeechat.domain.CoffeeChat;
+
+public interface CoffeeChatRepository extends JpaRepository<CoffeeChat, Long> {
+}

--- a/module-api/src/main/java/kernel/jdon/coffeechat/service/CoffeeChatService.java
+++ b/module-api/src/main/java/kernel/jdon/coffeechat/service/CoffeeChatService.java
@@ -1,0 +1,38 @@
+package kernel.jdon.coffeechat.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import kernel.jdon.coffeechat.domain.CoffeeChat;
+import kernel.jdon.coffeechat.dto.request.CreateCoffeeChatRequest;
+import kernel.jdon.coffeechat.dto.response.CreateCoffeeChatResponse;
+import kernel.jdon.coffeechat.dto.response.FindCoffeeChatResponse;
+import kernel.jdon.coffeechat.repository.CoffeeChatRepository;
+import kernel.jdon.error.code.CoffeeChatErrorCode;
+import kernel.jdon.error.exception.api.ApiException;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class CoffeeChatService {
+
+	private final CoffeeChatRepository coffeeChatRepository;
+
+	@Transactional
+	public FindCoffeeChatResponse find(Long coffeeChatId) {
+		CoffeeChat coffeeChat = coffeeChatRepository.findById(coffeeChatId)
+			.orElseThrow(() -> new ApiException(CoffeeChatErrorCode.NOT_FOUND_COFFEECHAT));
+		coffeeChat.increaseViewCount();
+
+		return FindCoffeeChatResponse.of(coffeeChat);
+	}
+
+	@Transactional
+	public CreateCoffeeChatResponse create(CreateCoffeeChatRequest request) {
+		CoffeeChat savedCoffeeChat = coffeeChatRepository.save(CreateCoffeeChatRequest.toEntity(request));
+
+		return CreateCoffeeChatResponse.of(savedCoffeeChat.getId());
+	}
+
+}

--- a/module-api/src/main/java/kernel/jdon/coffeechat/service/CoffeeChatService.java
+++ b/module-api/src/main/java/kernel/jdon/coffeechat/service/CoffeeChatService.java
@@ -21,11 +21,15 @@ public class CoffeeChatService {
 
 	@Transactional
 	public FindCoffeeChatResponse find(Long coffeeChatId) {
-		CoffeeChat coffeeChat = coffeeChatRepository.findById(coffeeChatId)
+		CoffeeChat findCoffeeChat = coffeeChatRepository.findById(coffeeChatId)
 			.orElseThrow(() -> new ApiException(CoffeeChatErrorCode.NOT_FOUND_COFFEECHAT));
-		coffeeChat.increaseViewCount();
+		increaseViewCount(findCoffeeChat);
 
-		return FindCoffeeChatResponse.of(coffeeChat);
+		return FindCoffeeChatResponse.of(findCoffeeChat);
+	}
+
+	private void increaseViewCount(CoffeeChat coffeeChat) {
+		coffeeChat.increaseViewCount();
 	}
 
 	@Transactional

--- a/module-common/src/main/java/kernel/jdon/error/code/CoffeeChatErrorCode.java
+++ b/module-common/src/main/java/kernel/jdon/error/code/CoffeeChatErrorCode.java
@@ -1,0 +1,23 @@
+package kernel.jdon.error.code;
+
+import org.springframework.http.HttpStatus;
+
+import lombok.AllArgsConstructor;
+
+@AllArgsConstructor
+public enum CoffeeChatErrorCode implements ErrorCode {
+	NOT_FOUND_COFFEECHAT(HttpStatus.NOT_FOUND, "존재하지 않는 커피챗 입니다.");
+
+	private final HttpStatus httpStatus;
+	private final String message;
+
+	@Override
+	public HttpStatus getHttpStatus() {
+		return httpStatus;
+	}
+
+	@Override
+	public String getMessage() {
+		return message;
+	}
+}

--- a/module-domain/src/main/java/kernel/jdon/coffeechat/domain/CoffeeChat.java
+++ b/module-domain/src/main/java/kernel/jdon/coffeechat/domain/CoffeeChat.java
@@ -1,6 +1,7 @@
 package kernel.jdon.coffeechat.domain;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 
 import jakarta.persistence.Column;
@@ -18,10 +19,14 @@ import jakarta.persistence.Table;
 import kernel.jdon.base.BaseEntity;
 import kernel.jdon.coffeechatmember.domain.CoffeeChatMember;
 import kernel.jdon.member.domain.Member;
+import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "coffee_chat")
 public class CoffeeChat extends BaseEntity {
 
@@ -36,7 +41,7 @@ public class CoffeeChat extends BaseEntity {
 	private String content;
 
 	@Column(name = "view_count", columnDefinition = "BIGINT default 0", nullable = false)
-	private Long viewCount;
+	private Long viewCount = 0L;
 
 	@Column(name = "is_deleted", columnDefinition = "BOOLEAN", nullable = false)
 	private boolean isDeleted;
@@ -55,12 +60,27 @@ public class CoffeeChat extends BaseEntity {
 	private Long totalRecruitCount;
 
 	@Column(name = "current_recruit_count", columnDefinition = "BIGINT default 0", nullable = false)
-	private Long currentRecruitCount;
+	private Long currentRecruitCount = 0L;
 
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "created_by", columnDefinition = "BIGINT")
 	private Member member;
 
 	@OneToMany(mappedBy = "coffeeChat")
-	private List<CoffeeChatMember> coffeeChatMemberList;
+	private List<CoffeeChatMember> coffeeChatMemberList = new ArrayList<>();
+
+	@Builder
+	public CoffeeChat(String title, String content, LocalDateTime meetDate, String openChatUrl,
+		Long totalRecruitCount, Member member) {
+		this.title = title;
+		this.content = content;
+		this.totalRecruitCount = totalRecruitCount;
+		this.meetDate = meetDate;
+		this.openChatUrl = openChatUrl;
+		this.member = member;
+	}
+
+	public void increaseViewCount() {
+		this.viewCount += 1;
+	}
 }

--- a/module-domain/src/main/java/kernel/jdon/coffeechat/dto/request/CreateCoffeeChatRequest.java
+++ b/module-domain/src/main/java/kernel/jdon/coffeechat/dto/request/CreateCoffeeChatRequest.java
@@ -5,9 +5,12 @@ import java.time.LocalDateTime;
 import kernel.jdon.coffeechat.domain.CoffeeChat;
 import kernel.jdon.faq.dto.request.CreateFaqRequest;
 import kernel.jdon.member.domain.Member;
+import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class CreateCoffeeChatRequest {
 
 	private String title;

--- a/module-domain/src/main/java/kernel/jdon/coffeechat/dto/request/CreateCoffeeChatRequest.java
+++ b/module-domain/src/main/java/kernel/jdon/coffeechat/dto/request/CreateCoffeeChatRequest.java
@@ -1,0 +1,30 @@
+package kernel.jdon.coffeechat.dto.request;
+
+import java.time.LocalDateTime;
+
+import kernel.jdon.coffeechat.domain.CoffeeChat;
+import kernel.jdon.faq.dto.request.CreateFaqRequest;
+import kernel.jdon.member.domain.Member;
+import lombok.Getter;
+
+@Getter
+public class CreateCoffeeChatRequest {
+
+	private String title;
+	private String content;
+	private Long totalRecruitCount;
+	private LocalDateTime meetDate;
+	private String openChatUrl;
+
+	public static CoffeeChat toEntity(CreateCoffeeChatRequest request) {
+		return CoffeeChat.builder()
+			.title(request.getTitle())
+			.content(request.getContent())
+			.totalRecruitCount(request.getTotalRecruitCount())
+			.meetDate(request.getMeetDate())
+			.openChatUrl(request.getOpenChatUrl())
+			.member(Member.builder().id(1L).build())
+			.build();
+	}
+
+}

--- a/module-domain/src/main/java/kernel/jdon/coffeechat/dto/response/CreateCoffeeChatResponse.java
+++ b/module-domain/src/main/java/kernel/jdon/coffeechat/dto/response/CreateCoffeeChatResponse.java
@@ -1,9 +1,12 @@
 package kernel.jdon.coffeechat.dto.response;
 
+import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor
 public class CreateCoffeeChatResponse {
 	private Long coffeeChatId;

--- a/module-domain/src/main/java/kernel/jdon/coffeechat/dto/response/CreateCoffeeChatResponse.java
+++ b/module-domain/src/main/java/kernel/jdon/coffeechat/dto/response/CreateCoffeeChatResponse.java
@@ -1,0 +1,14 @@
+package kernel.jdon.coffeechat.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class CreateCoffeeChatResponse {
+	private Long coffeeChatId;
+
+	public static CreateCoffeeChatResponse of(Long coffeeChatId) {
+		return new CreateCoffeeChatResponse(coffeeChatId);
+	}
+}

--- a/module-domain/src/main/java/kernel/jdon/coffeechat/dto/response/FindCoffeeChatResponse.java
+++ b/module-domain/src/main/java/kernel/jdon/coffeechat/dto/response/FindCoffeeChatResponse.java
@@ -1,0 +1,44 @@
+package kernel.jdon.coffeechat.dto.response;
+
+import java.time.LocalDateTime;
+
+import kernel.jdon.coffeechat.domain.CoffeeChat;
+import kernel.jdon.coffeechat.domain.CoffeeChatActiveStatus;
+import kernel.jdon.faq.dto.response.FindFaqResponse;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class FindCoffeeChatResponse {
+
+	private Long coffeeChatId;
+	private String nickname;
+	private String title;
+	private String content;
+	private Long viewCount;
+	private String status;
+	private LocalDateTime meetDate;
+	private String openChatUrl;
+	private Long totalRecruitCount;
+	private Long currentRecruitCount;
+
+	public static FindCoffeeChatResponse of(CoffeeChat coffeeChat) {
+		return FindCoffeeChatResponse.builder()
+			.coffeeChatId(coffeeChat.getId())
+			.nickname(coffeeChat.getMember().getNickname())
+			.title(coffeeChat.getTitle())
+			.content(coffeeChat.getContent())
+			.viewCount(coffeeChat.getViewCount())
+			.status(coffeeChat.getCoffeeChatStatus().getActiveStatus())
+			.meetDate(coffeeChat.getMeetDate())
+			.openChatUrl(coffeeChat.getOpenChatUrl())
+			.totalRecruitCount(coffeeChat.getTotalRecruitCount())
+			.currentRecruitCount(coffeeChat.getCurrentRecruitCount())
+			.build();
+
+	}
+
+}

--- a/module-domain/src/main/java/kernel/jdon/coffeechat/dto/response/FindCoffeeChatResponse.java
+++ b/module-domain/src/main/java/kernel/jdon/coffeechat/dto/response/FindCoffeeChatResponse.java
@@ -5,12 +5,15 @@ import java.time.LocalDateTime;
 import kernel.jdon.coffeechat.domain.CoffeeChat;
 import kernel.jdon.coffeechat.domain.CoffeeChatActiveStatus;
 import kernel.jdon.faq.dto.response.FindFaqResponse;
+import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
 @Builder
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor
 public class FindCoffeeChatResponse {
 

--- a/module-domain/src/main/java/kernel/jdon/member/domain/Member.java
+++ b/module-domain/src/main/java/kernel/jdon/member/domain/Member.java
@@ -23,10 +23,14 @@ import kernel.jdon.coffeechatmember.domain.CoffeeChatMember;
 import kernel.jdon.jobcategory.domain.JobCategory;
 import kernel.jdon.memberskill.domain.MemberSkill;
 import kernel.jdon.favorite.domain.Favorite;
+import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "member")
 public class Member {
 
@@ -84,4 +88,21 @@ public class Member {
 	@OneToMany(mappedBy = "member")
 	private List<Favorite> favoriteList = new ArrayList<>();
 
+	@Builder
+	public Member(Long id, String email, String nickname, String birth, Gender gender, LocalDateTime joinDate,
+		LocalDateTime lastLoginDate, MemberRole role, MemberAccountStatus accountStatus, LocalDateTime withdrawDate,
+		String socialProvider, JobCategory jobCategory) {
+		this.id = id;
+		this.email = email;
+		this.nickname = nickname;
+		this.birth = birth;
+		this.gender = gender;
+		this.joinDate = joinDate;
+		this.lastLoginDate = lastLoginDate;
+		this.role = role;
+		this.accountStatus = accountStatus;
+		this.withdrawDate = withdrawDate;
+		this.socialProvider = socialProvider;
+		this.jobCategory = jobCategory;
+	}
 }


### PR DESCRIPTION
## 개요
커피챗 등록과 상세조회 API를 구현했습니다.

### 요약
- Member 엔터티 변경
- CoffeChat 엔터티 변경 및 API별 DTO 생성
- CoffeChat Controller, Service, Repository 생성

### 변경한 부분
- Member
  - 엔터티에 생성자를 만들고 빌더어노테이션 적용
- CoffeeChat
  - 엔터티에서 디폴트값 필요한 항목들 적용
  - 등록, 상세조회에 필요한 DTO 작성
  - 커스텀 익셉션에 담을 에러코드 Enum 생성
  - Controller, Service, Repository 작성

### 이슈

- closes: #92 

---

## PR 유형

어떤 변경 사항이 있나요?

- [X] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경, 주석 변경)
- [ ] 코드 리팩토링
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 파일 혹은 폴더명 수정, 삭제
- [ ] 배포 관련