### PR TITLE
Bugfix: 영상 찜하기 API 이미 찜한 강의 새로 생성되는 문제 해결 

### DIFF
--- a/module-api/src/main/java/kernel/jdon/favorite/service/FavoriteService.java
+++ b/module-api/src/main/java/kernel/jdon/favorite/service/FavoriteService.java
@@ -40,10 +40,16 @@ public class FavoriteService {
 		InflearnCourse findInflearnCourse = inflearnCourseRepository.findById(
 				updateFavoriteRequest.getLectureId())
 			.orElseThrow(() -> new ApiException(InflearncourseErrorCode.NOT_FOUND_INFLEARN_COURSE));
+		
+		return favoriteRepository.findFavoriteByMemberIdAndInflearnCourseId(memberId,
+				updateFavoriteRequest.getLectureId())
+			.map(favorite -> UpdateFavoriteResponse.of(favorite.getId()))
+			.orElseGet(() -> createNewFavorite(findMember, findInflearnCourse));
+	}
 
-		Favorite favorite = new Favorite(findMember, findInflearnCourse);
+	private UpdateFavoriteResponse createNewFavorite(Member member, InflearnCourse inflearnCourse) {
+		Favorite favorite = new Favorite(member, inflearnCourse);
 		Favorite savedFavorite = favoriteRepository.save(favorite);
-
 		return UpdateFavoriteResponse.of(savedFavorite.getId());
 	}
 


### PR DESCRIPTION
## 개요

### 요약
- 영상 찜하기 API 이미 찜한 강의 새로 생성되는 문제 해결하였습니다.

### 변경한 부분
- favorite을 생성할 때, 해당 찜이 존재하는지 확인 후, 존재하지 않을 때만 새로 생성하도록 변경하였습니다.

### 변경한 결과
![image](https://github.com/Kernel360/f1-JDON-Backend/assets/86637372/c3f300c2-a285-4fe1-8e71-787f8ce41fca)
![image](https://github.com/Kernel360/f1-JDON-Backend/assets/86637372/183fa0e9-a4a9-4058-8586-3af771b63885)


### 이슈

- closes: #183 

---

## PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경, 주석 변경)
- [ ] 코드 리팩토링
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 파일 혹은 폴더명 수정, 삭제
- [ ] 배포 관련