### PR TITLE
Feature: OAuth2를 이용하여 사용자 정보를 받고, 로그인 유저정보를 세션에 저장하는 로직 구현

### DIFF
--- a/module-api/build.gradle
+++ b/module-api/build.gradle
@@ -34,6 +34,10 @@ dependencies {
 
     annotationProcessor 'org.projectlombok:lombok'
 
+    // security
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+
     // test
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'com.h2database:h2'

--- a/module-api/src/main/java/kernel/jdon/auth/JdonOAuth2User.java
+++ b/module-api/src/main/java/kernel/jdon/auth/JdonOAuth2User.java
@@ -1,0 +1,48 @@
+package kernel.jdon.auth;
+
+import java.util.Collection;
+import java.util.Map;
+
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
+
+import kernel.jdon.member.domain.SocialProviderType;
+import lombok.Getter;
+
+@Getter
+public class JdonOAuth2User extends DefaultOAuth2User {
+
+	private final String email;
+	private final SocialProviderType socialProvider;
+
+	/**
+	 * Constructs a {@code DefaultOAuth2User} using the provided parameters.
+	 * @param authorities the authorities granted to the user
+	 * @param attributes the attributes about the user
+	 * @param nameAttributeKey the key used to access the user's &quot;name&quot; from
+	 * {@link #getAttributes()}
+	 * @param email
+	 * @param socialProvider
+	 */
+	public JdonOAuth2User(Collection<? extends GrantedAuthority> authorities,
+		Map<String, Object> attributes, String nameAttributeKey, String email,
+		SocialProviderType socialProvider) {
+		super(authorities, attributes, nameAttributeKey);
+		this.email = email;
+		this.socialProvider = socialProvider;
+	}
+
+	public String getSocialProviderType() {
+		return socialProvider.getProviderName();
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		return super.equals(obj);
+	}
+
+	@Override
+	public int hashCode() {
+		return super.hashCode();
+	}
+}

--- a/module-api/src/main/java/kernel/jdon/auth/config/OAuth2SecurityConfig.java
+++ b/module-api/src/main/java/kernel/jdon/auth/config/OAuth2SecurityConfig.java
@@ -1,0 +1,73 @@
+package kernel.jdon.auth.config;
+
+import static kernel.jdon.auth.encrypt.AesUtil.*;
+import static kernel.jdon.auth.encrypt.HmacUtil.*;
+import static kernel.jdon.util.StringUtil.*;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+
+import kernel.jdon.auth.JdonOAuth2User;
+import kernel.jdon.auth.service.JdonOAuth2UserService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RequiredArgsConstructor
+@EnableWebSecurity
+// TODO: 이거하면 왜 HttpSecurity에서 Could not autowire. No beans of 'HttpSecurity' type found. 에러가 사라지는지 모르곘음.
+@Configuration
+public class OAuth2SecurityConfig {
+	private final JdonOAuth2UserService jdonOAuth2UserService;
+
+	@Bean
+	public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+		http.csrf().disable();
+		http.authorizeHttpRequests(config -> config
+			.requestMatchers("api/**").permitAll()
+			.anyRequest().permitAll());
+		http.oauth2Login(oauth2Configurer -> oauth2Configurer
+			.successHandler(oAuth2AuthenticationSuccessHandler())
+			.userInfoEndpoint()
+			.userService(jdonOAuth2UserService));
+
+		return http.build();
+	}
+
+	@Bean
+	public AuthenticationSuccessHandler oAuth2AuthenticationSuccessHandler() {
+		return ((request, response, authentication) -> {
+			JdonOAuth2User jdonOAuth2User = (JdonOAuth2User)authentication.getPrincipal();
+			if (isTemporaryUser(jdonOAuth2User)) {
+				String query = createUserInfoString(jdonOAuth2User.getEmail(), jdonOAuth2User.getSocialProviderType());
+				String encodedQueryString = createEncryptQueryString(query);
+				response.sendRedirect(joinToString("http://localhost:3000/oauth/info?", encodedQueryString));
+			}
+		});
+	}
+
+	private boolean isTemporaryUser(JdonOAuth2User jdonOAuth2User) {
+		return jdonOAuth2User.getAuthorities().contains(new SimpleGrantedAuthority("ROLE_TEMPORARY_USER"));
+	}
+
+	private String createUserInfoString(String email, String provider) {
+		return joinToString(createQueryString("email", email), createQueryString("provider", provider));
+	}
+
+	private String createEncryptQueryString(String info) {
+		String encoded = null;
+		try {
+			encoded = encryptAESCBC(info);
+			encoded = joinToString(createQueryString("value", encoded),
+				createQueryString("hmac", generateHMAC(encoded)));
+		} catch (Exception e) {
+			log.warn(e.getMessage(), e);
+		}
+		return encoded;
+	}
+}

--- a/module-api/src/main/java/kernel/jdon/auth/controller/AuthController.java
+++ b/module-api/src/main/java/kernel/jdon/auth/controller/AuthController.java
@@ -1,0 +1,41 @@
+package kernel.jdon.auth.controller;
+
+import java.net.URI;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+import kernel.jdon.auth.dto.request.RegisterRequest;
+import kernel.jdon.auth.dto.response.RegisterResponse;
+import kernel.jdon.auth.dto.response.WithdrawResponse;
+import kernel.jdon.dto.response.CommonResponse;
+import kernel.jdon.member.service.MemberService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+public class AuthController {
+
+	private final MemberService memberService;
+
+	@PostMapping("/api/v1/register")
+	public ResponseEntity<CommonResponse> register(@RequestBody RegisterRequest registerRequest) {
+
+		log.info("registerRequest: {}", registerRequest);
+		Long registerMemberId = memberService.register(registerRequest);
+		URI uri = URI.create("/api/v1/member/" + registerMemberId);
+
+		return ResponseEntity.created(uri).body(CommonResponse.of(RegisterResponse.of(registerMemberId)));
+	}
+
+	@DeleteMapping("/api/v1/withdraw")
+	public ResponseEntity<CommonResponse> withdraw() {
+
+		return ResponseEntity.ok(CommonResponse.of(WithdrawResponse.of(1L)));
+	}
+}

