### PR TITLE
Feature: add dummy data for favorite inflearn lecture api

### DIFF
--- a/module-api/src/main/java/kernel/jdon/favorite/controller/FavoriteController.java
+++ b/module-api/src/main/java/kernel/jdon/favorite/controller/FavoriteController.java
@@ -1,5 +1,6 @@
 package kernel.jdon.favorite.controller;
 
+import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -41,10 +42,9 @@ public class FavoriteController {
 
 	@PostMapping("/api/v1/favorites")
 	public ResponseEntity<CommonResponse> save(@RequestBody CreateFavoriteRequest createFavoriteRequest) {
-		CreateFavoriteResponse createFavoriteResponse = CreateFavoriteResponse.builder()
-			.lectureId(createFavoriteRequest.getLectureId())
-			.build();
+		Long lectureId = createFavoriteRequest.getLectureId();
+		URI uri = URI.create("/api/v1/favorites/" + lectureId);
 
-		return ResponseEntity.ok(CommonResponse.of(createFavoriteResponse));
+		return ResponseEntity.created(uri).body(CommonResponse.of(CreateFavoriteResponse.of(lectureId)));
 	}
 }

--- a/module-api/src/main/java/kernel/jdon/favorite/controller/FavoriteController.java
+++ b/module-api/src/main/java/kernel/jdon/favorite/controller/FavoriteController.java
@@ -10,9 +10,9 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
 import kernel.jdon.dto.response.CommonResponse;
-import kernel.jdon.favorite.domain.dto.request.SaveFavoriteRequest;
+import kernel.jdon.favorite.domain.dto.request.CreateFavoriteRequest;
+import kernel.jdon.favorite.domain.dto.response.CreateFavoriteResponse;
 import kernel.jdon.favorite.domain.dto.response.FindFavoriteResponse;
