### PR TITLE
Feature: add dummy data for finding companies by skill api

### DIFF
--- a/module-api/src/main/java/kernel/jdon/skill/controller/SkillController.java
+++ b/module-api/src/main/java/kernel/jdon/skill/controller/SkillController.java
@@ -10,6 +10,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import kernel.jdon.dto.response.CommonResponse;
+import kernel.jdon.skill.dto.FindCompanyBySkillResponse;
 import kernel.jdon.skill.dto.FindHotSkillResponse;
 import kernel.jdon.skill.dto.FindJdResponse;
 import kernel.jdon.skill.dto.FindJobCategorySkillResponse;
@@ -126,5 +127,24 @@ public class SkillController {
 				.build();
 
 		return ResponseEntity.ok(CommonResponse.of(findListDataBySkillResponse));
+	}
+
+	@GetMapping("/api/v1/skills/company")
+	public ResponseEntity<CommonResponse> getCompanyListBySkill(
+		@RequestParam(name = "keyword", defaultValue = "") String keyword) {
+
+		List<FindCompanyBySkillResponse> findCompanyBySkillResponseList = new ArrayList<>();
+		for (int i = 0; i < 6; i++) {
+			FindCompanyBySkillResponse findCompanyBySkillResponse = FindCompanyBySkillResponse.builder()
+				.companyName("회사명" + i)
+				.imageUrl(
+					"https://image.wanted.co.kr/optimize?src=https%3A%2F%2Fstatic.wanted.co.kr%2Fimages%2Fcompany%2F22005%2F1d2vjy100vmqwhux__1080_790.jpg&w=1000&q=75")
+				.title("웹 풀스택 개발자 (3년 이상)")
+				.build();
+
+			findCompanyBySkillResponseList.add(findCompanyBySkillResponse);
+		}
+
+		return ResponseEntity.ok(CommonResponse.of(findCompanyBySkillResponseList));
 	}
 }

--- a/module-api/src/main/java/kernel/jdon/skill/controller/SkillController.java
+++ b/module-api/src/main/java/kernel/jdon/skill/controller/SkillController.java
@@ -140,6 +140,7 @@ public class SkillController {
 				.imageUrl(
 					"https://image.wanted.co.kr/optimize?src=https%3A%2F%2Fstatic.wanted.co.kr%2Fimages%2Fcompany%2F22005%2F1d2vjy100vmqwhux__1080_790.jpg&w=1000&q=75")
 				.title("웹 풀스택 개발자 (3년 이상)")
+				.detailUrl("https://www.wanted.co.kr/wd/198250")
 				.build();
 
 			findCompanyBySkillResponseList.add(findCompanyBySkillResponse);

--- a/module-domain/src/main/java/kernel/jdon/skill/dto/FindCompanyBySkillResponse.java
+++ b/module-domain/src/main/java/kernel/jdon/skill/dto/FindCompanyBySkillResponse.java
@@ -14,4 +14,5 @@ public class FindCompanyBySkillResponse {
 	private String companyName;
 	private String imageUrl;
 	private String title;
+	private String detailUrl;
 }

--- a/module-domain/src/main/java/kernel/jdon/skill/dto/FindCompanyBySkillResponse.java
+++ b/module-domain/src/main/java/kernel/jdon/skill/dto/FindCompanyBySkillResponse.java
@@ -1,0 +1,17 @@
+package kernel.jdon.skill.dto;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor
+public class FindCompanyBySkillResponse {
+	private String companyName;
+	private String imageUrl;
+	private String title;
+}

--- a/module-domain/src/main/java/kernel/jdon/skill/dto/FindListCompanyBySkillResponse.java
+++ b/module-domain/src/main/java/kernel/jdon/skill/dto/FindListCompanyBySkillResponse.java
@@ -1,0 +1,17 @@
+package kernel.jdon.skill.dto;
+
+import java.util.List;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor
+public class FindListCompanyBySkillResponse {
+	private List<FindCompanyBySkillResponse> companyList;
+}


### PR DESCRIPTION
## 개요

### 요약
- 가데이터를 변환하는 Skill 관련 API 구현

### 변경한 부분
- 프론트엔드 요청에 따라 API 명세서 규격에 맞는 요청받고 데이터를 응답하도록 API를 구현하였습니다.
  - 기술 스택에 따른 회사 조회하기 API : https://www.notion.so/d579cc615f4a4facae5a5760edd64454

### 변경한 결과
#### 기술 스택에 따른 회사 조회하기 API
![image](https://github.com/Kernel360/f1-JDON-Backend/assets/86637372/4519e239-5ed3-48ce-a617-eda44c29df9c)
![image](https://github.com/Kernel360/f1-JDON-Backend/assets/86637372/2a8bd126-5be0-4b8e-9ff9-b56d1d7bd8d7)


### 이슈

- closes: #111 

---

## PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경, 주석 변경)
- [ ] 코드 리팩토링
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 파일 혹은 폴더명 수정, 삭제
- [ ] 배포 관련