### PR TITLE
Feature: 닉네임 중복 확인하는 API 구현

### DIFF
--- a/module-api/src/main/java/kernel/jdon/member/controller/MemberController.java
+++ b/module-api/src/main/java/kernel/jdon/member/controller/MemberController.java
@@ -42,9 +42,8 @@ public class MemberController {
 	}
 
 	@PostMapping("/api/v1/nickname/duplicate")
-	public ResponseEntity<Void> checkNicknameDuplicate(@LoginUser SessionUserInfo user,
-		@RequestBody NicknameDuplicateRequest nicknameDuplicateRequest) {
-		memberService.checkNicknameDuplicate(user.getId(), nicknameDuplicateRequest.getNickname());
+	public ResponseEntity<Void> checkNicknameDuplicate(@RequestBody NicknameDuplicateRequest nicknameDuplicateRequest) {
+		memberService.checkNicknameDuplicate(nicknameDuplicateRequest.getNickname());
 
 		return ResponseEntity.noContent().build();
 	}

--- a/module-api/src/main/java/kernel/jdon/member/controller/MemberController.java
+++ b/module-api/src/main/java/kernel/jdon/member/controller/MemberController.java
@@ -41,9 +41,10 @@ public class MemberController {
 		return ResponseEntity.ok(CommonResponse.of(updateMemberResponse));
 	}
 
-	@PostMapping("nickname/duplicate")
-	public ResponseEntity<Void> checkNicknameDuplicate(
+	@PostMapping("/api/v1/nickname/duplicate")
+	public ResponseEntity<Void> checkNicknameDuplicate(@LoginUser SessionUserInfo user,
 		@RequestBody NicknameDuplicateRequest nicknameDuplicateRequest) {
+		memberService.checkNicknameDuplicate(user.getId(), nicknameDuplicateRequest.getNickname());
 
 		return ResponseEntity.noContent().build();
 	}

--- a/module-api/src/main/java/kernel/jdon/member/service/MemberService.java
+++ b/module-api/src/main/java/kernel/jdon/member/service/MemberService.java
@@ -144,9 +144,9 @@ public class MemberService {
 		return params;
 	}
 
-	public void checkNicknameDuplicate(Long userId, String nickname) {
-		Member existNicknameMember = memberRepository.findByNickname(nickname);
-		if (null != existNicknameMember) {
+	public void checkNicknameDuplicate(String nickname) {
+		boolean isExistNickname = memberRepository.existsByNickname(nickname);
+		if (isExistNickname) {
 			throw new ApiException(MemberErrorCode.CONFLICT_DUPLICATE_NICKNAME);
 		}
 	}

--- a/module-api/src/main/java/kernel/jdon/member/service/MemberService.java
+++ b/module-api/src/main/java/kernel/jdon/member/service/MemberService.java
@@ -143,4 +143,11 @@ public class MemberService {
 		}
 		return params;
 	}
+
+	public void checkNicknameDuplicate(Long userId, String nickname) {
+		Member existNicknameMember = memberRepository.findByNickname(nickname);
+		if (null != existNicknameMember) {
+			throw new ApiException(MemberErrorCode.CONFLICT_DUPLICATE_NICKNAME);
+		}
+	}
 }

--- a/module-common/src/main/java/kernel/jdon/error/code/api/MemberErrorCode.java
+++ b/module-common/src/main/java/kernel/jdon/error/code/api/MemberErrorCode.java
@@ -11,6 +11,7 @@ public enum MemberErrorCode implements ErrorCode {
 	SERVER_ERROR_DECRYPTION(HttpStatus.INTERNAL_SERVER_ERROR, "복호화 과정에 실패하였습니다."),
 	SERVER_ERROR_PARSE_QUERY_STRING(HttpStatus.INTERNAL_SERVER_ERROR, "쿼리스트링 파싱에 실패하였습니다."),
 	NOT_FOUND_MEMBER(HttpStatus.NOT_FOUND, "존재하지 않는 회원입니다."),
+	CONFLICT_DUPLICATE_NICKNAME(HttpStatus.CONFLICT, "이미 존재하는 닉네임입니다."),
 	FORBIDDEN_NOT_MATCH_EMAIL(HttpStatus.FORBIDDEN, "이메일이 일치하지 않습니다.");
 
 	private final HttpStatus httpStatus;

--- a/module-domain/src/main/java/kernel/jdon/member/repository/MemberRepository.java
+++ b/module-domain/src/main/java/kernel/jdon/member/repository/MemberRepository.java
@@ -14,5 +14,5 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 
 	Member findByEmail(String email);
 
-	Member findByNickname(String nickname);
+	boolean existsByNickname(String nickname);
 }

--- a/module-domain/src/main/java/kernel/jdon/member/repository/MemberRepository.java
+++ b/module-domain/src/main/java/kernel/jdon/member/repository/MemberRepository.java
@@ -13,4 +13,6 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 	boolean existsByEmail(String email);
 
 	Member findByEmail(String email);
+
+	Member findByNickname(String nickname);
 }


### PR DESCRIPTION
## 개요

### 요약

### 변경한 부분
- `POST` `/api/v1/nickname/duplicate` 구현
- 닉네임이 중복된 닉네임인지 확인하는 API 구현했습니다. 
- 본인 닉네임과 같은 닉네임이면 이미 해당 닉네임이라는 에러를, 다른 유저가 사용중인 닉네임이면 이미 존재하는 닉네임이라는 에러를 반환합니다. 

### 변경한 결과
<img width="1349" alt="image" src="https://github.com/Kernel360/f1-JDON-Backend/assets/68376744/f93b6b94-afcb-46a0-bf41-ca1fe14142ab">

![image](https://github.com/Kernel360/f1-JDON-Backend/assets/68376744/0d7608a7-48b6-4e56-90ce-c33c327b2264)

![image](https://github.com/Kernel360/f1-JDON-Backend/assets/68376744/a0cf2832-978e-4ba5-8367-b61af0c9a8a4)

![image](https://github.com/Kernel360/f1-JDON-Backend/assets/68376744/9da30db5-1aa3-4dfd-b941-9ee09a2929aa)


### 이슈

- closes: #142 

---

## PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경, 주석 변경)
- [ ] 코드 리팩토링
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 파일 혹은 폴더명 수정, 삭제
- [ ] 배포 관련