### PR TITLE
 Feature: 커피챗 삭제 API 구현

### DIFF
--- a/module-api/src/main/java/kernel/jdon/coffeechat/controller/CoffeeChatController.java
+++ b/module-api/src/main/java/kernel/jdon/coffeechat/controller/CoffeeChatController.java
@@ -120,8 +120,9 @@ public class CoffeeChatController {
 
 	@DeleteMapping("/api/v1/coffeechats/{id}")
 	public ResponseEntity<CommonResponse> remove(@PathVariable(name = "id") Long coffeeChatId) {
+		DeleteCoffeeChatResponse response = coffeeChatService.delete(coffeeChatId);
 
-		return ResponseEntity.ok().body(CommonResponse.of(DeleteCoffeeChatResponse.of(coffeeChatId)));
+		return ResponseEntity.ok().body(CommonResponse.of(response));
 	}
 
 	@PostMapping("/api/v1/coffeechats/{id}")

--- a/module-api/src/main/java/kernel/jdon/coffeechat/repository/CoffeeChatRepository.java
+++ b/module-api/src/main/java/kernel/jdon/coffeechat/repository/CoffeeChatRepository.java
@@ -1,8 +1,13 @@
 package kernel.jdon.coffeechat.repository;
 
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import kernel.jdon.coffeechat.domain.CoffeeChat;
 
 public interface CoffeeChatRepository extends JpaRepository<CoffeeChat, Long> {
+
+	Optional<CoffeeChat> findByIdAndIsDeletedFalse(Long id);
+
 }

--- a/module-api/src/main/java/kernel/jdon/coffeechat/service/CoffeeChatService.java
+++ b/module-api/src/main/java/kernel/jdon/coffeechat/service/CoffeeChatService.java
@@ -7,6 +7,7 @@ import kernel.jdon.coffeechat.domain.CoffeeChat;
 import kernel.jdon.coffeechat.dto.request.CreateCoffeeChatRequest;
 import kernel.jdon.coffeechat.dto.request.UpdateCoffeeChatRequest;
 import kernel.jdon.coffeechat.dto.response.CreateCoffeeChatResponse;
+import kernel.jdon.coffeechat.dto.response.DeleteCoffeeChatResponse;
 import kernel.jdon.coffeechat.dto.response.FindCoffeeChatResponse;
 import kernel.jdon.coffeechat.dto.response.UpdateCoffeeChatResponse;
 import kernel.jdon.coffeechat.repository.CoffeeChatRepository;
@@ -22,9 +23,9 @@ public class CoffeeChatService {
 	private final CoffeeChatRepository coffeeChatRepository;
 
 	private CoffeeChat findById(Long coffeeChatId) {
-		CoffeeChat findCoffeeChat = coffeeChatRepository.findById(coffeeChatId)
+
+		return coffeeChatRepository.findById(coffeeChatId)
 			.orElseThrow(() -> new ApiException(CoffeeChatErrorCode.NOT_FOUND_COFFEECHAT));
-		return findCoffeeChat;
 	}
 
 	@Transactional
@@ -50,8 +51,16 @@ public class CoffeeChatService {
 	public UpdateCoffeeChatResponse update(Long coffeeChatId, UpdateCoffeeChatRequest request) {
 		CoffeeChat findCoffeeChat = findById(coffeeChatId);
 		findCoffeeChat.updateCoffeeChat(request);
-		
+
 		return UpdateCoffeeChatResponse.of(findCoffeeChat.getId());
+	}
+
+	@Transactional
+	public DeleteCoffeeChatResponse delete(Long coffeeChatId) {
+		CoffeeChat findCoffeeChat = findById(coffeeChatId);
+		coffeeChatRepository.deleteById(findCoffeeChat.getId());
+		
+		return DeleteCoffeeChatResponse.of(coffeeChatId);
 	}
 
 }

--- a/module-api/src/main/java/kernel/jdon/coffeechat/service/CoffeeChatService.java
+++ b/module-api/src/main/java/kernel/jdon/coffeechat/service/CoffeeChatService.java
@@ -22,15 +22,15 @@ public class CoffeeChatService {
 
 	private final CoffeeChatRepository coffeeChatRepository;
 
-	private CoffeeChat findById(Long coffeeChatId) {
+	private CoffeeChat findByIdIfNotDeleted(Long coffeeChatId) {
 
-		return coffeeChatRepository.findById(coffeeChatId)
+		return coffeeChatRepository.findByIdAndIsDeletedFalse(coffeeChatId)
 			.orElseThrow(() -> new ApiException(CoffeeChatErrorCode.NOT_FOUND_COFFEECHAT));
 	}
 
 	@Transactional
 	public FindCoffeeChatResponse find(Long coffeeChatId) {
-		CoffeeChat findCoffeeChat = findById(coffeeChatId);
+		CoffeeChat findCoffeeChat = findByIdIfNotDeleted(coffeeChatId);
 		increaseViewCount(findCoffeeChat);
 
 		return FindCoffeeChatResponse.of(findCoffeeChat);
@@ -49,7 +49,7 @@ public class CoffeeChatService {
 
 	@Transactional
 	public UpdateCoffeeChatResponse update(Long coffeeChatId, UpdateCoffeeChatRequest request) {
-		CoffeeChat findCoffeeChat = findById(coffeeChatId);
+		CoffeeChat findCoffeeChat = findByIdIfNotDeleted(coffeeChatId);
 		findCoffeeChat.updateCoffeeChat(request);
 
 		return UpdateCoffeeChatResponse.of(findCoffeeChat.getId());
@@ -57,9 +57,9 @@ public class CoffeeChatService {
 
 	@Transactional
 	public DeleteCoffeeChatResponse delete(Long coffeeChatId) {
-		CoffeeChat findCoffeeChat = findById(coffeeChatId);
+		CoffeeChat findCoffeeChat = findByIdIfNotDeleted(coffeeChatId);
 		coffeeChatRepository.deleteById(findCoffeeChat.getId());
-		
+
 		return DeleteCoffeeChatResponse.of(coffeeChatId);
 	}
 

--- a/module-domain/src/main/java/kernel/jdon/coffeechat/domain/CoffeeChat.java
+++ b/module-domain/src/main/java/kernel/jdon/coffeechat/domain/CoffeeChat.java
@@ -4,6 +4,8 @@ import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.hibernate.annotations.SQLDelete;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -29,6 +31,7 @@ import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
+@SQLDelete(sql = "UPDATE coffee_chat SET is_deleted = true WHERE id = ?")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "coffee_chat")
 public class CoffeeChat extends BaseEntity {
@@ -47,7 +50,7 @@ public class CoffeeChat extends BaseEntity {
 	private Long viewCount = 0L;
 
 	@Column(name = "is_deleted", columnDefinition = "BOOLEAN", nullable = false)
-	private boolean isDeleted;
+	private boolean isDeleted = false;
 
 	@Enumerated(EnumType.STRING)
 	@Column(name = "active_status", columnDefinition = "VARCHAR(50)", nullable = false)


### PR DESCRIPTION
### 요약

커피챗 삭제 API를 구현했습니다(Soft Delete)
커피챗 단건 조회시 삭제여부를 조회조건에 추가했습니다

### 변경한 부분
- 커피챗 엔터티
  - soft delete위해 @SQLDelete 어노테이션 추가
  - isDeleted 필드 디폴트 값 명시
- Controller, Service 클래스 수정
- 커피챗 레포지토리에서 단건 조회시 삭제여부 조건을 포함한 메서드를 추가
  - 서비스 계층의 단건 조회 공통메서드에서 추가한 해당 메서드를 사용하도록 변경

### 이슈

- closes: #110 

---

## PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경, 주석 변경)
- [ ] 코드 리팩토링
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 파일 혹은 폴더명 수정, 삭제
- [ ] 배포 관련