### PR TITLE
Feature: 커피챗 생성시 로그인 유저의 정보로 작성자 설정하도록 변경

### DIFF
--- a/module-api/src/main/java/kernel/jdon/coffeechat/controller/CoffeeChatController.java
+++ b/module-api/src/main/java/kernel/jdon/coffeechat/controller/CoffeeChatController.java
@@ -14,6 +14,7 @@ import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
+import kernel.jdon.auth.dto.SessionUserInfo;
 import kernel.jdon.coffeechat.dto.request.CreateCoffeeChatRequest;
 import kernel.jdon.coffeechat.dto.request.UpdateCoffeeChatRequest;
 import kernel.jdon.coffeechat.dto.response.ApplyCoffeeChatResponse;
@@ -23,6 +24,7 @@ import kernel.jdon.coffeechat.dto.response.FindCoffeeChatListResponse;
 import kernel.jdon.coffeechat.dto.response.UpdateCoffeeChatResponse;
 import kernel.jdon.coffeechat.service.CoffeeChatService;
 import kernel.jdon.dto.response.CommonResponse;
+import kernel.jdon.global.annotation.LoginUser;
 import lombok.RequiredArgsConstructor;
 
 @RestController
@@ -38,8 +40,10 @@ public class CoffeeChatController {
 	}
 
 	@PostMapping("/api/v1/coffeechats")
-	public ResponseEntity<CommonResponse> save(@RequestBody CreateCoffeeChatRequest request) {
-		CreateCoffeeChatResponse response = coffeeChatService.create(request);
+	public ResponseEntity<CommonResponse> save(
+		@RequestBody CreateCoffeeChatRequest request,
+		@LoginUser SessionUserInfo sessionUser) {
+		CreateCoffeeChatResponse response = coffeeChatService.create(request, sessionUser.getId());
 		URI uri = URI.create("/v1/coffeechats/" + response.getCoffeeChatId());
 
 		return ResponseEntity.created(uri).body(CommonResponse.of(response));

--- a/module-api/src/main/java/kernel/jdon/coffeechat/dto/request/CreateCoffeeChatRequest.java
+++ b/module-api/src/main/java/kernel/jdon/coffeechat/dto/request/CreateCoffeeChatRequest.java
@@ -25,14 +25,14 @@ public class CreateCoffeeChatRequest {
 	private LocalDateTime meetDate;
 	private String openChatUrl;
 
-	public static CoffeeChat toEntity(CreateCoffeeChatRequest request) {
+	public CoffeeChat toEntity(Member member) {
 		return CoffeeChat.builder()
-			.title(request.getTitle())
-			.content(request.getContent())
-			.totalRecruitCount(request.getTotalRecruitCount())
-			.meetDate(request.getMeetDate())
-			.openChatUrl(request.getOpenChatUrl())
-			.member(Member.builder().id(1L).build())
+			.title(title)
+			.content(content)
+			.totalRecruitCount(totalRecruitCount)
+			.meetDate(meetDate)
+			.openChatUrl(openChatUrl)
+			.member(member)
 			.build();
 	}
 

--- a/module-api/src/test/java/kernel/jdon/coffeechat/controller/CoffeeChatControllerTest.java
+++ b/module-api/src/test/java/kernel/jdon/coffeechat/controller/CoffeeChatControllerTest.java
@@ -49,7 +49,7 @@ class CoffeeChatControllerTest {
 		CreateCoffeeChatResponse response = createCoffeeChatResponse();
 
 		doReturn(response).when(coffeeChatService)
-			.create(any(CreateCoffeeChatRequest.class));
+			.create(any(CreateCoffeeChatRequest.class), any(Long.class));
 
 		//when
 		ResultActions resultActions = mockMvc.perform(


### PR DESCRIPTION
## 개요
시큐리티 적용됨에 따라 커피챗 생성시 로그인 유저의 정보로 작성자를 설정 했습니다.

### 변경한 부분

- 생성요청 DTO에서 Entity 변환 메소드를 static -> 인스턴스 메서드로 변경했습니다
  - 멤버 엔터티를 인자로 받아서 작성자로 설정합니다.
- 컨트롤러에서 로그인 유저정보를 받아오도록 수정했습니다.
- 서비스에서 전달받은 유저정보(멤버 Id)로 멤버 엔터티를 찾도록 변경했습니다.

### 변경한 결과

![image](https://github.com/Kernel360/f1-JDON-Backend/assets/111513287/44c0ec8c-e93a-4d16-930e-e97cee28ca4a)
회원가입 후 멤버Id = 5
![image](https://github.com/Kernel360/f1-JDON-Backend/assets/111513287/4b0546c0-aeac-4952-9f12-edccede17f1d)
커피챗 생성 성공시 created_by에 멤버Id가 적용됩니다

### 이슈

- closes: #161 

---

## PR 유형

어떤 변경 사항이 있나요?

- [X] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경, 주석 변경)
- [X] 코드 리팩토링
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 파일 혹은 폴더명 수정, 삭제
- [ ] 배포 관련