### PR TITLE
Refactor : CustomPageResponse 정적 팩토리 메서드 추가

### DIFF
--- a/module-api/src/main/java/kernel/jdon/coffeechat/service/CoffeeChatService.java
+++ b/module-api/src/main/java/kernel/jdon/coffeechat/service/CoffeeChatService.java
@@ -50,12 +50,12 @@ public class CoffeeChatService {
 		coffeeChat.increaseViewCount();
 	}
 
-	public CustomPageResponse<FindCoffeeChatListResponse> findHostCoffeeChatList(Long memberId, Pageable pageable) {
+	public CustomPageResponse findHostCoffeeChatList(Long memberId, Pageable pageable) {
 		Page<FindCoffeeChatListResponse> findCoffeeChatPage = coffeeChatRepository.findAllByMemberIdAndIsDeletedFalse(
 				memberId, pageable)
 			.map(FindCoffeeChatListResponse::of);
 
-		return new CustomPageResponse<>(findCoffeeChatPage);
+		return CustomPageResponse.of(findCoffeeChatPage);
 	}
 
 	@Transactional

--- a/module-api/src/main/java/kernel/jdon/global/page/CustomPageResponse.java
+++ b/module-api/src/main/java/kernel/jdon/global/page/CustomPageResponse.java
@@ -5,21 +5,22 @@ import java.util.List;
 
 import org.springframework.data.domain.Page;
 
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
+@AllArgsConstructor
 public class CustomPageResponse<T> {
 
 	private List<T> content;
 	private PageInfo pageInfo;
 
-	public CustomPageResponse(Page<T> page) {
-		this.content = page.getContent();
-		this.pageInfo = new PageInfo(page);
+	public static CustomPageResponse of(Page page) {
+		return new CustomPageResponse(page.getContent(), new PageInfo(page));
 	}
 
 	@Getter
-	public class PageInfo implements Serializable {
+	public static class PageInfo implements Serializable {
 
 		private Integer pageNumber;
 		private Integer pageSize;


### PR DESCRIPTION

### 요약
응답DTO는 정적 팩토리 메서드를 사용하는 컨벤션에 따라
CustomPageResponse에 정적 팩토리 메서드를 추가했습니다.

### 변경한 부분
- CustomPageResponse
  - @AllArgsConstructor 어노테이션 추가
  - 정적 팩토리 메서드 of 작성
   - 그에 따라 Page관련 정보를 묶기위해 선언한 이너 클래스도 static으로 변경
 - 생성자로 CustomPageResponse를 사용하던 CoffeeChatService를 정적 팩토리 메서드를 사용하도록 변경
### 이슈

- closes: #192

---

## PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경, 주석 변경)
- [X] 코드 리팩토링
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 파일 혹은 폴더명 수정, 삭제
- [ ] 배포 관련