### PR TITLE
Feature: Add corsFilter setting

### DIFF
--- a/module-api/src/main/java/kernel/jdon/config/OAuth2SecurityConfig.java
+++ b/module-api/src/main/java/kernel/jdon/config/OAuth2SecurityConfig.java
@@ -4,6 +4,8 @@ import static kernel.jdon.auth.encrypt.AesUtil.*;
 import static kernel.jdon.auth.encrypt.HmacUtil.*;
 import static kernel.jdon.util.StringUtil.*;
 
+import java.util.List;
+
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -11,6 +13,7 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+import org.springframework.web.cors.CorsConfiguration;
 
 import kernel.jdon.auth.dto.JdonOAuth2User;
 import kernel.jdon.auth.service.JdonOAuth2UserService;
@@ -28,10 +31,16 @@ public class OAuth2SecurityConfig {
 	@Bean
 	public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
 
+		http.cors(corsCustomizer -> corsCustomizer.configurationSource(request -> {
+			CorsConfiguration config = new CorsConfiguration();
+			config.setAllowedOrigins(List.of("http://localhost:3000"));
+			config.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE"));
+			config.setAllowedHeaders(List.of("*"));
+			config.setMaxAge(3600L);
+
+			return config;
+		}));
 		http.csrf().disable();
-
-		http.cors(corsConfiguerer -> corsConfiguerer.disable());
-
 		http.authorizeHttpRequests(config -> config
 			.requestMatchers("api/**").permitAll()
 			.anyRequest().permitAll());


### PR DESCRIPTION
## 개요

### 요약

### 변경한 부분

security filter에서 corsFilter를 커스텀했습니다. 
이제 `localhost:3000` 에서 오는 요청은 허용됩니다. 

### 변경한 결과

<img width="875" alt="image" src="https://github.com/Kernel360/f1-JDON-Backend/assets/68376744/12e57fe5-4816-45d1-8d5b-c390c8f523c1">
다음과 같이 설정하지 않은 도메인에서 온 요청은 cors 에러가 나고 

<img width="761" alt="image" src="https://github.com/Kernel360/f1-JDON-Backend/assets/68376744/eccc78df-92d0-4b96-af11-e5849515b624">
설정한 도메인에서 온 요청은 cors 에러가 나지 않습니다. 

### 이슈

- closes: #164 

---

## PR 유형

어떤 변경 사항이 있나요?

- [X] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경, 주석 변경)
- [ ] 코드 리팩토링
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 파일 혹은 폴더명 수정, 삭제
- [ ] 배포 관련