### PR TITLE
Feature: 로그아웃 API 구현하기

### DIFF
--- a/module-api/src/main/java/kernel/jdon/config/OAuth2SecurityConfig.java
+++ b/module-api/src/main/java/kernel/jdon/config/OAuth2SecurityConfig.java
@@ -33,8 +33,13 @@ public class OAuth2SecurityConfig {
 			.anyRequest().permitAll());
 		http.oauth2Login(oauth2Configurer -> oauth2Configurer
 			.successHandler(oAuth2AuthenticationSuccessHandler())
-			.userInfoEndpoint()
-			.userService(jdonOAuth2UserService));
+			.userInfoEndpoint(userInfoEndpointConfigurer -> userInfoEndpointConfigurer
+				.userService(jdonOAuth2UserService)));
+		http.logout(logoutConfigurer -> logoutConfigurer
+			.logoutUrl("/api/v1/logout")
+			.logoutSuccessUrl("http://localhost:3000/main") // TODO: 프론트와 상의 후 메인페이지 url로 변경
+			.invalidateHttpSession(true)
+			.deleteCookies("JSESSIONID"));
 
 		return http.build();
 	}


### PR DESCRIPTION
## 개요

### 요약
로그아웃을 위한 api 구현했습니다. 

### 변경한 부분
- security chain에서 `api/v1/logout`으로 요청을 보내면 해당 유저의 세션을 삭제하고, JSESSIONID 쿠키도 삭제한 후 프론트의 메인 페이지로 리다이렉트하는 코드를 추가했습니다. 
- oauth2Login() 에서 deprecate된 userInfoEndpoint() 메서드를 쓰고 있어서 현재 버전에서 지원하고 있는 userInfoEndpoint() 메서드 시그니처 형식으로 변경했습니다. 
    - 아마 람다 형식으로 쓰기를 권장하는 것 같습니다. 

### 변경한 결과
`/api/v1/logout`으로 요청을 보내면 쿠키와 세션이 삭제되고, 설정한 리다이렉트 url로 이동합니다. 

### 이슈

- closes: #153
- 프론트 분들과 상의하여 리다이렉트할 프론트 페이지의 endpoint를 수정해야합니다.  

---

## PR 유형

어떤 변경 사항이 있나요?

- [X] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경, 주석 변경)
- [ ] 코드 리팩토링
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 파일 혹은 폴더명 수정, 삭제
- [ ] 배포 관련