### PR TITLE
Refactor: 원티드 JD의  skill 데이터 적재 방식 변경

### DIFF
--- a/module-crawler/src/main/java/kernel/jdon/crawler/wanted/converter/EntityConverter.java
+++ b/module-crawler/src/main/java/kernel/jdon/crawler/wanted/converter/EntityConverter.java
@@ -3,6 +3,7 @@ package kernel.jdon.crawler.wanted.converter;
 import kernel.jdon.crawler.wanted.dto.object.CreateSkillDto;
 import kernel.jdon.crawler.wanted.dto.response.WantedJobDetailResponse;
 import kernel.jdon.skill.domain.Skill;
+import kernel.jdon.skillhistory.domain.SkillHistory;
 import kernel.jdon.wantedjd.domain.WantedJd;
 import kernel.jdon.wantedjdskill.domain.WantedJdSkill;
 import lombok.AccessLevel;
@@ -36,6 +37,14 @@ public class EntityConverter {
 	public static Skill createSkill(CreateSkillDto createSkillDto) {
 		return Skill.builder()
 			.keyword(createSkillDto.getKeyword())
+			.jobCategory(createSkillDto.getJobCategory())
+			.build();
+	}
+
+	public static SkillHistory createSkillHistory(CreateSkillDto createSkillDto) {
+		return SkillHistory.builder()
+			.keyword(createSkillDto.getKeyword())
+			.wantedJd(createSkillDto.getWantedJd())
 			.jobCategory(createSkillDto.getJobCategory())
 			.build();
 	}

--- a/module-crawler/src/main/java/kernel/jdon/crawler/wanted/converter/EntityConverter.java
+++ b/module-crawler/src/main/java/kernel/jdon/crawler/wanted/converter/EntityConverter.java
@@ -34,13 +34,6 @@ public class EntityConverter {
 			.build();
 	}
 
-	public static Skill createSkill(CreateSkillDto createSkillDto) {
-		return Skill.builder()
-			.keyword(createSkillDto.getKeyword())
-			.jobCategory(createSkillDto.getJobCategory())
-			.build();
-	}
-
 	public static SkillHistory createSkillHistory(CreateSkillDto createSkillDto) {
 		return SkillHistory.builder()
 			.keyword(createSkillDto.getKeyword())

--- a/module-crawler/src/main/java/kernel/jdon/crawler/wanted/dto/object/CreateSkillDto.java
+++ b/module-crawler/src/main/java/kernel/jdon/crawler/wanted/dto/object/CreateSkillDto.java
@@ -1,6 +1,7 @@
 package kernel.jdon.crawler.wanted.dto.object;
 
 import kernel.jdon.jobcategory.domain.JobCategory;
+import kernel.jdon.wantedjd.domain.WantedJd;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -8,5 +9,6 @@ import lombok.Getter;
 @AllArgsConstructor
 public class CreateSkillDto {
 	private JobCategory jobCategory;
+	private WantedJd wantedJd;
 	private String keyword;
 }

--- a/module-crawler/src/main/java/kernel/jdon/crawler/wanted/skill/BackendSkillType.java
+++ b/module-crawler/src/main/java/kernel/jdon/crawler/wanted/skill/BackendSkillType.java
@@ -1,0 +1,57 @@
+package kernel.jdon.crawler.wanted.skill;
+
+import lombok.AllArgsConstructor;
+
+@AllArgsConstructor
+public enum BackendSkillType implements SkillType {
+	AWS("AWS"),
+	GIT("Git"),
+	PYTHON("Python"),
+	MYSQL("MySQL"),
+	JAVA("Java"),
+	SPRING_FRAMEWORK("Spring Framework"),
+	GITHUB("Github"),
+	DOCKER("Docker"),
+	KOTLIN("Kotlin"),
+	NODEJS("Node.js"),
+	SQL("SQL"),
+	LINUX("Linux"),
+	SPRING_BOOT("Spring Boot"),
+	JIRA("JIRA"),
+	JPA("JPA"),
+	KUBERNETES("Kubernetes"),
+	REDIS("Redis"),
+	C_PLUS_PLUS("C++"),
+	POSTGRESQL("PostgreSQL"),
+	RESTFUL_API("Restful API"),
+	MONGODB("MongoDB"),
+	DJANGO("Django"),
+	JENKINS("Jenkins"),
+	GO("Go"),
+	ELASTICSEARCH("ElasticSearch"),
+	PHP("PHP"),
+	NOSQL("NoSQL"),
+	C("C"),
+	RDBMS("RDBMS"),
+	ORACLE("Oracle"),
+	API("API"),
+	DEVOPS("DevOps"),
+	GOLANG("Golang"),
+	NGINX("Nginx"),
+	MSSQL("MSSQL"),
+	GRAPHQL("GraphQL"),
+	RABBITMQ("RabbitMQ"),
+	ORM("ORM"),
+	TDD("TDD"),
+	R("R"),
+	HADOOP("Hadoop"),
+	LARAVEL("Laravel");
+
+
+	private String keyword;
+
+	@Override
+	public String getKeyword() {
+		return keyword;
+	}
+}

--- a/module-crawler/src/main/java/kernel/jdon/crawler/wanted/skill/FrontendSkillType.java
+++ b/module-crawler/src/main/java/kernel/jdon/crawler/wanted/skill/FrontendSkillType.java
@@ -1,0 +1,32 @@
+package kernel.jdon.crawler.wanted.skill;
+
+import lombok.AllArgsConstructor;
+
+@AllArgsConstructor
+public enum FrontendSkillType implements SkillType {
+	JAVASCRIPT("JavaScript"),
+	REACT("React"),
+	TYPESCRIPT("TypeScript"),
+	HTML("HTML"),
+	CSS("CSS"),
+	DOCKER("Docker"),
+	NEXT_JS("Next.js"),
+	NODE_JS("Node.js"),
+	REACT_JS("React.js"),
+	VUE_JS("Vue.JS"),
+	VUEJS("VueJS"),
+	FIGMA("Figma"),
+	ANGULAR("Angular"),
+	UX("UX"),
+	WEBGL("WebGL"),
+	WEBRTC("WebRTC"),
+	SVELTE("Svelte"),
+	LARAVEL("Laravel");
+
+	private final String keyword;
+
+	@Override
+	public String getKeyword() {
+		return keyword;
+	}
+}

--- a/module-crawler/src/main/java/kernel/jdon/crawler/wanted/skill/SkillType.java
+++ b/module-crawler/src/main/java/kernel/jdon/crawler/wanted/skill/SkillType.java
@@ -1,0 +1,9 @@
+package kernel.jdon.crawler.wanted.skill;
+
+public interface SkillType {
+	String getKeyword();
+
+	static String getOrderKeyword() {
+		return "기타";
+	}
+}

--- a/module-domain/src/main/java/kernel/jdon/skill/repository/SkillRepository.java
+++ b/module-domain/src/main/java/kernel/jdon/skill/repository/SkillRepository.java
@@ -8,6 +8,5 @@ import kernel.jdon.skill.domain.Skill;
 
 public interface SkillRepository extends JpaRepository<Skill, Long>, SkillRepositoryCustom {
 	Optional<Skill> findByJobCategoryIdAndKeyword(Long jobCategoryId, String keyword);
-
 	Optional<Skill> findByKeyword(String keyword);
 }

--- a/module-domain/src/main/java/kernel/jdon/skill/repository/SkillRepositoryCustom.java
+++ b/module-domain/src/main/java/kernel/jdon/skill/repository/SkillRepositoryCustom.java
@@ -2,9 +2,6 @@ package kernel.jdon.skill.repository;
 
 import java.util.List;
 
-import kernel.jdon.skill.domain.Skill;
-import kernel.jdon.skill.dto.FindHotSkillResponse;
-
 public interface SkillRepositoryCustom {
 	List<String> findHotSkillList();
 }

--- a/module-domain/src/main/java/kernel/jdon/skillhistory/domain/SkillHistory.java
+++ b/module-domain/src/main/java/kernel/jdon/skillhistory/domain/SkillHistory.java
@@ -1,7 +1,4 @@
-package kernel.jdon.skill.domain;
-
-import java.util.ArrayList;
-import java.util.List;
+package kernel.jdon.skillhistory.domain;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -11,11 +8,9 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
-import jakarta.persistence.UniqueConstraint;
 import kernel.jdon.jobcategory.domain.JobCategory;
-import kernel.jdon.wantedjdskill.domain.WantedJdSkill;
+import kernel.jdon.wantedjd.domain.WantedJd;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -24,12 +19,8 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Table(name = "skill",
-	   uniqueConstraints = {
-			@UniqueConstraint(columnNames = {"job_category_id", "keyword"})
-})
-public class Skill {
-
+@Table(name = "skill_history")
+public class SkillHistory {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
@@ -37,18 +28,19 @@ public class Skill {
 	@Column(name = "keyword", columnDefinition = "VARCHAR(50)", nullable = false)
 	private String keyword;
 
-	@OneToMany(mappedBy = "skill")
-	private List<WantedJdSkill> wantedJdSkillList = new ArrayList<>();
-
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "job_category_id", columnDefinition = "BIGINT")
 	private JobCategory jobCategory;
 
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "wanted_jd_id", columnDefinition = "BIGINT")
+	private WantedJd wantedJd;
+
 	@Builder
-	public Skill(Long id, String keyword, JobCategory jobCategory) {
+	public SkillHistory(Long id, String keyword, JobCategory jobCategory, WantedJd wantedJd) {
 		this.id = id;
 		this.keyword = keyword;
 		this.jobCategory = jobCategory;
+		this.wantedJd = wantedJd;
 	}
-
 }

--- a/module-domain/src/main/java/kernel/jdon/skillhistory/domain/SkillHistory.java
+++ b/module-domain/src/main/java/kernel/jdon/skillhistory/domain/SkillHistory.java
@@ -9,6 +9,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import kernel.jdon.jobcategory.domain.JobCategory;
 import kernel.jdon.wantedjd.domain.WantedJd;
 import lombok.AccessLevel;
@@ -19,7 +20,10 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Table(name = "skill_history")
+@Table(name = "skill_history",
+	uniqueConstraints = {
+		@UniqueConstraint(columnNames = {"job_category_id", "wanted_jd_id", "keyword"})
+	})
 public class SkillHistory {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/module-domain/src/main/java/kernel/jdon/skillhistory/domain/SkillHistory.java
+++ b/module-domain/src/main/java/kernel/jdon/skillhistory/domain/SkillHistory.java
@@ -41,8 +41,7 @@ public class SkillHistory {
 	private WantedJd wantedJd;
 
 	@Builder
-	public SkillHistory(Long id, String keyword, JobCategory jobCategory, WantedJd wantedJd) {
-		this.id = id;
+	public SkillHistory(String keyword, JobCategory jobCategory, WantedJd wantedJd) {
 		this.keyword = keyword;
 		this.jobCategory = jobCategory;
 		this.wantedJd = wantedJd;

--- a/module-domain/src/main/java/kernel/jdon/skillhistory/repository/SkillHistoryRepository.java
+++ b/module-domain/src/main/java/kernel/jdon/skillhistory/repository/SkillHistoryRepository.java
@@ -1,0 +1,8 @@
+package kernel.jdon.skillhistory.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import kernel.jdon.skillhistory.domain.SkillHistory;
+
+public interface SkillHistoryRepository extends JpaRepository<SkillHistory, Long> {
+}


### PR DESCRIPTION
## 개요

### 요약
- 원티드 스크래핑 skill 데이터 적재 방식 변경
- 원티드 스크래핑 skill 데이터 히스토리 테이블 추가

### 변경한 부분
#### 원티드 스크래핑시 skill 데이터가 존재하는지 확인하는 로직 변경
- Skill 테이블에 우리 서비스에서 사용할 기술스택을 미리 정의하여 데이터베이스와 Enum타입으로 서버에 저장해두고, 그 이외의 키워드로 들어오는 기술스택은 '기타'로  데이터가 삽입되도록 수정하였습니다.
- 사전에 정의한 기술스택을  Enum타입으로 서버에 저장해두었기 때문에 데이터베이스에서 데이터의 유무를 결정하는 것이 아니라 **서버 내에서 즉시 확인**할 수 있으며 이로인해서 **데이터베이스에 질의를 통해 존재하는 기술스택인지 확인하지 않아도 되도록 문제를 해결**하였습니다.
또한 **다대다 관계에서 중간테이블을 저장하기 위해 해당 JD에 포함된 스킬목록을 메모리에 저장하지 않아도** 되기 때문에 서버 부하를 줄일 수 있습니다. 
이로인해 기술스택의 존재 유무를 서버에서 비교함에 따라 데이터베이스에 있는 기술스택과 Enum 타입의 기술스택을 의미하는 각각의 필드들이 동기화가 되어야 하는 제약조건이 있습니다.
하지만 서버에 부하가되는 단점보다 장점이 더 많은 상황이라서 해당 방법을 채택하였고 적용하였습니다.

사전에 정의한 기술스택과 기술스택을 결정한 배경은 아래의 노션페이지에서 확인할 수 있습니다.
https://www.notion.so/678ab1bfd8a64c51a2b2715d627785f6?pvs=4

#### skill_history 테이블 추가
- 추출된 기술스택을 중복제거 없이 모두 skill_history 테이블에 추가하여 이력을 관리하며 이 테이블을 통해 추출된 기술스택의 count를 알 수 있도록 설계하였습니다.

### 변경한 결과
로컬에서 테스트한 데이터 입니다.
####원티드 JD
```
select * from wanted_jd where id = 39;
```
<img width="882" alt="image" src="https://github.com/Kernel360/f1-JDON-Backend/assets/59242594/35f62d38-7cca-44f9-8c79-9fdad4e9bde0">

#### 원티드 JD 기술스택 히스토리
```
select * skill_history where wanted_jd_id = 39;
```
<img width="526" alt="image" src="https://github.com/Kernel360/f1-JDON-Backend/assets/59242594/1cbb7049-855b-44c1-adf7-0abfa76fa87d">

#### 원티드 JD <-> Skill 매핑
```
select * from wanted_jd_skill where wanted_jd_id = 39;
```
<img width="337" alt="image" src="https://github.com/Kernel360/f1-JDON-Backend/assets/59242594/9a6bf30c-3b56-42a0-afa5-653c79422d47">

#### Skill
```
select * from skill where id in (90,91,95,87,92,101,99);
```
<img width="382" alt="image" src="https://github.com/Kernel360/f1-JDON-Backend/assets/59242594/870263b1-528d-4809-9f90-ff3c023ae6fc">



### 이슈

- closes: #139 

---

## PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경, 주석 변경)
- [x] 코드 리팩토링
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 파일 혹은 폴더명 수정, 삭제
- [ ] 배포 관련