--- a/module-api/src/main/java/kernel/jdon/auth/controller/OAuthController.java
+++ b/module-api/src/main/java/kernel/jdon/auth/controller/OAuthController.java
@@ -1,0 +1,13 @@
+package kernel.jdon.auth.controller;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@Controller
+public class OAuthController {
+
+	@GetMapping("/login")
+	public String login() {
+		return "login";
+	}
+}

--- a/module-api/src/main/java/kernel/jdon/auth/dto/JdonOAuth2User.java
+++ b/module-api/src/main/java/kernel/jdon/auth/dto/JdonOAuth2User.java
@@ -1,4 +1,4 @@
-package kernel.jdon.auth;
+package kernel.jdon.auth.dto;
 
 import java.util.Collection;
 import java.util.Map;

--- a/module-api/src/main/java/kernel/jdon/auth/dto/SessionUserInfo.java
+++ b/module-api/src/main/java/kernel/jdon/auth/dto/SessionUserInfo.java
@@ -1,0 +1,28 @@
+package kernel.jdon.auth.dto;
+
+import java.io.Serializable;
+import java.time.LocalDateTime;
+
+import kernel.jdon.member.domain.Member;
+import kernel.jdon.member.domain.MemberRole;
+import lombok.Getter;
+
+@Getter
+public class SessionUserInfo implements Serializable {
+
+	private Long id;
+	private String email;
+	private LocalDateTime lastLoginDate;
+	private MemberRole role;
+
+	private SessionUserInfo(Member member) {
+		this.id = member.getId();
+		this.email = member.getEmail();
+		this.lastLoginDate = member.getLastLoginDate();
+		this.role = member.getRole();
+	}
+
+	public static SessionUserInfo of(Member member) {
+		return new SessionUserInfo(member);
+	}
+}

--- a/module-api/src/main/java/kernel/jdon/auth/encrypt/AesUtil.java
+++ b/module-api/src/main/java/kernel/jdon/auth/encrypt/AesUtil.java
@@ -1,0 +1,40 @@
+package kernel.jdon.auth.encrypt;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+
+import javax.crypto.Cipher;
+import javax.crypto.spec.IvParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class AesUtil {
+	private static final String iv = SecretKeyConstants.AES_PRIVATE_KEY;
+
+	public static String encryptAESCBC(String message) throws Exception {
+		Cipher cipher = getCipher(Cipher.ENCRYPT_MODE);
+		byte[] encrypted = cipher.doFinal(message.getBytes(StandardCharsets.UTF_8));
+
+		return Base64.getEncoder().encodeToString(encrypted);
+	}
+
+	public static String decryptAESCBC(String message) throws Exception {
+		Cipher cipher = getCipher(Cipher.DECRYPT_MODE);
+		byte[] decrypted = cipher.doFinal(Base64.getDecoder().decode(message));
+
+		return new String(decrypted);
+	}
+
+	private static Cipher getCipher(int mode) throws Exception {
+		SecretKeySpec secretKey = new SecretKeySpec(iv.getBytes(StandardCharsets.UTF_8), "AES");
+		IvParameterSpec IV = new IvParameterSpec(iv.substring(0, 16).getBytes());
+
+		Cipher cipher = Cipher.getInstance("AES/CBC/PKCS5Padding");
+		cipher.init(mode, secretKey, IV);
+
+		return cipher;
+	}
+}

--- a/module-api/src/main/java/kernel/jdon/auth/encrypt/HmacUtil.java
+++ b/module-api/src/main/java/kernel/jdon/auth/encrypt/HmacUtil.java
@@ -1,0 +1,30 @@
+package kernel.jdon.auth.encrypt;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = lombok.AccessLevel.PRIVATE)
+public class HmacUtil {
+	private static final String secretKey = SecretKeyConstants.HMAC_PRIVATE_KEY;
+
+	public static String generateHMAC(String data) throws Exception {
+		Mac hmac = Mac.getInstance("HmacSHA256");
+		SecretKeySpec secretKeySpec = new SecretKeySpec(secretKey.getBytes(StandardCharsets.UTF_8),
+			"HmacSHA256");
+		hmac.init(secretKeySpec);
+		byte[] hmacBytes = hmac.doFinal(data.getBytes(StandardCharsets.UTF_8));
+
+		return Base64.getEncoder().encodeToString(hmacBytes);
+	}
+
+	public static boolean isValidHMAC(String receivedHMAC, String data) throws Exception {
+		String calculatedHMAC = generateHMAC(data);
+		
+		return receivedHMAC.equals(calculatedHMAC);
+	}
+}

--- a/module-api/src/main/java/kernel/jdon/auth/encrypt/SecretKeyConstants.java
+++ b/module-api/src/main/java/kernel/jdon/auth/encrypt/SecretKeyConstants.java
@@ -1,0 +1,7 @@
+package kernel.jdon.auth.encrypt;
+
+public final class SecretKeyConstants {
+	public static final String AES_PRIVATE_KEY = "JDON_SECRET_KEY_AES_USE_THIS_KEY";
+	public static final String HMAC_PRIVATE_KEY = "JDON_SECRET_KEY_HMAC_USE_THIS_KK";
+
+}

--- a/module-api/src/main/java/kernel/jdon/auth/error/AuthErrorCode.java
+++ b/module-api/src/main/java/kernel/jdon/auth/error/AuthErrorCode.java
@@ -2,7 +2,7 @@ package kernel.jdon.auth.error;
 
 import org.springframework.http.HttpStatus;
 
-import kernel.jdon.error.code.ErrorCode;
+import kernel.jdon.error.ErrorCode;
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor

--- a/module-api/src/main/java/kernel/jdon/auth/error/AuthErrorCode.java
+++ b/module-api/src/main/java/kernel/jdon/auth/error/AuthErrorCode.java
@@ -1,0 +1,24 @@
+package kernel.jdon.auth.error;
+
+import org.springframework.http.HttpStatus;
+
+import kernel.jdon.error.code.ErrorCode;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public enum AuthErrorCode implements ErrorCode {
+	NOT_FOUND_NOT_MATCH_PROVIDER_TYPE(HttpStatus.NOT_FOUND, "다른 소셜 로그인으로 가입된 이메일입니다."),;
+
+	private final HttpStatus httpStatus;
+	private final String message;
+
+	@Override
+	public HttpStatus getHttpStatus() {
+		return httpStatus;
+	}
+
+	@Override
+	public String getMessage() {
+		return message;
+	}
+}

