### PR TITLE
Fix: Q 클래스가 생성되는 문제 해결

### DIFF
--- a/module-domain/build.gradle
+++ b/module-domain/build.gradle
@@ -38,8 +38,19 @@ dependencies {
 
 }
 
+def buildDir = 'build'
+
 clean {
-    delete file('src/main/generated')
+    delete file(buildDir)
+}
+
+sourceSets {
+    main.java.srcDir buildDir
+}
+
+tasks.withType(JavaCompile) {
+    options.annotationProcessorPath = configurations.annotationProcessor
+    options.compilerArgs += ['-s', buildDir]
 }
 
 tasks.register("prepareKotlinBuildScriptModel") {}


### PR DESCRIPTION
## 개요
- `ModuleApiApplication`이나 `ModuleCrawlerApplication`을 실행할 때, `module-domain`의 main/generated 아래에 Q 클래스가 생성되는 문제
- 참고로, `module-domain` 자체를 build할 때는 src 파일과 같은 레벨에 build파일이 정상적으로 생성되었음
![image](https://github.com/Kernel360/f1-JDON-Backend/assets/86637372/2a9d8de9-4b53-488b-bd4f-4d67ded63da9)

### 요약
- `build` 디렉토리 내에 Q 클래스 파일들이 생성되도록 querydsl 설정을 변경

### 변경한 부분
- `build` 디렉토리
```java
def buildDir = 'build'
```
- 소스코드가 있는 곳으로 **인식**하는 부분입니다.
```java
sourceSets {
    main.java.srcDir buildDir
}
```
- `JavaCompile` 시, 생성된 소스 코드의 **출력 경로**로 변경했습니다.
 Querydsl **어노테이션 프로세서**가 이 경로에서 Q 클래스 파일을 생성하도록 합니다. 
```java
tasks.withType(JavaCompile) {
    options.annotationProcessorPath = configurations.annotationProcessor
    options.compilerArgs += ['-s', buildDir]
}
```
- `clean`할 때 **삭제할 디렉토리**도 동일하게 설정했습니다.
```java
def buildDir = 'build'

clean {
    delete file(buildDir)
}
```

### 변경한 결과
![image](https://github.com/Kernel360/f1-JDON-Backend/assets/86637372/e70fbf28-edd0-40c6-a858-fa20b38ba870)


### 이슈

- closes: #148 

---

## PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경, 주석 변경)
- [ ] 코드 리팩토링
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 파일 혹은 폴더명 수정, 삭제
- [ ] 배포 관련