### PR TITLE
Fix: cors 허용 origin에  프론트 배포 주소 추가

### DIFF
--- a/module-api/src/main/java/kernel/jdon/config/auth/OAuth2SecurityConfig.java
+++ b/module-api/src/main/java/kernel/jdon/config/auth/OAuth2SecurityConfig.java
@@ -27,7 +27,7 @@ public class OAuth2SecurityConfig {
 
 		http.cors(corsCustomizer -> corsCustomizer.configurationSource(request -> {
 			CorsConfiguration config = new CorsConfiguration();
-			config.setAllowedOrigins(List.of("http://localhost:3000"));
+			config.setAllowedOrigins(List.of("http://localhost:3000", "https://peaceful-sopapillas-36c089.netlify.app"));
 			config.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE"));
 			config.setAllowedHeaders(List.of("*"));
 			config.setMaxAge(3600L);


### PR DESCRIPTION
## 개요

### 요약

### 변경한 부분
프론트 배포 주소를 cors allow origin 주소에 허용했습니다.

### 변경한 결과

### 이슈

- closes: #

---

## PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경, 주석 변경)
- [ ] 코드 리팩토링
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 파일 혹은 폴더명 수정, 삭제
- [ ] 배포 관련