--- a/module-api/src/main/java/kernel/jdon/auth/service/JdonOAuth2UserService.java
+++ b/module-api/src/main/java/kernel/jdon/auth/service/JdonOAuth2UserService.java
@@ -1,0 +1,81 @@
+package kernel.jdon.auth.service;
+
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import jakarta.servlet.http.HttpSession;
+import kernel.jdon.auth.JdonOAuth2User;
+import kernel.jdon.auth.error.AuthErrorCode;
+import kernel.jdon.error.exception.api.ApiException;
+import kernel.jdon.member.domain.Member;
+import kernel.jdon.member.domain.SocialProviderType;
+import kernel.jdon.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class JdonOAuth2UserService extends DefaultOAuth2UserService {
+
+	private final MemberRepository memberRepository;
+	private final HttpSession httpSession;
+
+	@Override
+	public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+		OAuth2User user = super.loadUser(userRequest);
+
+		return getOAuth2UserFromOAuthServer(userRequest, user);
+	}
+
+	private DefaultOAuth2User getOAuth2UserFromOAuthServer(OAuth2UserRequest userRequest, OAuth2User user) {
+		SocialProviderType socialProvider = getSocialProvider(userRequest);
+		String email = null;
+		if (SocialProviderType.KAKAO == socialProvider) {
+			email = getEmailFromKakao(user);
+		}
+
+		Member findMember = memberRepository.findByEmail(email);
+		List<SimpleGrantedAuthority> authorities = null;
+		if (findMember != null && findMember.isActiveMember()) {
+			checkRightSocialProvider(findMember, socialProvider);
+			httpSession.setAttribute("USER", email);
+			authorities = List.of(new SimpleGrantedAuthority("ROLE_USER"));
+		} else {
+			authorities = List.of(new SimpleGrantedAuthority("ROLE_TEMPORARY_USER"));
+		}
+		return new JdonOAuth2User(authorities, user.getAttributes(), getUserNameAttributeName(userRequest),
+			email, socialProvider);
+	}
+
+	private String getEmailFromKakao(OAuth2User user) {
+		Map<String, Object> attributes = user.getAttributes();
+		return ((Map<String, String>)attributes.get("kakao_account")).get("email");
+	}
+
+	private void checkRightSocialProvider(Member findMember, SocialProviderType socialProvider) {
+		if (!findMember.isRightSocialProvider(socialProvider))
+			throw new ApiException(AuthErrorCode.NOT_FOUND_NOT_MATCH_PROVIDER_TYPE);
+	}
+
+	private SocialProviderType getSocialProvider(OAuth2UserRequest userRequest) {
+		return SocialProviderType.valueOf((userRequest.getClientRegistration().getRegistrationId()).toUpperCase());
+	}
+
+	private String getUserNameAttributeName(OAuth2UserRequest userRequest) {
+		return userRequest.getClientRegistration()
+			.getProviderDetails()
+			.getUserInfoEndpoint()
+			.getUserNameAttributeName();
+	}
+}

--- a/module-api/src/main/java/kernel/jdon/auth/service/JdonOAuth2UserService.java
+++ b/module-api/src/main/java/kernel/jdon/auth/service/JdonOAuth2UserService.java
@@ -13,7 +13,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import jakarta.servlet.http.HttpSession;
-import kernel.jdon.auth.JdonOAuth2User;
+import kernel.jdon.auth.dto.JdonOAuth2User;
+import kernel.jdon.auth.dto.SessionUserInfo;
 import kernel.jdon.auth.error.AuthErrorCode;
 import kernel.jdon.error.exception.api.ApiException;
 import kernel.jdon.member.domain.Member;
