### PR TITLE
Fix: 요즘 뜨는 기술스택 조회 API 수정

### DIFF
--- a/module-api/build.gradle
+++ b/module-api/build.gradle
@@ -36,7 +36,7 @@ dependencies {
 
     // querydsl
     implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
-    annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
+    annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
     annotationProcessor "jakarta.annotation:jakarta.annotation-api"
     annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 

--- a/module-api/src/main/java/kernel/jdon/skill/dto/object/FindHotSkillDto.java
+++ b/module-api/src/main/java/kernel/jdon/skill/dto/object/FindHotSkillDto.java
@@ -1,0 +1,17 @@
+package kernel.jdon.skill.dto.object;
+
+import com.querydsl.core.annotations.QueryProjection;
+
+import lombok.Getter;
+
+@Getter
+public class FindHotSkillDto {
+	private Long id;
+	private String keyword;
+
+	@QueryProjection
+	public FindHotSkillDto(Long id, String keyword) {
+		this.id = id;
+		this.keyword = keyword;
+	}
+}

--- a/module-api/src/main/java/kernel/jdon/skill/dto/response/FindListHotSkillResponse.java
+++ b/module-api/src/main/java/kernel/jdon/skill/dto/response/FindListHotSkillResponse.java
@@ -2,11 +2,12 @@ package kernel.jdon.skill.dto.response;
 
 import java.util.List;
 
+import kernel.jdon.skill.dto.object.FindHotSkillDto;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
 @AllArgsConstructor
 public class FindListHotSkillResponse {
-	private List<FindHotSkillResponse> skillList;
+	private List<FindHotSkillDto> skillList;
 }

--- a/module-api/src/main/java/kernel/jdon/skill/repository/SkillRepositoryCustom.java
+++ b/module-api/src/main/java/kernel/jdon/skill/repository/SkillRepositoryCustom.java
@@ -2,6 +2,8 @@ package kernel.jdon.skill.repository;
 
 import java.util.List;
 
+import kernel.jdon.skill.dto.object.FindHotSkillDto;
+
 public interface SkillRepositoryCustom {
-	List<String> findHotSkillList();
+	List<FindHotSkillDto> findHotSkillList();
 }

--- a/module-api/src/main/java/kernel/jdon/skill/repository/SkillRepositoryImpl.java
+++ b/module-api/src/main/java/kernel/jdon/skill/repository/SkillRepositoryImpl.java
@@ -1,11 +1,14 @@
 package kernel.jdon.skill.repository;
 
 import static kernel.jdon.skill.domain.QSkill.*;
+import static kernel.jdon.skillhistory.domain.QSkillHistory.*;
 
 import java.util.List;
 
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
+import kernel.jdon.skill.dto.object.FindHotSkillDto;
+import kernel.jdon.skill.dto.object.QFindHotSkillDto;
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
@@ -14,13 +17,16 @@ public class SkillRepositoryImpl implements SkillRepositoryCustom {
 	private final JPAQueryFactory jpaQueryFactory;
 
 	@Override
-	public List<String> findHotSkillList() {
+	public List<FindHotSkillDto> findHotSkillList() {
 		final int hotSkillKeywordCount = 10;
 
 		return jpaQueryFactory
-			.select(skill.keyword)
-			.from(skill)
-			.groupBy(skill.keyword)
+			.select(new QFindHotSkillDto(skill.id, skill.keyword))
+			.from(skillHistory)
+			.innerJoin(skill)
+			.on(skillHistory.jobCategory.id.eq(skill.jobCategory.id)
+				.and(skillHistory.keyword.eq(skill.keyword)))
+			.groupBy(skill.id, skill.keyword)
 			.orderBy(skill.keyword.count().desc())
 			.limit(hotSkillKeywordCount)
 			.fetch();

--- a/module-api/src/main/java/kernel/jdon/skill/service/SkillService.java
+++ b/module-api/src/main/java/kernel/jdon/skill/service/SkillService.java
@@ -4,7 +4,7 @@ import java.util.List;
 
 import org.springframework.stereotype.Service;
 
-import kernel.jdon.skill.dto.response.FindHotSkillResponse;
+import kernel.jdon.skill.dto.object.FindHotSkillDto;
 import kernel.jdon.skill.dto.response.FindListHotSkillResponse;
 import kernel.jdon.skill.repository.SkillRepository;
 import lombok.RequiredArgsConstructor;
@@ -15,9 +15,7 @@ public class SkillService {
 	private final SkillRepository skillRepository;
 
 	public FindListHotSkillResponse findHotSkillList() {
-		List<FindHotSkillResponse> findHotSkillList = skillRepository.findHotSkillList().stream()
-			.map(FindHotSkillResponse::of)
-			.toList();
+		List<FindHotSkillDto> findHotSkillList = skillRepository.findHotSkillList();
 
 		return new FindListHotSkillResponse(findHotSkillList);
 	}

--- a/module-crawler/src/main/java/kernel/jdon/crawler/wanted/service/WantedCrawlerService.java
+++ b/module-crawler/src/main/java/kernel/jdon/crawler/wanted/service/WantedCrawlerService.java
@@ -162,17 +162,17 @@ public class WantedCrawlerService {
 		while (fetchJobIds.size() < MAX_FETCH_JD_LIST_SIZE) {
 			WantedJobListResponse jobListResponse = fetchJobList(jobPosition, offset);
 
-			List<Long> jobIds = jobListResponse.getData().stream()
+			List<Long> jobIdList = jobListResponse.getData().stream()
 				.map(WantedJobListResponse.Data::getId)
 				.toList();
 
-			fetchJobIds.addAll(jobIds);
+			fetchJobIds.addAll(jobIdList);
 
-			if (jobIds.size() < MAX_FETCH_JD_LIST_OFFSET) {
-				offset += MAX_FETCH_JD_LIST_OFFSET;
-			} else {
+			if (jobIdList.size() < MAX_FETCH_JD_LIST_OFFSET) {
 				break;
 			}
+
+			offset += MAX_FETCH_JD_LIST_OFFSET;
 		}
 
 		return fetchJobIds;

--- a/module-crawler/src/main/java/kernel/jdon/crawler/wanted/service/WantedCrawlerService.java
+++ b/module-crawler/src/main/java/kernel/jdon/crawler/wanted/service/WantedCrawlerService.java
@@ -168,7 +168,11 @@ public class WantedCrawlerService {
 
 			fetchJobIds.addAll(jobIds);
 
-			offset += MAX_FETCH_JD_LIST_OFFSET;
+			if (jobIds.size() < MAX_FETCH_JD_LIST_OFFSET) {
+				offset += MAX_FETCH_JD_LIST_OFFSET;
+			} else {
+				break;
+			}
 		}
 
 		return fetchJobIds;

--- a/module-domain/build.gradle
+++ b/module-domain/build.gradle
@@ -27,7 +27,7 @@ dependencies {
 
     // querydsl
     implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
-    annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
+    annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
     annotationProcessor "jakarta.annotation:jakarta.annotation-api"
     annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 


### PR DESCRIPTION
## 개요

### 요약
- skill 데이터 적재 방식 변경에 따른 기술스택 조회 API의 SQL 수정

### 변경한 부분
- skill_history 테이블을 기준으로 가장 많이 추출된 기술스택을 반환하도록 수정하였습니다.
 
### 변경한 결과
API 명세에 맞게 데이터를 반환합니다.
![image](https://github.com/Kernel360/f1-JDON-Backend/assets/59242594/0b827911-42bc-4746-8f13-b1f9056671c4)


### 이슈

- closes: #159 

---

## PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경, 주석 변경)
- [ ] 코드 리팩토링
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 파일 혹은 폴더명 수정, 삭제
- [ ] 배포 관련