-import kernel.jdon.favorite.domain.dto.response.SaveFavoriteResponse;
 
 @RestController
 public class FavoriteController {
@@ -40,11 +40,11 @@ public class FavoriteController {
 	}
 
 	@PostMapping("/api/v1/favorites")
-	public ResponseEntity<CommonResponse> save(@RequestBody SaveFavoriteRequest saveFavoriteRequest) {
-		SaveFavoriteResponse saveFavoriteResponse = SaveFavoriteResponse.builder()
-			.lectureId(saveFavoriteRequest.getLectureId())
+	public ResponseEntity<CommonResponse> save(@RequestBody CreateFavoriteRequest createFavoriteRequest) {
+		CreateFavoriteResponse createFavoriteResponse = CreateFavoriteResponse.builder()
+			.lectureId(createFavoriteRequest.getLectureId())
 			.build();
 
-		return ResponseEntity.ok(CommonResponse.of(saveFavoriteResponse));
+		return ResponseEntity.ok(CommonResponse.of(createFavoriteResponse));
 	}
 }

--- a/module-api/src/main/java/kernel/jdon/favorite/controller/FavoriteController.java
+++ b/module-api/src/main/java/kernel/jdon/favorite/controller/FavoriteController.java
@@ -1,0 +1,50 @@
+package kernel.jdon.favorite.controller;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+import kernel.jdon.dto.response.CommonResponse;
+import kernel.jdon.favorite.domain.dto.request.SaveFavoriteRequest;
+import kernel.jdon.favorite.domain.dto.response.FindFavoriteResponse;
+import kernel.jdon.favorite.domain.dto.response.SaveFavoriteResponse;
+
+@RestController
+public class FavoriteController {
+
+	@GetMapping("/api/v1/favorites")
+	public ResponseEntity<CommonResponse> getAll() {
+		List<FindFavoriteResponse> findFavoriteResponseList = new ArrayList<>();
+		for (long i = 1; i < 10; i++) {
+			FindFavoriteResponse findFavoriteLectureResponse = FindFavoriteResponse.builder()
+				.lectureId(i)
+				.title("스프링부트 초급편_" + i)
+				.lectureUrl("www.inflearn.com/we234")
+				.imageUrl(
+					"https://cdn.inflearn.com/public/courses/330459/cover/00d1bd8e-3b9d-4c62-b801-fea717c942fa/330459-eng.png")
+				.instructor("김영한")
+				.studentCount(5332)
+				.price(180000)
+				.isFavorite(true)
+				.build();
+
+			findFavoriteResponseList.add(findFavoriteLectureResponse);
+		}
+
+		return ResponseEntity.ok(CommonResponse.of(findFavoriteResponseList));
+	}
+
+	@PostMapping("/api/v1/favorites")
+	public ResponseEntity<CommonResponse> save(@RequestBody SaveFavoriteRequest saveFavoriteRequest) {
+		SaveFavoriteResponse saveFavoriteResponse = SaveFavoriteResponse.builder()
+			.lectureId(saveFavoriteRequest.getLectureId())
+			.build();
+
+		return ResponseEntity.ok(CommonResponse.of(saveFavoriteResponse));
+	}
+}

--- a/module-domain/src/main/java/kernel/jdon/favorite/domain/dto/request/CreateFavoriteRequest.java
+++ b/module-domain/src/main/java/kernel/jdon/favorite/domain/dto/request/CreateFavoriteRequest.java
@@ -6,7 +6,7 @@ import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
-public class SaveFavoriteRequest {
+public class CreateFavoriteRequest {
 	private Long lectureId;
 	private Boolean isFavorite;
 }

--- a/module-domain/src/main/java/kernel/jdon/favorite/domain/dto/request/SaveFavoriteRequest.java
+++ b/module-domain/src/main/java/kernel/jdon/favorite/domain/dto/request/SaveFavoriteRequest.java
@@ -1,0 +1,12 @@
+package kernel.jdon.favorite.domain.dto.request;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class SaveFavoriteRequest {
+	private Long lectureId;
+	private Boolean isFavorite;
+}

--- a/module-domain/src/main/java/kernel/jdon/favorite/domain/dto/response/CreateFavoriteResponse.java
+++ b/module-domain/src/main/java/kernel/jdon/favorite/domain/dto/response/CreateFavoriteResponse.java
@@ -10,6 +10,6 @@ import lombok.NoArgsConstructor;
 @Builder
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor
-public class SaveFavoriteResponse {
+public class CreateFavoriteResponse {
 	private Long lectureId;
 }

--- a/module-domain/src/main/java/kernel/jdon/favorite/domain/dto/response/CreateFavoriteResponse.java
+++ b/module-domain/src/main/java/kernel/jdon/favorite/domain/dto/response/CreateFavoriteResponse.java
@@ -1,9 +1,12 @@
 package kernel.jdon.favorite.domain.dto.response;
 
+import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor
 public class CreateFavoriteResponse {
 	private Long lectureId;

--- a/module-domain/src/main/java/kernel/jdon/favorite/domain/dto/response/CreateFavoriteResponse.java
+++ b/module-domain/src/main/java/kernel/jdon/favorite/domain/dto/response/CreateFavoriteResponse.java
@@ -1,15 +1,14 @@
 package kernel.jdon.favorite.domain.dto.response;
 
-import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 @Getter
-@Builder
-@NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor
 public class CreateFavoriteResponse {
 	private Long lectureId;
+
+	public static CreateFavoriteResponse of(Long lectureId) {
+		return new CreateFavoriteResponse(lectureId);
+	}
 }

--- a/module-domain/src/main/java/kernel/jdon/favorite/domain/dto/response/FindFavoriteResponse.java
+++ b/module-domain/src/main/java/kernel/jdon/favorite/domain/dto/response/FindFavoriteResponse.java
@@ -1,0 +1,22 @@
+package kernel.jdon.favorite.domain.dto.response;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor
+public class FindFavoriteResponse {
+	private Long lectureId;
+	private String title;
+	private String lectureUrl;
+	private String imageUrl;
+	private String instructor;
+	private Integer studentCount;
+	private Integer price;
+	private Boolean isFavorite;
+}

--- a/module-domain/src/main/java/kernel/jdon/favorite/domain/dto/response/SaveFavoriteResponse.java
+++ b/module-domain/src/main/java/kernel/jdon/favorite/domain/dto/response/SaveFavoriteResponse.java
@@ -1,0 +1,15 @@
+package kernel.jdon.favorite.domain.dto.response;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor
+public class SaveFavoriteResponse {
+	private Long lectureId;
+}


### PR DESCRIPTION
## 개요

### 요약
- 가데이터를 반환하는 Skill 관련 API 구현

### 변경한 부분
- 프론트엔드 요청에 따라 API 명세서 규격에 맞는 요청받고 데이터를 응답하도록 API를 구현하였습니다.
  - 내가 찜한 영상 목록 조회하기 API : https://www.notion.so/a54d5635404a4dfd8b79d7561e5b80d6
  - 영상 찜하는 버튼 누르기 API : https://www.notion.so/API-d0b2b8e78dd142ca8ace674e8d4a5705

### 변경한 결과
#### 내가 찜한 영상 목록 조회하기 API
- /api/v1/favorites
![image](https://github.com/Kernel360/f1-JDON-Backend/assets/86637372/c44905d4-0b10-4ee1-83ad-df54d17f9ba4)
![image](https://github.com/Kernel360/f1-JDON-Backend/assets/86637372/a800ea80-22c5-401c-84d9-5991b99ae663)


#### 영상 찜하는 버튼 누르기 API
- /api/v1/favorites
![image](https://github.com/Kernel360/f1-JDON-Backend/assets/86637372/7995a334-2a42-452c-b9a5-2450b73c57ce)
![image](https://github.com/Kernel360/f1-JDON-Backend/assets/86637372/650b7723-164a-4973-85bc-7b68e69ab915)



### 이슈

- closes: #69 

---

## PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경, 주석 변경)
- [ ] 코드 리팩토링
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 파일 혹은 폴더명 수정, 삭제
- [ ] 배포 관련