### PR TITLE
Refactor: 불필요한 static method 수정

### DIFF
--- a/module-api/src/main/java/kernel/jdon/faq/dto/request/CreateFaqRequest.java
+++ b/module-api/src/main/java/kernel/jdon/faq/dto/request/CreateFaqRequest.java
@@ -1,17 +1,20 @@
 package kernel.jdon.faq.dto.request;
 
 import kernel.jdon.faq.domain.Faq;
+import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class CreateFaqRequest {
 	private String title;
 	private String content;
 
-	public static Faq toEntity(CreateFaqRequest createFaqRequest) {
+	public Faq toEntity() {
 		return Faq.builder()
-			.title(createFaqRequest.title)
-			.content(createFaqRequest.content)
+			.title(this.title)
+			.content(this.content)
 			.build();
 	}
 }

--- a/module-api/src/main/java/kernel/jdon/faq/service/FaqService.java
+++ b/module-api/src/main/java/kernel/jdon/faq/service/FaqService.java
@@ -1,10 +1,5 @@
 package kernel.jdon.faq.service;
 
-import java.util.List;
-
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-
 import kernel.jdon.faq.domain.Faq;
 import kernel.jdon.faq.dto.request.CreateFaqRequest;
 import kernel.jdon.faq.dto.request.UpdateFaqRequest;
@@ -16,6 +11,10 @@ import kernel.jdon.faq.error.FaqErrorCode;
 import kernel.jdon.faq.repository.FaqRepository;
 import kernel.jdon.global.exception.ApiException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Service
 @Transactional(readOnly = true)
@@ -30,7 +29,7 @@ public class FaqService {
 
 	@Transactional
 	public CreateFaqResponse create(CreateFaqRequest createFaqRequest) {
-		Faq savedFaq = faqRepository.save(CreateFaqRequest.toEntity(createFaqRequest));
+		Faq savedFaq = faqRepository.save(createFaqRequest.toEntity());
 
 		return CreateFaqResponse.of(savedFaq.getId());
 	}


### PR DESCRIPTION
## 개요

### 요약

### 변경한 부분
- faq create request에서 불필요하게 static method로 처리한 toEntity()를 인스턴스 메서드로 변경했습니다. 
- request dto에 대해서 생성자를 쓸일이 없어 default 생성자와 private 옵션 추가했습니다. 

### 변경한 결과
응답 결과가 달라진 것은 없습니다. 

### 이슈

- closes: #174

---

## PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경, 주석 변경)
- [x] 코드 리팩토링
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 파일 혹은 폴더명 수정, 삭제
- [ ] 배포 관련