### PR TITLE
Test: 커피챗 컨트롤러 단위테스트 작성

### DIFF
--- a/module-api/build.gradle
+++ b/module-api/build.gradle
@@ -41,6 +41,7 @@ dependencies {
     // test
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'com.h2database:h2'
+    testImplementation 'org.springframework.security:spring-security-test'
 }
 
 tasks.register("prepareKotlinBuildScriptModel") {}

--- a/module-api/src/main/java/kernel/jdon/coffeechat/dto/request/CreateCoffeeChatRequest.java
+++ b/module-api/src/main/java/kernel/jdon/coffeechat/dto/request/CreateCoffeeChatRequest.java
@@ -7,10 +7,14 @@ import com.fasterxml.jackson.annotation.JsonFormat;
 import kernel.jdon.coffeechat.domain.CoffeeChat;
 import kernel.jdon.member.domain.Member;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
+@Builder
+@AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class CreateCoffeeChatRequest {
 

--- a/module-api/src/main/java/kernel/jdon/coffeechat/dto/request/UpdateCoffeeChatRequest.java
+++ b/module-api/src/main/java/kernel/jdon/coffeechat/dto/request/UpdateCoffeeChatRequest.java
@@ -6,10 +6,14 @@ import com.fasterxml.jackson.annotation.JsonFormat;
 
 import kernel.jdon.coffeechat.domain.CoffeeChat;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
+@Builder
+@AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class UpdateCoffeeChatRequest {
 

--- a/module-api/src/main/java/kernel/jdon/coffeechat/dto/response/FindCoffeeChatResponse.java
+++ b/module-api/src/main/java/kernel/jdon/coffeechat/dto/response/FindCoffeeChatResponse.java
@@ -12,7 +12,8 @@ import lombok.Getter;
 @Getter
 @Builder
 @AllArgsConstructor
-public class FindCoffeeChatResponse {
+public class
+FindCoffeeChatResponse {
 
 	private Long coffeeChatId;
 	private String nickname;

--- a/module-api/src/main/java/kernel/jdon/coffeechat/dto/response/FindCoffeeChatResponse.java
+++ b/module-api/src/main/java/kernel/jdon/coffeechat/dto/response/FindCoffeeChatResponse.java
@@ -12,8 +12,7 @@ import lombok.Getter;
 @Getter
 @Builder
 @AllArgsConstructor
-public class
-FindCoffeeChatResponse {
+public class FindCoffeeChatResponse {
 
 	private Long coffeeChatId;
 	private String nickname;

--- a/module-api/src/test/java/kernel/jdon/coffeechat/controller/CoffeeChatControllerTest.java
+++ b/module-api/src/test/java/kernel/jdon/coffeechat/controller/CoffeeChatControllerTest.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import kernel.jdon.coffeechat.dto.request.CreateCoffeeChatRequest;
 import kernel.jdon.coffeechat.dto.request.UpdateCoffeeChatRequest;
 import kernel.jdon.coffeechat.dto.response.CreateCoffeeChatResponse;
+import kernel.jdon.coffeechat.dto.response.DeleteCoffeeChatResponse;
 import kernel.jdon.coffeechat.dto.response.FindCoffeeChatResponse;
 import kernel.jdon.coffeechat.dto.response.UpdateCoffeeChatResponse;
 import kernel.jdon.coffeechat.service.CoffeeChatService;
@@ -100,6 +101,24 @@ class CoffeeChatControllerTest {
 			.andExpect(jsonPath("$.data.coffeeChatId").value(updateCoffeeChatID));
 	}
 
+	@DisplayName("커피챗 삭제 성공")
+	@Test
+	void removeCoffeeChat() throws Exception {
+		//given
+		Long deleteCoffeeChatId = 1L;
+		DeleteCoffeeChatResponse response = deleteCoffeeChatResponse();
+		doReturn(response).when(coffeeChatService).delete(any(Long.class));
+
+		//when
+		ResultActions resultActions = mockMvc.perform(
+			MockMvcRequestBuilders.delete("/api/v1/coffeechats/{id}", deleteCoffeeChatId)
+		);
+
+		//then
+		resultActions.andExpect(status().isOk())
+			.andExpect(jsonPath("$.data.coffeeChatId").value(deleteCoffeeChatId));
+	}
+
 	private FindCoffeeChatResponse findCoffeeChatResponse() {
 
 		return FindCoffeeChatResponse.builder()
@@ -146,6 +165,10 @@ class CoffeeChatControllerTest {
 			.meetDate(LocalDateTime.now())
 			.openChatUrl("https://open.kakao.com/o/def")
 			.build();
+	}
+
+	private DeleteCoffeeChatResponse deleteCoffeeChatResponse() {
+		return new DeleteCoffeeChatResponse(1L);
 	}
 
 }

--- a/module-api/src/test/java/kernel/jdon/coffeechat/controller/CoffeeChatControllerTest.java
+++ b/module-api/src/test/java/kernel/jdon/coffeechat/controller/CoffeeChatControllerTest.java
@@ -19,8 +19,10 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import kernel.jdon.coffeechat.dto.request.CreateCoffeeChatRequest;
+import kernel.jdon.coffeechat.dto.request.UpdateCoffeeChatRequest;
 import kernel.jdon.coffeechat.dto.response.CreateCoffeeChatResponse;
 import kernel.jdon.coffeechat.dto.response.FindCoffeeChatResponse;
+import kernel.jdon.coffeechat.dto.response.UpdateCoffeeChatResponse;
 import kernel.jdon.coffeechat.service.CoffeeChatService;
 
 @WebMvcTest(CoffeeChatController.class)
@@ -77,6 +79,27 @@ class CoffeeChatControllerTest {
 
 	}
 
+	@DisplayName("커피챗 수정 성공")
+	@Test
+	void modifyCoffeeChat() throws Exception {
+		//given
+		Long updateCoffeeChatID = 1L;
+		UpdateCoffeeChatRequest request = updateCoffeeChatRequest();
+		UpdateCoffeeChatResponse response = new UpdateCoffeeChatResponse(updateCoffeeChatID);
+		doReturn(response).when(coffeeChatService).update(any(Long.class), any(UpdateCoffeeChatRequest.class));
+
+		//when
+		ResultActions resultActions = mockMvc.perform(
+			MockMvcRequestBuilders.put("/api/v1/coffeechats/{id}", updateCoffeeChatID)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(toJson(request))
+		);
+
+		//then
+		resultActions.andExpect(status().isOk())
+			.andExpect(jsonPath("$.data.coffeeChatId").value(updateCoffeeChatID));
+	}
+
 	private FindCoffeeChatResponse findCoffeeChatResponse() {
 
 		return FindCoffeeChatResponse.builder()
@@ -112,6 +135,17 @@ class CoffeeChatControllerTest {
 
 	private <T> String toJson(T data) throws JsonProcessingException {
 		return objectMapper.writeValueAsString(data);
+	}
+
+	private UpdateCoffeeChatRequest updateCoffeeChatRequest() {
+
+		return UpdateCoffeeChatRequest.builder()
+			.title("커피챗제목1")
+			.content("커피챗내용1")
+			.totalRecruitCount(10L)
+			.meetDate(LocalDateTime.now())
+			.openChatUrl("https://open.kakao.com/o/def")
+			.build();
 	}
 
 }

--- a/module-api/src/test/java/kernel/jdon/coffeechat/controller/CoffeeChatControllerTest.java
+++ b/module-api/src/test/java/kernel/jdon/coffeechat/controller/CoffeeChatControllerTest.java
@@ -1,6 +1,7 @@
 package kernel.jdon.coffeechat.controller;
 
 import static org.mockito.Mockito.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 import java.time.LocalDateTime;
@@ -11,6 +12,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
@@ -39,6 +41,7 @@ class CoffeeChatControllerTest {
 	ObjectMapper objectMapper;
 
 	@DisplayName("커피챗 생성 성공")
+	@WithMockUser
 	@Test
 	void createCoffeeChat() throws Exception {
 		//given
@@ -51,6 +54,7 @@ class CoffeeChatControllerTest {
 		//when
 		ResultActions resultActions = mockMvc.perform(
 			MockMvcRequestBuilders.post("/api/v1/coffeechats")
+				.with(csrf())
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(toJson(request))
 		);
@@ -62,6 +66,7 @@ class CoffeeChatControllerTest {
 	}
 
 	@DisplayName("커피챗 상세조회 성공")
+	@WithMockUser
 	@Test
 	void getCoffeeChat() throws Exception {
 		//given
@@ -81,6 +86,7 @@ class CoffeeChatControllerTest {
 	}
 
 	@DisplayName("커피챗 수정 성공")
+	@WithMockUser
 	@Test
 	void modifyCoffeeChat() throws Exception {
 		//given
@@ -92,6 +98,7 @@ class CoffeeChatControllerTest {
 		//when
 		ResultActions resultActions = mockMvc.perform(
 			MockMvcRequestBuilders.put("/api/v1/coffeechats/{id}", updateCoffeeChatID)
+				.with(csrf())
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(toJson(request))
 		);
@@ -102,6 +109,7 @@ class CoffeeChatControllerTest {
 	}
 
 	@DisplayName("커피챗 삭제 성공")
+	@WithMockUser
 	@Test
 	void removeCoffeeChat() throws Exception {
 		//given
@@ -112,6 +120,7 @@ class CoffeeChatControllerTest {
 		//when
 		ResultActions resultActions = mockMvc.perform(
 			MockMvcRequestBuilders.delete("/api/v1/coffeechats/{id}", deleteCoffeeChatId)
+				.with(csrf())
 		);
 
 		//then

--- a/module-api/src/test/java/kernel/jdon/coffeechat/controller/CoffeeChatControllerTest.java
+++ b/module-api/src/test/java/kernel/jdon/coffeechat/controller/CoffeeChatControllerTest.java
@@ -1,12 +1,25 @@
 package kernel.jdon.coffeechat.controller;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
+import java.time.LocalDateTime;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import kernel.jdon.coffeechat.dto.request.CreateCoffeeChatRequest;
+import kernel.jdon.coffeechat.dto.response.CreateCoffeeChatResponse;
 import kernel.jdon.coffeechat.service.CoffeeChatService;
 
 @WebMvcTest(CoffeeChatController.class)
@@ -17,5 +30,49 @@ class CoffeeChatControllerTest {
 
 	@Autowired
 	private MockMvc mockMvc;
+
+	@Autowired
+	ObjectMapper objectMapper;
+
+	@DisplayName("커피챗 생성 성공")
+	@Test
+	void createCoffeeChat() throws Exception {
+		//given
+		CreateCoffeeChatRequest request = createCoffeeChatRequest();
+		CreateCoffeeChatResponse response = createCoffeeChatResponse();
+
+		doReturn(response).when(coffeeChatService)
+			.create(any(CreateCoffeeChatRequest.class));
+
+		//when
+		ResultActions resultActions = mockMvc.perform(
+			MockMvcRequestBuilders.post("/api/v1/coffeechats")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(toJson(request))
+		);
+
+		//then
+		resultActions.andExpect(status().isCreated())
+			.andExpect(jsonPath("$.data.coffeeChatId").value(1L));
+
+	}
+
+	private CreateCoffeeChatRequest createCoffeeChatRequest() {
+		return CreateCoffeeChatRequest.builder()
+			.title("chat1")
+			.content("content1")
+			.totalRecruitCount(5L)
+			.meetDate(LocalDateTime.parse("2024-02-06T00:00:00"))
+			.openChatUrl("https://open.kakao.com/o/abc")
+			.build();
+	}
+
+	private CreateCoffeeChatResponse createCoffeeChatResponse() {
+		return new CreateCoffeeChatResponse(1L);
+	}
+
+	private <T> String toJson(T data) throws JsonProcessingException {
+		return objectMapper.writeValueAsString(data);
+	}
 
 }

--- a/module-api/src/test/java/kernel/jdon/coffeechat/controller/CoffeeChatControllerTest.java
+++ b/module-api/src/test/java/kernel/jdon/coffeechat/controller/CoffeeChatControllerTest.java
@@ -40,10 +40,10 @@ class CoffeeChatControllerTest {
 	@Autowired
 	ObjectMapper objectMapper;
 
-	@DisplayName("커피챗 생성 성공")
+	@DisplayName("유효한 요청으로 커피챗 생성 성공시 생성된 커피챗의 ID를 반환한다.")
 	@WithMockUser
 	@Test
-	void createCoffeeChat() throws Exception {
+	void givenValidRequest_whenCreateCoffeeChat_thenReturnCreatedCoffeeChatId() throws Exception {
 		//given
 		CreateCoffeeChatRequest request = createCoffeeChatRequest();
 		CreateCoffeeChatResponse response = createCoffeeChatResponse();
@@ -65,10 +65,10 @@ class CoffeeChatControllerTest {
 
 	}
 
-	@DisplayName("커피챗 상세조회 성공")
+	@DisplayName("유효한 커피챗 ID로 상세 조회 시 정상 응답과 데이터를 반환한다.")
 	@WithMockUser
 	@Test
-	void getCoffeeChat() throws Exception {
+	void givenValidCoffeeChatId_whenFindCoffeeChat_thenReturnValidCoffeeChatResponse() throws Exception {
 		//given
 		Long coffeeChatId = 1L;
 		FindCoffeeChatResponse response = findCoffeeChatResponse();
@@ -81,14 +81,18 @@ class CoffeeChatControllerTest {
 		//then
 		resultActions.andExpect(status().isOk())
 			.andExpect(jsonPath("$.data.coffeeChatId").value(coffeeChatId))
+			.andExpect(jsonPath("$.data.meetDate").exists())
+			.andExpect(jsonPath("$.data.createdDate").exists())
+			.andExpect(jsonPath("$.data.totalRecruitCount").value(5))
+			.andExpect(jsonPath("$.data.currentRecruitCount").value(3))
 			.andExpect(jsonPath("$.data.nickname").value("마틴 파울러"));
 
 	}
 
-	@DisplayName("커피챗 수정 성공")
+	@DisplayName("유효한 요청으로 커피챗 수정 성공시 수정된 커피챗의 ID를 반환한다.")
 	@WithMockUser
 	@Test
-	void modifyCoffeeChat() throws Exception {
+	void givenValidUpdateRequest_whenUpdateCoffeeChat_thenReturnUpdatedCoffeeChatId() throws Exception {
 		//given
 		Long updateCoffeeChatID = 1L;
 		UpdateCoffeeChatRequest request = updateCoffeeChatRequest();
@@ -108,10 +112,10 @@ class CoffeeChatControllerTest {
 			.andExpect(jsonPath("$.data.coffeeChatId").value(updateCoffeeChatID));
 	}
 
-	@DisplayName("커피챗 삭제 성공")
+	@DisplayName("유효한 커피챗 ID로 삭제 성공 시 정상응답과 삭제된 커피챗의 ID를 반환한다.")
 	@WithMockUser
 	@Test
-	void removeCoffeeChat() throws Exception {
+	void givenValidCoffeeChatId_whenDeleteCoffeeChat_thenReturnDeletedCoffeeChatId() throws Exception {
 		//given
 		Long deleteCoffeeChatId = 1L;
 		DeleteCoffeeChatResponse response = deleteCoffeeChatResponse();

--- a/module-api/src/test/java/kernel/jdon/coffeechat/controller/CoffeeChatControllerTest.java
+++ b/module-api/src/test/java/kernel/jdon/coffeechat/controller/CoffeeChatControllerTest.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 import kernel.jdon.coffeechat.dto.request.CreateCoffeeChatRequest;
 import kernel.jdon.coffeechat.dto.response.CreateCoffeeChatResponse;
+import kernel.jdon.coffeechat.dto.response.FindCoffeeChatResponse;
 import kernel.jdon.coffeechat.service.CoffeeChatService;
 
 @WebMvcTest(CoffeeChatController.class)
@@ -55,6 +56,30 @@ class CoffeeChatControllerTest {
 		resultActions.andExpect(status().isCreated())
 			.andExpect(jsonPath("$.data.coffeeChatId").value(1L));
 
+	}
+
+	@DisplayName("커피챗 상세조회 성공")
+	@Test
+	void getCoffeeChat() throws Exception {
+		//given
+		Long coffeeChatId = 1L;
+		FindCoffeeChatResponse response = findCoffeeChatResponse();
+		when(coffeeChatService.find(coffeeChatId)).thenReturn(response);
+
+		//when
+		ResultActions resultActions = mockMvc.perform(
+			MockMvcRequestBuilders.get("/api/v1/coffeechats/{id}", coffeeChatId));
+
+		//then
+		resultActions.andExpect(status().isOk())
+			.andExpect(jsonPath("$.data.coffeeChatId").value(coffeeChatId))
+			.andExpect(jsonPath("$.data.nickname").value("마틴 파울러"));
+
+	}
+
+	private FindCoffeeChatResponse findCoffeeChatResponse() {
+		return new FindCoffeeChatResponse(1L, "마틴 파울러", "커피챗제목1", "커피챗내용1", 1000L, "모집중", LocalDateTime.now(),
+			LocalDateTime.now(), "https://open.kakao.com/o/abc", 5L, 3L, "backend");
 	}
 
 	private CreateCoffeeChatRequest createCoffeeChatRequest() {

--- a/module-api/src/test/java/kernel/jdon/coffeechat/controller/CoffeeChatControllerTest.java
+++ b/module-api/src/test/java/kernel/jdon/coffeechat/controller/CoffeeChatControllerTest.java
@@ -1,0 +1,21 @@
+package kernel.jdon.coffeechat.controller;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import kernel.jdon.coffeechat.service.CoffeeChatService;
+
+@WebMvcTest(CoffeeChatController.class)
+class CoffeeChatControllerTest {
+
+	@MockBean
+	private CoffeeChatService coffeeChatService;
+
+	@Autowired
+	private MockMvc mockMvc;
+
+}

--- a/module-api/src/test/java/kernel/jdon/coffeechat/controller/CoffeeChatControllerTest.java
+++ b/module-api/src/test/java/kernel/jdon/coffeechat/controller/CoffeeChatControllerTest.java
@@ -78,11 +78,25 @@ class CoffeeChatControllerTest {
 	}
 
 	private FindCoffeeChatResponse findCoffeeChatResponse() {
-		return new FindCoffeeChatResponse(1L, "마틴 파울러", "커피챗제목1", "커피챗내용1", 1000L, "모집중", LocalDateTime.now(),
-			LocalDateTime.now(), "https://open.kakao.com/o/abc", 5L, 3L, "backend");
+
+		return FindCoffeeChatResponse.builder()
+			.coffeeChatId(1L)
+			.nickname("마틴 파울러")
+			.title("커피챗제목1")
+			.content("커피챗내용1")
+			.viewCount(1000L)
+			.status("모집중")
+			.meetDate(LocalDateTime.now())
+			.createdDate(LocalDateTime.now())
+			.openChatUrl("https://open.kakao.com/o/abc")
+			.totalRecruitCount(5L)
+			.currentRecruitCount(3L)
+			.job("backend")
+			.build();
 	}
 
 	private CreateCoffeeChatRequest createCoffeeChatRequest() {
+
 		return CreateCoffeeChatRequest.builder()
 			.title("chat1")
 			.content("content1")


### PR DESCRIPTION
### 요약
- 커피챗 단건 CRUD에 대한 컨트롤러 계층 테스트를 작성했습니다

### 변경한 부분
- 시큐리티 적용에 따른 test 의존성 추가
- 응답 및 요청 dto에 빌더 추가
- 각 crud 메서드별로 mock Service 객체와 mockMvc 활용하여 성공 로직 작성

### 변경한 결과
![image](https://github.com/Kernel360/f1-JDON-Backend/assets/111513287/872ec152-a46d-422e-83dc-4a6ec2709f54)

### 이슈

- closes: #122 

---

## PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경, 주석 변경)
- [ ] 코드 리팩토링
- [ ] 문서 수정
- [x] 테스트 추가, 테스트 리팩토링
- [ ] 파일 혹은 폴더명 수정, 삭제
- [ ] 배포 관련