@@ -49,7 +50,7 @@ public class JdonOAuth2UserService extends DefaultOAuth2UserService {
 		List<SimpleGrantedAuthority> authorities = null;
 		if (findMember != null && findMember.isActiveMember()) {
 			checkRightSocialProvider(findMember, socialProvider);
-			httpSession.setAttribute("USER", email);
+			httpSession.setAttribute("USER", SessionUserInfo.of(findMember));
 			authorities = List.of(new SimpleGrantedAuthority("ROLE_USER"));
 		} else {
 			authorities = List.of(new SimpleGrantedAuthority("ROLE_TEMPORARY_USER"));

--- a/module-api/src/main/java/kernel/jdon/auth/service/JdonOAuth2UserService.java
+++ b/module-api/src/main/java/kernel/jdon/auth/service/JdonOAuth2UserService.java
@@ -16,7 +16,7 @@ import jakarta.servlet.http.HttpSession;
 import kernel.jdon.auth.dto.JdonOAuth2User;
 import kernel.jdon.auth.dto.SessionUserInfo;
 import kernel.jdon.auth.error.AuthErrorCode;
-import kernel.jdon.error.exception.api.ApiException;
+import kernel.jdon.global.exception.ApiException;
 import kernel.jdon.member.domain.Member;
 import kernel.jdon.member.domain.SocialProviderType;
 import kernel.jdon.member.repository.MemberRepository;

--- a/module-api/src/main/java/kernel/jdon/auth/service/LoginUserArgumentResolver.java
+++ b/module-api/src/main/java/kernel/jdon/auth/service/LoginUserArgumentResolver.java
@@ -1,0 +1,35 @@
+package kernel.jdon.auth.service;
+
+import org.springframework.core.MethodParameter;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+import jakarta.servlet.http.HttpSession;
+import kernel.jdon.global.annotation.LoginUser;
+import kernel.jdon.auth.dto.SessionUserInfo;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class LoginUserArgumentResolver implements HandlerMethodArgumentResolver {
+
+	private final HttpSession httpSession;
+
+	@Override
+	public boolean supportsParameter(MethodParameter parameter) {
+		boolean isLoginUserAnnotation = parameter.getParameterAnnotation(LoginUser.class) != null;
+		boolean isUserClass = SessionUserInfo.class.equals(parameter.getParameterType());
+
+		return isLoginUserAnnotation && isUserClass;
+	}
+
+	@Override
+	public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer,
+		NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
+
+		return httpSession.getAttribute("USER");
+	}
+}

--- a/module-api/src/main/java/kernel/jdon/config/OAuth2SecurityConfig.java
+++ b/module-api/src/main/java/kernel/jdon/config/OAuth2SecurityConfig.java
@@ -1,4 +1,4 @@
-package kernel.jdon.auth.config;
+package kernel.jdon.config;
 
 import static kernel.jdon.auth.encrypt.AesUtil.*;
 import static kernel.jdon.auth.encrypt.HmacUtil.*;
@@ -12,7 +12,7 @@ import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
 
-import kernel.jdon.auth.JdonOAuth2User;
+import kernel.jdon.auth.dto.JdonOAuth2User;
 import kernel.jdon.auth.service.JdonOAuth2UserService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;

--- a/module-api/src/main/java/kernel/jdon/config/WebConfig.java
+++ b/module-api/src/main/java/kernel/jdon/config/WebConfig.java
@@ -1,0 +1,22 @@
+package kernel.jdon.config;
+
+import java.util.List;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import kernel.jdon.auth.service.LoginUserArgumentResolver;
+import lombok.RequiredArgsConstructor;
+
+@Configuration
+@RequiredArgsConstructor
+public class WebConfig implements WebMvcConfigurer {
+
+	private final LoginUserArgumentResolver loginUserArgumentResolver;
+
+	@Override
+	public void addArgumentResolvers(List<HandlerMethodArgumentResolver> argumentResolvers) {
+		argumentResolvers.add(loginUserArgumentResolver);
+	}
+}

--- a/module-api/src/main/java/kernel/jdon/global/annotation/LoginUser.java
+++ b/module-api/src/main/java/kernel/jdon/global/annotation/LoginUser.java
@@ -1,0 +1,11 @@
+package kernel.jdon.global.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface LoginUser {
+}

--- a/module-api/src/main/java/kernel/jdon/jobcategory/repository/JobCategoryRepository.java
+++ b/module-api/src/main/java/kernel/jdon/jobcategory/repository/JobCategoryRepository.java
@@ -1,0 +1,8 @@
+package kernel.jdon.jobcategory.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import kernel.jdon.jobcategory.domain.JobCategory;
+
+public interface JobCategoryRepository extends JpaRepository<JobCategory, Long> {
+}

--- a/module-api/src/main/java/kernel/jdon/member/controller/MemberController.java
+++ b/module-api/src/main/java/kernel/jdon/member/controller/MemberController.java
@@ -1,11 +1,9 @@
 package kernel.jdon.member.controller;
 
-import java.net.URI;
 import java.time.LocalDate;
 import java.util.List;
 
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -15,22 +13,11 @@ import org.springframework.web.bind.annotation.RestController;
 import kernel.jdon.dto.response.CommonResponse;
 import kernel.jdon.member.dto.request.ModifyMemberRequest;
 import kernel.jdon.member.dto.request.NicknameDuplicateRequest;
-import kernel.jdon.member.dto.request.SaveMemberRequest;
 import kernel.jdon.member.dto.response.GetMemberResponse;
 import kernel.jdon.member.dto.response.ModifyMemberResponse;
-import kernel.jdon.member.dto.response.RemoveMemberResponse;
-import kernel.jdon.member.dto.response.SaveMemberResponse;
 
 @RestController
 public class MemberController {
-
-	@PostMapping("/api/v1/member")
-	public ResponseEntity<CommonResponse> save(@RequestBody SaveMemberRequest saveMemberRequest) {
-		Long memberId = 1L;
-		URI uri = URI.create("/api/v1/member/" + memberId);
-
-		return ResponseEntity.created(uri).body(CommonResponse.of(SaveMemberResponse.of(memberId)));
-	}
 
 	@GetMapping("/api/v1/member")
 	public ResponseEntity<CommonResponse> get() {
@@ -58,12 +45,6 @@ public class MemberController {
 			.build();
 
 		return ResponseEntity.ok(CommonResponse.of(modifyMemberResponse));
-	}
-
-	@DeleteMapping("/api/v1/member")
-	public ResponseEntity<CommonResponse> withdraw() {
-
-		return ResponseEntity.ok(CommonResponse.of(RemoveMemberResponse.of(1L)));
 	}
 
 	@PostMapping("nickname/duplicate")

--- a/module-api/src/main/java/kernel/jdon/member/controller/MemberController.java
+++ b/module-api/src/main/java/kernel/jdon/member/controller/MemberController.java
@@ -10,17 +10,23 @@ import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
+import kernel.jdon.global.annotation.LoginUser;
+import kernel.jdon.auth.dto.SessionUserInfo;
 import kernel.jdon.dto.response.CommonResponse;
 import kernel.jdon.member.dto.request.ModifyMemberRequest;
 import kernel.jdon.member.dto.request.NicknameDuplicateRequest;
 import kernel.jdon.member.dto.response.GetMemberResponse;
 import kernel.jdon.member.dto.response.ModifyMemberResponse;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @RestController
 public class MemberController {
 
 	@GetMapping("/api/v1/member")
-	public ResponseEntity<CommonResponse> get() {
+	public ResponseEntity<CommonResponse> get(@LoginUser SessionUserInfo sessionUser) {
+		log.info("sessionUser: {}", sessionUser.getEmail(), sessionUser.getId());
+
 		GetMemberResponse getMemberResponse = GetMemberResponse.builder()
 			.email("aaa@gmail.com")
 			.nickname("aaa")

--- a/module-api/src/main/java/kernel/jdon/member/service/MemberService.java
+++ b/module-api/src/main/java/kernel/jdon/member/service/MemberService.java
@@ -16,7 +16,7 @@ import kernel.jdon.auth.dto.object.RegisterMemberDto;
 import kernel.jdon.auth.dto.request.RegisterRequest;
 import kernel.jdon.auth.encrypt.AesUtil;
 import kernel.jdon.error.code.api.MemberErrorCode;
-import kernel.jdon.error.exception.api.ApiException;
+import kernel.jdon.global.exception.ApiException;
 import kernel.jdon.jobcategory.domain.JobCategory;
 import kernel.jdon.jobcategory.repository.JobCategoryRepository;
 import kernel.jdon.member.domain.Member;

--- a/module-api/src/main/java/kernel/jdon/member/service/MemberService.java
+++ b/module-api/src/main/java/kernel/jdon/member/service/MemberService.java
@@ -1,0 +1,113 @@
+package kernel.jdon.member.service;
+
+import static kernel.jdon.auth.encrypt.HmacUtil.*;
+
+import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import kernel.jdon.auth.dto.object.RegisterMemberDto;
+import kernel.jdon.auth.dto.request.RegisterRequest;
+import kernel.jdon.auth.encrypt.AesUtil;
+import kernel.jdon.auth.encrypt.HmacUtil;
+import kernel.jdon.error.code.api.MemberErrorCode;
+import kernel.jdon.error.exception.api.ApiException;
+import kernel.jdon.jobcategory.domain.JobCategory;
+import kernel.jdon.jobcategory.repository.JobCategoryRepository;
+import kernel.jdon.member.domain.Member;
+import kernel.jdon.member.domain.MemberRole;
+import kernel.jdon.member.domain.SocialProviderType;
+import kernel.jdon.member.repository.MemberRepository;
+import kernel.jdon.memberskill.domain.MemberSkill;
+import kernel.jdon.memberskill.repository.MemberSkillRepository;
+import kernel.jdon.skill.domain.Skill;
+import kernel.jdon.skill.repository.SkillRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class MemberService {
+
+	private final MemberRepository memberRepository;
+	private final SkillRepository skillRepository;
+	private final MemberSkillRepository memberSkillRepository;
+	private final JobCategoryRepository jobCategoryRepository;
+
+	@Transactional
+	public Long register(RegisterRequest registerRequest) {
+		String emailAndProvider = getEmailAndProviderString(registerRequest.getHmac(), registerRequest.getEncrypted());
+		Map<String, String> userInfo = parseQueryString(emailAndProvider);
+
+		JobCategory findJobCategory = findJobCategory(registerRequest.getJobCategoryId());
+		RegisterMemberDto registerMemberDto = RegisterMemberDto.builder()
+			.email(userInfo.get("email"))
+			.jobCategory(findJobCategory)
+			.memberRole(MemberRole.ROLE_USER)
+			.socialProvider(SocialProviderType.ofType(userInfo.get("provider")))
+			.build();
+		Member registeredMember = memberRepository.save(registerRequest.toEntity(registerMemberDto));
+		saveMemberSkillList(registerRequest.getSkillList(), registeredMember);
+
+		return registeredMember.getId();
+	}
+
+	private void saveMemberSkillList(List<Long> skillIdList, Member member) {
+		List<Skill> findSkillList = skillIdList.stream()
+			.map(skillId -> skillRepository.findById(skillId)
+				.orElseThrow(() -> new ApiException(MemberErrorCode.NOT_FOUND_SKILL))).toList();
+		List<MemberSkill> memberSkillList = findSkillList.stream()
+			.map(skill -> MemberSkill.builder()
+				.member(member)
+				.skill(skill)
+				.build())
+			.collect(Collectors.toList());
+		memberSkillRepository.saveAll(memberSkillList);
+	}
+
+	private JobCategory findJobCategory(Long jobCategoryId) {
+		return jobCategoryRepository.findById(jobCategoryId)
+			.orElseThrow(() -> new ApiException(MemberErrorCode.NOT_FOUND_JOB_CATEGORY));
+	}
+
+	private String getEmailAndProviderString (String hmac, String encrypted) {
+		String emailAndProvider = null;
+		try {
+			if (isValidHMAC(hmac, encrypted)) {
+				emailAndProvider = AesUtil.decryptAESCBC(encrypted);
+			} else {
+				throw new ApiException(MemberErrorCode.UNAUTHORIZED_EMAIL_OAUTH2);
+			}
+		} catch (Exception e) {
+			throw new ApiException(MemberErrorCode.SERVER_ERROR_DECRYPTION);
+		}
+		return emailAndProvider;
+	}
+
+	private Map<String, String> parseQueryString(String queryString) {
+		Map<String, String> params = new HashMap<>();
+
+		String[] pairs = queryString.split("&");
+
+		try {
+			for (String pair : pairs) {
+				String[] keyValue = pair.split("=");
+				String key = URLDecoder.decode(keyValue[0], "UTF-8");
+				String value = URLDecoder.decode(keyValue[1], "UTF-8");
+
+				params.put(key, value);
+			}
+		} catch (UnsupportedEncodingException e) {
+			throw new ApiException(MemberErrorCode.SERVER_ERROR_PARSE_QUERY_STRING);
+		}
+		return params;
+	}
+}

--- a/module-api/src/main/java/kernel/jdon/member/service/MemberService.java
+++ b/module-api/src/main/java/kernel/jdon/member/service/MemberService.java
@@ -15,7 +15,6 @@ import org.springframework.transaction.annotation.Transactional;
 import kernel.jdon.auth.dto.object.RegisterMemberDto;
 import kernel.jdon.auth.dto.request.RegisterRequest;
 import kernel.jdon.auth.encrypt.AesUtil;
-import kernel.jdon.auth.encrypt.HmacUtil;
 import kernel.jdon.error.code.api.MemberErrorCode;
 import kernel.jdon.error.exception.api.ApiException;
 import kernel.jdon.jobcategory.domain.JobCategory;

--- a/module-api/src/main/resources/application.yml
+++ b/module-api/src/main/resources/application.yml
@@ -2,7 +2,6 @@ server:
   port: 1221
 
 spring:
-
   datasource:
     url: ${DB_URL}
     driver-class-name: com.mysql.cj.jdbc.Driver
@@ -12,6 +11,25 @@ spring:
   jpa:
     hibernate:
       ddl-auto: update
+
+  security:
+    oauth2:
+      client:
+        registration:
+          kakao:
+            client-name: kakao
+            client-id: ${KAKAO_CLIENT_ID}
+            client-secret: ${KAKAO_CLIENT_SECRET}
+            redirect-uri: ${KAKAO_CLIENT_REDIRECT_URI}
+            authorization-grant-type: authorization_code
+            client-authentication-method: client_secret_post
+            scope: account_email
+        provider:
+          kakao:
+            authorization-uri: https://kauth.kakao.com/oauth/authorize
+            token-uri: https://kauth.kakao.com/oauth/token
+            user-info-uri: https://kapi.kakao.com/v2/user/me
+            user-name-attribute: id
 
 logging:
   level:

--- a/module-common/src/main/java/kernel/jdon/error/code/api/MemberErrorCode.java
+++ b/module-common/src/main/java/kernel/jdon/error/code/api/MemberErrorCode.java
@@ -2,7 +2,7 @@ package kernel.jdon.error.code.api;
 
 import org.springframework.http.HttpStatus;
 
-import kernel.jdon.error.code.ErrorCode;
+import kernel.jdon.error.ErrorCode;
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor

--- a/module-common/src/main/java/kernel/jdon/error/code/api/MemberErrorCode.java
+++ b/module-common/src/main/java/kernel/jdon/error/code/api/MemberErrorCode.java
@@ -1,0 +1,29 @@
+package kernel.jdon.error.code.api;
+
+import org.springframework.http.HttpStatus;
+
+import kernel.jdon.error.code.ErrorCode;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public enum MemberErrorCode implements ErrorCode {
+	NOT_FOUND_JOB_CATEGORY(HttpStatus.NOT_FOUND, "존재하지 않는 직군 또는 직무입니다."),
+	UNAUTHORIZED_EMAIL_OAUTH2(HttpStatus.UNAUTHORIZED, "이메일 인증에 실패하였습니다."),
+	SERVER_ERROR_DECRYPTION(HttpStatus.INTERNAL_SERVER_ERROR, "복호화 과정에 실패하였습니다."),
+	SERVER_ERROR_PARSE_QUERY_STRING(HttpStatus.INTERNAL_SERVER_ERROR, "쿼리스트링 파싱에 실패하였습니다."),
+	NOT_FOUND_SKILL(HttpStatus.NOT_FOUND, "존재하지 않는 기술 스킬입니다.");
+
+	private final HttpStatus httpStatus;
+	private final String message;
+
+	@Override
+	public HttpStatus getHttpStatus() {
+		return httpStatus;
+	}
+
+	@Override
+	public String getMessage() {
+		return message;
+	}
+}
+

--- a/module-domain/src/main/java/kernel/jdon/auth/dto/object/RegisterMemberDto.java
+++ b/module-domain/src/main/java/kernel/jdon/auth/dto/object/RegisterMemberDto.java
@@ -1,0 +1,18 @@
+package kernel.jdon.auth.dto.object;
+
+import kernel.jdon.jobcategory.domain.JobCategory;
+import kernel.jdon.member.domain.MemberRole;
+import kernel.jdon.member.domain.SocialProviderType;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class RegisterMemberDto {
+	private String email;
+	private MemberRole memberRole;
+	private SocialProviderType socialProvider;
+	private JobCategory jobCategory;
+}

--- a/module-domain/src/main/java/kernel/jdon/auth/dto/request/RegisterRequest.java
+++ b/module-domain/src/main/java/kernel/jdon/auth/dto/request/RegisterRequest.java
@@ -1,0 +1,39 @@
+package kernel.jdon.auth.dto.request;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import kernel.jdon.auth.dto.object.RegisterMemberDto;
+import kernel.jdon.member.domain.Gender;
+import kernel.jdon.member.domain.Member;
+import kernel.jdon.member.domain.MemberAccountStatus;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class RegisterRequest {
+	private String encrypted;
+	private String hmac;
+	private String nickname;
+	private LocalDate birth;
+	private String gender;
+	private Long jobCategoryId;
+	private List<Long> skillList;
+
+	public Member toEntity(RegisterMemberDto registerMemberDto) {
+		return Member.builder()
+			.email(registerMemberDto.getEmail())
+			.nickname(nickname)
+			.birth(birth.toString())
+			.gender(Gender.ofType(gender))
+			.role(registerMemberDto.getMemberRole())
+			.accountStatus(MemberAccountStatus.ACTIVE)
+			.socialProvider(registerMemberDto.getSocialProvider())
+			.jobCategory(registerMemberDto.getJobCategory())
+			.joinDate(LocalDateTime.now())
+			.build();
+	}
+}

--- a/module-domain/src/main/java/kernel/jdon/auth/dto/response/RegisterResponse.java
+++ b/module-domain/src/main/java/kernel/jdon/auth/dto/response/RegisterResponse.java
@@ -1,0 +1,15 @@
+package kernel.jdon.auth.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class RegisterResponse {
+
+	private Long memberId;
+
+	public static RegisterResponse of(Long memberId) {
+		return new RegisterResponse(memberId);
+	}
+}

--- a/module-domain/src/main/java/kernel/jdon/auth/dto/response/WithdrawResponse.java
+++ b/module-domain/src/main/java/kernel/jdon/auth/dto/response/WithdrawResponse.java
@@ -1,0 +1,14 @@
+package kernel.jdon.auth.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class WithdrawResponse {
+	private Long memberId;
+
+	public static WithdrawResponse of(Long memberId) {
+		return new WithdrawResponse(memberId);
+	}
+}

--- a/module-domain/src/main/java/kernel/jdon/member/domain/Gender.java
+++ b/module-domain/src/main/java/kernel/jdon/member/domain/Gender.java
@@ -1,5 +1,7 @@
 package kernel.jdon.member.domain;
 
+import java.util.Arrays;
+
 public enum Gender {
 
 	MALE("남성"),
@@ -13,5 +15,12 @@ public enum Gender {
 
 	public String getGender() {
 		return gender;
+	}
+
+	public static Gender ofType(String gender) {
+		return Arrays.stream(Gender.values())
+			.filter(e -> e.getGender().equals(gender))
+			.findAny()
+			.orElseThrow(() -> null);
 	}
 }

--- a/module-domain/src/main/java/kernel/jdon/member/domain/Member.java
+++ b/module-domain/src/main/java/kernel/jdon/member/domain/Member.java
@@ -20,9 +20,9 @@ import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import kernel.jdon.coffeechat.domain.CoffeeChat;
 import kernel.jdon.coffeechatmember.domain.CoffeeChatMember;
+import kernel.jdon.favorite.domain.Favorite;
 import kernel.jdon.jobcategory.domain.JobCategory;
 import kernel.jdon.memberskill.domain.MemberSkill;
-import kernel.jdon.favorite.domain.Favorite;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -34,64 +34,50 @@ import lombok.NoArgsConstructor;
 @Table(name = "member")
 public class Member {
 
+	@OneToMany(mappedBy = "member")
+	private List<CoffeeChat> hostChatList = new ArrayList<>();
+	@OneToMany(mappedBy = "member")
+	private List<CoffeeChatMember> guestChatList = new ArrayList<>();
+	@OneToMany(mappedBy = "member")
+	private List<MemberSkill> memberSkillList = new ArrayList<>();
+	@OneToMany(mappedBy = "member")
+	private List<Favorite> favoriteList = new ArrayList<>();
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
-
 	@Column(name = "email", columnDefinition = "VARCHAR(255)", nullable = false, unique = true)
 	private String email;
-
 	@Column(name = "nickname", columnDefinition = "VARCHAR(255)", nullable = false, unique = true)
 	private String nickname;
-
 	@Column(name = "birth", columnDefinition = "VARCHAR(11)", nullable = false)
 	private String birth;
-
 	@Enumerated(EnumType.STRING)
 	@Column(name = "gender", columnDefinition = "VARCHAR(11)", nullable = false)
 	private Gender gender;
-
 	@CreatedDate
 	@Column(name = "join_date", columnDefinition = "DATETIME", nullable = false)
 	private LocalDateTime joinDate;
-
 	@Column(name = "last_login_date", columnDefinition = "DATETIME")
 	private LocalDateTime lastLoginDate;
-
 	@Enumerated(EnumType.STRING)
 	@Column(name = "role", columnDefinition = "VARCHAR(10)", nullable = false)
 	private MemberRole role;
-
 	@Enumerated(EnumType.STRING)
 	@Column(name = "account_status", columnDefinition = "VARCHAR(10)", nullable = false)
 	private MemberAccountStatus accountStatus;
-
 	@Column(name = "withdraw_date", columnDefinition = "DATETIME")
 	private LocalDateTime withdrawDate;
-
+	@Enumerated(EnumType.STRING)
 	@Column(name = "social_provider", columnDefinition = "VARCHAR(20)", nullable = false)
-	private String socialProvider;
-
+	private SocialProviderType socialProvider;
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "job_category_id", columnDefinition = "BIGINT")
 	private JobCategory jobCategory;
 
-	@OneToMany(mappedBy = "member")
-	private List<CoffeeChat> hostChatList = new ArrayList<>();
-
-	@OneToMany(mappedBy = "member")
-	private List<CoffeeChatMember> guestChatList = new ArrayList<>();
-
-	@OneToMany(mappedBy = "member")
-	private List<MemberSkill> memberSkillList = new ArrayList<>();
-
-	@OneToMany(mappedBy = "member")
-	private List<Favorite> favoriteList = new ArrayList<>();
-
 	@Builder
 	public Member(Long id, String email, String nickname, String birth, Gender gender, LocalDateTime joinDate,
 		LocalDateTime lastLoginDate, MemberRole role, MemberAccountStatus accountStatus, LocalDateTime withdrawDate,
-		String socialProvider, JobCategory jobCategory) {
+		SocialProviderType socialProvider, JobCategory jobCategory) {
 		this.id = id;
 		this.email = email;
 		this.nickname = nickname;
@@ -104,5 +90,13 @@ public class Member {
 		this.withdrawDate = withdrawDate;
 		this.socialProvider = socialProvider;
 		this.jobCategory = jobCategory;
+	}
+
+	public boolean isActiveMember() {
+		return this.accountStatus != MemberAccountStatus.WITHDRAW;
+	}
+
+	public boolean isRightSocialProvider(SocialProviderType socialProvider) {
+		return this.socialProvider == socialProvider;
 	}
 }

--- a/module-domain/src/main/java/kernel/jdon/member/domain/Member.java
+++ b/module-domain/src/main/java/kernel/jdon/member/domain/Member.java
@@ -85,18 +85,6 @@ public class Member {
 	@JoinColumn(name = "job_category_id", columnDefinition = "BIGINT")
 	private JobCategory jobCategory;
 
-	@OneToMany(mappedBy = "member")
-	private List<CoffeeChat> hostChatList = new ArrayList<>();
-
-	@OneToMany(mappedBy = "member")
-	private List<CoffeeChatMember> guestChatList = new ArrayList<>();
-
-	@OneToMany(mappedBy = "member")
-	private List<MemberSkill> memberSkillList = new ArrayList<>();
-
-	@OneToMany(mappedBy = "member")
-	private List<Favorite> favoriteList = new ArrayList<>();
-
 	@Builder
 	public Member(Long id, String email, String nickname, String birth, Gender gender, LocalDateTime joinDate,
 		LocalDateTime lastLoginDate, MemberRole role, MemberAccountStatus accountStatus, LocalDateTime withdrawDate,

--- a/module-domain/src/main/java/kernel/jdon/member/domain/Member.java
+++ b/module-domain/src/main/java/kernel/jdon/member/domain/Member.java
@@ -45,34 +45,57 @@ public class Member {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
+
 	@Column(name = "email", columnDefinition = "VARCHAR(255)", nullable = false, unique = true)
 	private String email;
+
 	@Column(name = "nickname", columnDefinition = "VARCHAR(255)", nullable = false, unique = true)
 	private String nickname;
+
 	@Column(name = "birth", columnDefinition = "VARCHAR(11)", nullable = false)
 	private String birth;
+
 	@Enumerated(EnumType.STRING)
 	@Column(name = "gender", columnDefinition = "VARCHAR(11)", nullable = false)
 	private Gender gender;
+
 	@CreatedDate
 	@Column(name = "join_date", columnDefinition = "DATETIME", nullable = false)
 	private LocalDateTime joinDate;
+
 	@Column(name = "last_login_date", columnDefinition = "DATETIME")
 	private LocalDateTime lastLoginDate;
+
 	@Enumerated(EnumType.STRING)
 	@Column(name = "role", columnDefinition = "VARCHAR(10)", nullable = false)
 	private MemberRole role;
+
 	@Enumerated(EnumType.STRING)
 	@Column(name = "account_status", columnDefinition = "VARCHAR(10)", nullable = false)
 	private MemberAccountStatus accountStatus;
+
 	@Column(name = "withdraw_date", columnDefinition = "DATETIME")
 	private LocalDateTime withdrawDate;
+
 	@Enumerated(EnumType.STRING)
 	@Column(name = "social_provider", columnDefinition = "VARCHAR(20)", nullable = false)
 	private SocialProviderType socialProvider;
+
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "job_category_id", columnDefinition = "BIGINT")
 	private JobCategory jobCategory;
+
+	@OneToMany(mappedBy = "member")
+	private List<CoffeeChat> hostChatList = new ArrayList<>();
+
+	@OneToMany(mappedBy = "member")
+	private List<CoffeeChatMember> guestChatList = new ArrayList<>();
+
+	@OneToMany(mappedBy = "member")
+	private List<MemberSkill> memberSkillList = new ArrayList<>();
+
+	@OneToMany(mappedBy = "member")
+	private List<Favorite> favoriteList = new ArrayList<>();
 
 	@Builder
 	public Member(Long id, String email, String nickname, String birth, Gender gender, LocalDateTime joinDate,

--- a/module-domain/src/main/java/kernel/jdon/member/domain/MemberAccountStatus.java
+++ b/module-domain/src/main/java/kernel/jdon/member/domain/MemberAccountStatus.java
@@ -3,7 +3,7 @@ package kernel.jdon.member.domain;
 public enum MemberAccountStatus {
 
 	ACTIVE("활성계정"),
-	INACTIVE("휴면계정"),
+	// INACTIVE("휴면계정"),
 	WITHDRAW("탈퇴계정");
 
 	private final String status;

--- a/module-domain/src/main/java/kernel/jdon/member/domain/SocialProviderType.java
+++ b/module-domain/src/main/java/kernel/jdon/member/domain/SocialProviderType.java
@@ -1,0 +1,25 @@
+package kernel.jdon.member.domain;
+
+import java.util.Arrays;
+
+public enum SocialProviderType {
+	KAKAO("kakao"),
+	GITHUB("github");
+
+	private final String providerName;
+
+	SocialProviderType(String providerName) {
+		this.providerName = providerName;
+	}
+
+	public String getProviderName() {
+		return providerName;
+	}
+
+	public static SocialProviderType ofType(String providerName) {
+		return Arrays.stream(SocialProviderType.values())
+			.filter(e -> e.getProviderName().equals(providerName))
+			.findAny()
+			.orElseThrow(() -> null);
+	}
+}

--- a/module-domain/src/main/java/kernel/jdon/member/repository/MemberRepository.java
+++ b/module-domain/src/main/java/kernel/jdon/member/repository/MemberRepository.java
@@ -1,0 +1,16 @@
+package kernel.jdon.member.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import kernel.jdon.member.domain.Member;
+import kernel.jdon.member.domain.SocialProviderType;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+	Optional<Member> findByEmailAndSocialProvider(String email, SocialProviderType socialProvider);
+
+	boolean existsByEmail(String email);
+
+	Member findByEmail(String email);
+}

--- a/module-domain/src/main/java/kernel/jdon/memberskill/domain/MemberSkill.java
+++ b/module-domain/src/main/java/kernel/jdon/memberskill/domain/MemberSkill.java
@@ -10,8 +10,11 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import kernel.jdon.member.domain.Member;
 import kernel.jdon.skill.domain.Skill;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
 
 @Entity
+@NoArgsConstructor(access = lombok.AccessLevel.PROTECTED)
 @Table(name = "member_skill")
 public class MemberSkill {
 
@@ -26,4 +29,10 @@ public class MemberSkill {
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "skill_id", columnDefinition = "BIGINT")
 	private Skill skill;
+
+	@Builder
+	public MemberSkill(Member member, Skill skill) {
+		this.member = member;
+		this.skill = skill;
+	}
 }

--- a/module-domain/src/main/java/kernel/jdon/memberskill/repository/MemberSkillRepository.java
+++ b/module-domain/src/main/java/kernel/jdon/memberskill/repository/MemberSkillRepository.java
@@ -1,0 +1,9 @@
+package kernel.jdon.memberskill.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import kernel.jdon.memberskill.domain.MemberSkill;
+
+public interface MemberSkillRepository extends JpaRepository<MemberSkill, Long> {
+
+}


### PR DESCRIPTION
## 개요

### 요약

### 변경한 부분
- OAuth2 (kakao) 서버로부터 사용자 인증을 받고 이메일 정보를 받아오는 로직을 구현했습니다.
- 로그인한 회원정보를 세션에 저장하고 API 요청시 어노테이션`@LoginUser`를 이용해서 세션에 있는 사용자 정보를 가져오는 로직을 구현했습니다. 

### 변경한 결과
- 카카오를 통해서 회원가입을 할 수 있습니다. 
- 컨트롤러에서 `@LoginUser` 어노테이션을 통해서 세션에 있는 회원의 정보를 가져올 수 있습니다. 

### 이슈

- closes: #51 
- closes: #124 

---

## PR 유형

어떤 변경 사항이 있나요?

- [X] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경, 주석 변경)
- [ ] 코드 리팩토링
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 파일 혹은 폴더명 수정, 삭제
- [ ] 배포 관련