### PR TITLE
Feature: 직군 별 기술 스택 조회하기 API 구현

### DIFF
--- a/module-api/src/main/java/kernel/jdon/config/OAuth2SecurityConfig.java
+++ b/module-api/src/main/java/kernel/jdon/config/OAuth2SecurityConfig.java
@@ -27,7 +27,11 @@ public class OAuth2SecurityConfig {
 
 	@Bean
 	public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+
 		http.csrf().disable();
+
+		http.cors(corsConfiguerer -> corsConfiguerer.disable());
+
 		http.authorizeHttpRequests(config -> config
 			.requestMatchers("api/**").permitAll()
 			.anyRequest().permitAll());

--- a/module-api/src/main/java/kernel/jdon/skill/controller/SkillController.java
+++ b/module-api/src/main/java/kernel/jdon/skill/controller/SkillController.java
@@ -12,7 +12,6 @@ import org.springframework.web.bind.annotation.RestController;
 import kernel.jdon.dto.response.CommonResponse;
 import kernel.jdon.skill.dto.response.FindCompanyBySkillResponse;
 import kernel.jdon.skill.dto.response.FindJdResponse;
-import kernel.jdon.skill.dto.response.FindJobCategorySkillResponse;
 import kernel.jdon.skill.dto.response.FindLectureResponse;
 import kernel.jdon.skill.dto.response.FindListDataBySkillResponse;
 import kernel.jdon.skill.dto.response.FindListHotSkillResponse;
@@ -56,21 +55,8 @@ public class SkillController {
 
 	@GetMapping("/api/v1/skills/job-category/{jobCategoryId}")
 	public ResponseEntity<CommonResponse> getJobCategorySkillList(@PathVariable Long jobCategoryId) {
-
-		List<FindJobCategorySkillResponse> findJobCategorySkillResponseList = new ArrayList<>();
-		for (long i = 1; i <= 5; i++) {
-			FindJobCategorySkillResponse findJobCategorySkillResponse = FindJobCategorySkillResponse.builder()
-				.skillId(i)
-				.keyword("jobCategory_skill_" + i)
-				.build();
-
-			findJobCategorySkillResponseList.add(findJobCategorySkillResponse);
-		}
-
 		FindListJobCategorySkillResponse findListJobCategorySkillResponse =
-			FindListJobCategorySkillResponse.builder()
-				.skillList(findJobCategorySkillResponseList)
-				.build();
+			skillService.findJobCategorySkillList(jobCategoryId);
 
 		return ResponseEntity.ok(CommonResponse.of(findListJobCategorySkillResponse));
 	}

--- a/module-api/src/main/java/kernel/jdon/skill/dto/response/FindJobCategorySkillResponse.java
+++ b/module-api/src/main/java/kernel/jdon/skill/dto/response/FindJobCategorySkillResponse.java
@@ -1,5 +1,6 @@
 package kernel.jdon.skill.dto.response;
 
+import kernel.jdon.skill.domain.Skill;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -13,4 +14,11 @@ import lombok.NoArgsConstructor;
 public class FindJobCategorySkillResponse {
 	private Long skillId;
 	private String keyword;
+
+	public static FindJobCategorySkillResponse of(Skill skill) {
+		return FindJobCategorySkillResponse.builder()
+			.skillId(skill.getId())
+			.keyword(skill.getKeyword())
+			.build();
+	}
 }

--- a/module-api/src/main/java/kernel/jdon/skill/repository/SkillRepository.java
+++ b/module-api/src/main/java/kernel/jdon/skill/repository/SkillRepository.java
@@ -1,5 +1,12 @@
 package kernel.jdon.skill.repository;
 
-public interface SkillRepository extends SkillDomainRepository, SkillRepositoryCustom {
+import java.util.List;
 
+import org.springframework.data.jpa.repository.Query;
+
+import kernel.jdon.skill.domain.Skill;
+
+public interface SkillRepository extends SkillDomainRepository, SkillRepositoryCustom {
+	@Query("select s from Skill s where s.keyword != '기타' and s.jobCategory.id = :jobCategoryId")
+	List<Skill> findAllByJobCategoryId(Long jobCategoryId);
 }

--- a/module-api/src/main/java/kernel/jdon/skill/service/SkillService.java
+++ b/module-api/src/main/java/kernel/jdon/skill/service/SkillService.java
@@ -5,7 +5,9 @@ import java.util.List;
 import org.springframework.stereotype.Service;
 
 import kernel.jdon.skill.dto.object.FindHotSkillDto;
+import kernel.jdon.skill.dto.response.FindJobCategorySkillResponse;
 import kernel.jdon.skill.dto.response.FindListHotSkillResponse;
+import kernel.jdon.skill.dto.response.FindListJobCategorySkillResponse;
 import kernel.jdon.skill.repository.SkillRepository;
 import lombok.RequiredArgsConstructor;
 
@@ -18,5 +20,15 @@ public class SkillService {
 		List<FindHotSkillDto> findHotSkillList = skillRepository.findHotSkillList();
 
 		return new FindListHotSkillResponse(findHotSkillList);
+	}
+
+	public FindListJobCategorySkillResponse findJobCategorySkillList(Long jobCategoryId) {
+		List<FindJobCategorySkillResponse> findJobCategorySkillList = skillRepository.findAllByJobCategoryId(jobCategoryId)
+			.stream()
+			.map(FindJobCategorySkillResponse::of)
+			.toList();
+
+
+		return new FindListJobCategorySkillResponse(findJobCategorySkillList);
 	}
 }


### PR DESCRIPTION
## 개요

### 요약
- API 구현 : [직군 별 기술 스택 조회하기](https://www.notion.so/d7734d2eeb364296b7aaf66a1b06bb3e?pvs=4)

### 변경한 부분
- api 명세서 기반으로 직군 별 기술 스택 조회하기 API 구현

### 변경한 결과
<img width="454" alt="image" src="https://github.com/Kernel360/f1-JDON-Backend/assets/59242594/9cc06d35-1831-40d2-8f25-5583a398cb91">
### 이슈

- closes: #138 

---

## PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경, 주석 변경)
- [ ] 코드 리팩토링
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 파일 혹은 폴더명 수정, 삭제
- [ ] 배포 관련