### PR TITLE
Feature: 요즘 뜨는 기술 스택 조회 API 구현

### DIFF
--- a/module-api/src/main/java/kernel/jdon/skill/controller/SkillController.java
+++ b/module-api/src/main/java/kernel/jdon/skill/controller/SkillController.java
@@ -11,7 +11,6 @@ import org.springframework.web.bind.annotation.RestController;
 
 import kernel.jdon.dto.response.CommonResponse;
 import kernel.jdon.skill.dto.response.FindCompanyBySkillResponse;
-import kernel.jdon.skill.dto.response.FindHotSkillResponse;
 import kernel.jdon.skill.dto.response.FindJdResponse;
 import kernel.jdon.skill.dto.response.FindJobCategorySkillResponse;
 import kernel.jdon.skill.dto.response.FindLectureResponse;
@@ -20,29 +19,18 @@ import kernel.jdon.skill.dto.response.FindListHotSkillResponse;
 import kernel.jdon.skill.dto.response.FindListJobCategorySkillResponse;
 import kernel.jdon.skill.dto.response.FindListMemberSkillResponse;
 import kernel.jdon.skill.dto.response.FindMemberSkillResponse;
+import kernel.jdon.skill.service.SkillService;
+import lombok.RequiredArgsConstructor;
 
 @RestController
+@RequiredArgsConstructor
 public class SkillController {
-
+	private final SkillService skillService;
 	@GetMapping("/api/v1/skills/hot")
 	public ResponseEntity<CommonResponse> getHotSkillList() {
-		List<FindHotSkillResponse> findHotSkillResponseList = new ArrayList<>();
-		for (long i = 1; i <= 10; i++) {
-			FindHotSkillResponse findHotSkillResponse =
-				FindHotSkillResponse.builder()
-					.skillId(i)
-					.keyword("skill_" + i)
-					.build();
+		FindListHotSkillResponse hotSkillList = skillService.findHotSkillList();
 
-			findHotSkillResponseList.add(findHotSkillResponse);
-		}
-
-		FindListHotSkillResponse findListHotSkillResponse =
-			FindListHotSkillResponse.builder()
-				.skillList(findHotSkillResponseList)
-				.build();
-
-		return ResponseEntity.ok(CommonResponse.of(findListHotSkillResponse));
+		return ResponseEntity.ok(CommonResponse.of(hotSkillList));
 	}
 
 	@GetMapping("/api/v1/skills/member")

--- a/module-api/src/main/java/kernel/jdon/skill/dto/response/FindHotSkillResponse.java
+++ b/module-api/src/main/java/kernel/jdon/skill/dto/response/FindHotSkillResponse.java
@@ -1,16 +1,14 @@
 package kernel.jdon.skill.dto.response;
 
-import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 @Getter
-@Builder
-@NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor
 public class FindHotSkillResponse {
-	private Long skillId;
 	private String keyword;
+
+	public static FindHotSkillResponse of(String keyword) {
+		return new FindHotSkillResponse(keyword);
+	}
 }

--- a/module-api/src/main/java/kernel/jdon/skill/dto/response/FindListHotSkillResponse.java
+++ b/module-api/src/main/java/kernel/jdon/skill/dto/response/FindListHotSkillResponse.java
@@ -2,15 +2,10 @@ package kernel.jdon.skill.dto.response;
 
 import java.util.List;
 
-import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 @Getter
-@Builder
-@NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor
 public class FindListHotSkillResponse {
 	private List<FindHotSkillResponse> skillList;

--- a/module-api/src/main/java/kernel/jdon/skill/service/SkillService.java
+++ b/module-api/src/main/java/kernel/jdon/skill/service/SkillService.java
@@ -1,0 +1,24 @@
+package kernel.jdon.skill.service;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+
+import kernel.jdon.skill.dto.response.FindHotSkillResponse;
+import kernel.jdon.skill.dto.response.FindListHotSkillResponse;
+import kernel.jdon.skill.repository.SkillRepository;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class SkillService {
+	private final SkillRepository skillRepository;
+
+	public FindListHotSkillResponse findHotSkillList() {
+		List<FindHotSkillResponse> findHotSkillList = skillRepository.findHotSkillList().stream()
+			.map(FindHotSkillResponse::of)
+			.toList();
+
+		return new FindListHotSkillResponse(findHotSkillList);
+	}
+}

--- a/module-domain/src/main/java/kernel/jdon/skill/repository/SkillRepository.java
+++ b/module-domain/src/main/java/kernel/jdon/skill/repository/SkillRepository.java
@@ -6,7 +6,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import kernel.jdon.skill.domain.Skill;
 
-public interface SkillRepository extends JpaRepository<Skill, Long> {
+public interface SkillRepository extends JpaRepository<Skill, Long>, SkillRepositoryCustom {
 	Optional<Skill> findByJobCategoryIdAndKeyword(Long jobCategoryId, String keyword);
 
 	Optional<Skill> findByKeyword(String keyword);

--- a/module-domain/src/main/java/kernel/jdon/skill/repository/SkillRepositoryCustom.java
+++ b/module-domain/src/main/java/kernel/jdon/skill/repository/SkillRepositoryCustom.java
@@ -1,0 +1,10 @@
+package kernel.jdon.skill.repository;
+
+import java.util.List;
+
+import kernel.jdon.skill.domain.Skill;
+import kernel.jdon.skill.dto.FindHotSkillResponse;
+
+public interface SkillRepositoryCustom {
+	List<String> findHotSkillList();
+}

--- a/module-domain/src/main/java/kernel/jdon/skill/repository/SkillRepositoryImpl.java
+++ b/module-domain/src/main/java/kernel/jdon/skill/repository/SkillRepositoryImpl.java
@@ -1,0 +1,28 @@
+package kernel.jdon.skill.repository;
+
+import static kernel.jdon.skill.domain.QSkill.*;
+
+import java.util.List;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class SkillRepositoryImpl implements SkillRepositoryCustom {
+
+	private final JPAQueryFactory jpaQueryFactory;
+
+	@Override
+	public List<String> findHotSkillList() {
+		final int hotSkillKeywordCount = 10;
+
+		return jpaQueryFactory
+			.select(skill.keyword)
+			.from(skill)
+			.groupBy(skill.keyword)
+			.orderBy(skill.keyword.count().desc())
+			.limit(hotSkillKeywordCount)
+			.fetch();
+	}
+}


### PR DESCRIPTION
## 개요

### 요약
- Feature: 요즘 뜨는 기술 스택 조회 API 구현

### 변경한 부분
-  요즘 뜨는 기술 스택 조회 API 구현하였습니다.
- querydsl 사용으로 인해 custom repository를 interface로 생성하고 인터페이스를 구현한 impl 클래스를 생성하였습니다.
- skill 테이블에서 가장 많이 추출된 키워드 10개를 조회하도록 sql을 작성했습니다.

### 변경한 결과
- 로컬 환경에서 api를 호출한 결과를 확인했습니다.
<img width="839" alt="image" src="https://github.com/Kernel360/f1-JDON-Backend/assets/59242594/a1b7ff52-298e-4490-8c6b-e01e4afff923">

### 이슈

- closes: #121 

---

## PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경, 주석 변경)
- [ ] 코드 리팩토링
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 파일 혹은 폴더명 수정, 삭제
- [ ] 배포 관련