### PR TITLE
Feature: 커피챗 신청 API

### DIFF
--- a/module-api/src/main/java/kernel/jdon/coffeechat/controller/CoffeeChatController.java
+++ b/module-api/src/main/java/kernel/jdon/coffeechat/controller/CoffeeChatController.java
@@ -123,9 +123,13 @@ public class CoffeeChatController {
 	}
 
 	@PostMapping("/api/v1/coffeechats/{id}")
-	public ResponseEntity<CommonResponse> apply(@PathVariable(name = "id") Long coffeeChatId) {
+	public ResponseEntity<CommonResponse> apply(
+		@PathVariable(name = "id") Long coffeeChatId,
+		@LoginUser SessionUserInfo sessionUser) {
 
-		return ResponseEntity.ok().body(CommonResponse.of(ApplyCoffeeChatResponse.of(coffeeChatId)));
+		ApplyCoffeeChatResponse response = coffeeChatService.apply(coffeeChatId, sessionUser.getId());
+
+		return ResponseEntity.ok().body(CommonResponse.of(response));
 	}
 
 }

--- a/module-api/src/main/java/kernel/jdon/coffeechat/error/CoffeeChatErrorCode.java
+++ b/module-api/src/main/java/kernel/jdon/coffeechat/error/CoffeeChatErrorCode.java
@@ -10,7 +10,7 @@ public enum CoffeeChatErrorCode implements ErrorCode {
 	NOT_FOUND_COFFEECHAT(HttpStatus.NOT_FOUND, "존재하지 않는 커피챗 입니다."),
 	NOT_OPEN_COFFEECHAT(HttpStatus.BAD_REQUEST, "모집중이 아닌 커피챗 입니다."),
 	INVALID_RECRUIT_COUNT(HttpStatus.BAD_REQUEST, "유효하지 않은 모집인원 입니다."),
-	CAN_NOT_JOIN_OWN_COFEECHAT(HttpStatus.BAD_REQUEST, "본인이 개설한 커피챗에 참여할 수 없습니다."),
+	CAN_NOT_JOIN_OWN_COFFEECHAT(HttpStatus.BAD_REQUEST, "본인이 개설한 커피챗에 참여할 수 없습니다."),
 	EXPIRED_COFFEECHAT(HttpStatus.BAD_REQUEST, "지난 일자의 커피챗은 수정할 수 없습니다."),
 	MEET_DATE_ISBEFORE_NOW(HttpStatus.BAD_REQUEST, "지금보다 이전 시점으로 설정할 수 없습니다.");
 	private final HttpStatus httpStatus;

--- a/module-api/src/main/java/kernel/jdon/coffeechat/error/CoffeeChatErrorCode.java
+++ b/module-api/src/main/java/kernel/jdon/coffeechat/error/CoffeeChatErrorCode.java
@@ -8,10 +8,11 @@ import lombok.AllArgsConstructor;
 @AllArgsConstructor
 public enum CoffeeChatErrorCode implements ErrorCode {
 	NOT_FOUND_COFFEECHAT(HttpStatus.NOT_FOUND, "존재하지 않는 커피챗 입니다."),
+	NOT_OPEN_COFFEECHAT(HttpStatus.BAD_REQUEST, "모집중이 아닌 커피챗 입니다."),
 	INVALID_RECRUIT_COUNT(HttpStatus.BAD_REQUEST, "유효하지 않은 모집인원 입니다."),
+	CAN_NOT_JOIN_OWN_COFEECHAT(HttpStatus.BAD_REQUEST, "본인이 개설한 커피챗에 참여할 수 없습니다."),
 	EXPIRED_COFFEECHAT(HttpStatus.BAD_REQUEST, "지난 일자의 커피챗은 수정할 수 없습니다."),
 	MEET_DATE_ISBEFORE_NOW(HttpStatus.BAD_REQUEST, "지금보다 이전 시점으로 설정할 수 없습니다.");
-
 	private final HttpStatus httpStatus;
 	private final String message;
 

--- a/module-api/src/main/java/kernel/jdon/coffeechat/repository/CoffeeChatRepository.java
+++ b/module-api/src/main/java/kernel/jdon/coffeechat/repository/CoffeeChatRepository.java
@@ -6,10 +6,13 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 import kernel.jdon.coffeechat.domain.CoffeeChat;
+import kernel.jdon.coffeechat.domain.CoffeeChatActiveStatus;
 
 public interface CoffeeChatRepository extends CoffeeChatDomainRepository {
 
 	Optional<CoffeeChat> findByIdAndIsDeletedFalse(Long id);
+
+	Optional<CoffeeChat> findByIdAndCoffeeChatStatus(Long id, CoffeeChatActiveStatus status);
 
 	Page<CoffeeChat> findAllByMemberIdAndIsDeletedFalse(Long id, Pageable pageable);
 }

--- a/module-api/src/main/java/kernel/jdon/coffeechat/service/CoffeeChatService.java
+++ b/module-api/src/main/java/kernel/jdon/coffeechat/service/CoffeeChatService.java
@@ -88,13 +88,13 @@ public class CoffeeChatService {
 		CoffeeChat findCoffeeChat = findExistAndOpenCoffeeChat(coffeeChatId);
 		Member findMember = findMember(memberId);
 
-		checkIfGuestEqualToHost(findMember, findCoffeeChat);
+		checkIfMemberIsHost(findMember, findCoffeeChat);
 		findCoffeeChat.addCoffeeChatMember(findMember);
 
 		return ApplyCoffeeChatResponse.of(findCoffeeChat.getId());
 	}
 
-	private void checkIfGuestEqualToHost(Member findMember, CoffeeChat findCoffeeChat) {
+	private void checkIfMemberIsHost(Member findMember, CoffeeChat findCoffeeChat) {
 		if (findMember.getId().equals(findCoffeeChat.getMember().getId())) {
 			throw new ApiException(CoffeeChatErrorCode.CAN_NOT_JOIN_OWN_COFFEECHAT);
 		}

--- a/module-domain/src/main/java/kernel/jdon/coffeechat/domain/CoffeeChat.java
+++ b/module-domain/src/main/java/kernel/jdon/coffeechat/domain/CoffeeChat.java
@@ -6,6 +6,7 @@ import java.util.List;
 
 import org.hibernate.annotations.SQLDelete;
 
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -69,7 +70,7 @@ public class CoffeeChat extends BaseEntity {
 	@JoinColumn(name = "created_by", columnDefinition = "BIGINT")
 	private Member member;
 
-	@OneToMany(mappedBy = "coffeeChat")
+	@OneToMany(mappedBy = "coffeeChat", cascade = CascadeType.ALL, orphanRemoval = true)
 	private List<CoffeeChatMember> coffeeChatMemberList = new ArrayList<>();
 
 	@Builder
@@ -85,6 +86,16 @@ public class CoffeeChat extends BaseEntity {
 
 	public void increaseViewCount() {
 		this.viewCount += 1;
+	}
+
+	public void applyCoffeeChat(CoffeeChatMember coffeeChatMember) {
+		this.coffeeChatMemberList.add(coffeeChatMember);
+		increaseCurrentRecruitCount();
+		updateStatusByRecruitCount();
+	}
+
+	private void increaseCurrentRecruitCount() {
+		this.currentRecruitCount += 1;
 	}
 
 	public void updateCoffeeChat(CoffeeChat request) {

--- a/module-domain/src/main/java/kernel/jdon/coffeechat/domain/CoffeeChat.java
+++ b/module-domain/src/main/java/kernel/jdon/coffeechat/domain/CoffeeChat.java
@@ -88,7 +88,11 @@ public class CoffeeChat extends BaseEntity {
 		this.viewCount += 1;
 	}
 
-	public void applyCoffeeChat(CoffeeChatMember coffeeChatMember) {
+	public void addCoffeeChatMember(Member member) {
+		CoffeeChatMember coffeeChatMember = CoffeeChatMember.builder()
+			.coffeeChat(this)
+			.member(member)
+			.build();
 		this.coffeeChatMemberList.add(coffeeChatMember);
 		increaseCurrentRecruitCount();
 		updateStatusByRecruitCount();

--- a/module-domain/src/main/java/kernel/jdon/coffeechatmember/domain/CoffeeChatMember.java
+++ b/module-domain/src/main/java/kernel/jdon/coffeechatmember/domain/CoffeeChatMember.java
@@ -18,6 +18,7 @@ import jakarta.persistence.Table;
 import kernel.jdon.coffeechat.domain.CoffeeChat;
 import kernel.jdon.member.domain.Member;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -43,13 +44,9 @@ public class CoffeeChatMember {
 	@JoinColumn(name = "coffee_chat_id", columnDefinition = "BIGINT")
 	private CoffeeChat coffeeChat;
 
+	@Builder
 	private CoffeeChatMember(Member member, CoffeeChat coffeeChat) {
 		this.member = member;
 		this.coffeeChat = coffeeChat;
 	}
-
-	public static CoffeeChatMember from(Member member, CoffeeChat coffeeChat) {
-		return new CoffeeChatMember(member, coffeeChat);
-	}
-
 }

--- a/module-domain/src/main/java/kernel/jdon/coffeechatmember/domain/CoffeeChatMember.java
+++ b/module-domain/src/main/java/kernel/jdon/coffeechatmember/domain/CoffeeChatMember.java
@@ -3,9 +3,11 @@ package kernel.jdon.coffeechatmember.domain;
 import java.time.LocalDateTime;
 
 import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -15,9 +17,15 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import kernel.jdon.coffeechat.domain.CoffeeChat;
 import kernel.jdon.member.domain.Member;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
 @Table(name = "coffee_chat_member")
+@EntityListeners(AuditingEntityListener.class)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class CoffeeChatMember {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -34,4 +42,14 @@ public class CoffeeChatMember {
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "coffee_chat_id", columnDefinition = "BIGINT")
 	private CoffeeChat coffeeChat;
+
+	private CoffeeChatMember(Member member, CoffeeChat coffeeChat) {
+		this.member = member;
+		this.coffeeChat = coffeeChat;
+	}
+
+	public static CoffeeChatMember from(Member member, CoffeeChat coffeeChat) {
+		return new CoffeeChatMember(member, coffeeChat);
+	}
+
 }


### PR DESCRIPTION
### 요약

커피챗 신청 API를 구현했습니다
- 커피챗 엔터티가 신청로직에 대한 책임을 지도록 했습니다
  - CoffeeChatMember 레포지토리를 두지않고 CoffeeChat에서만 신청여부를 관리합니다

### 변경한 부분

- CoffeeChatRepository
  -  신청가능한 커피챗을 찾아오도록 쿼리메소드를 추가했습니다
- CoffeeChatErrorCode
  - 예외 상황에 따른 에러코드를 추가했습니다 
- CoffeeChatService
  - apply 메서드에서 db에서 신청하고자 하는 엔터티를 찾아올 때 상태 칼럼이 OPEN인지 확인하고 결과가 없으면 예외를 던지도록 했습니다. 
  - 커피챗 상태와 삭제여부 상태를 구분하기 위해 findById 공통 메서드를 'findExist~'로 변경했습니다.
  - 커피챗을 개설한 host가 guest로서 참여신청을 하는 경우 예외를 던집니다.
- CoffeeChatEntity
  - coffeeChat 엔터티가 신청에 대한 책임을 갖도록 했습니다.
  - coffeeChatMemberList에 cascade.ALL, orphanRemoval 옵션을  적용해서
  coffeeChat만 변경되어도 coffeeChatMember에도 변경사항이 반영되도록 했습니다. 
  - updateStatusByRecruitCount 메소드를 재활용해서 참여인원에 따라 상태를 변경합니다.
- CoffeeChatMember
  - 연결 엔터티 생성을 위해 정적 팩토리 메서드를 추가 했습니다

### 변경한 결과

- 아래와 같이 status가 open인 커피챗에 참여신청을 하면
![image](https://github.com/Kernel360/f1-JDON-Backend/assets/111513287/e139b04a-5532-4062-9657-6feafe4d1dc8)
- currentRecruitCount가 올라가고 totalRecruitCount와 같으면 Status가 업데이트 됩니다
![image](https://github.com/Kernel360/f1-JDON-Backend/assets/111513287/0a9fd8e2-b128-431d-a23b-c0987ed104a0)
- Status가 OPEN이 아닌 해당 커피챗에 또 참여신청을 하면 아래와 같이 예외를 반환합니다.
![image](https://github.com/Kernel360/f1-JDON-Backend/assets/111513287/228c6cb8-d8a6-48a7-b61e-eeb33c5fbdc2)
- 본인이 작성한 커피챗에 참여신청을 하면 예외를 반환합니다.
![image](https://github.com/Kernel360/f1-JDON-Backend/assets/111513287/ac99bfd0-4426-4e0c-9937-e4ae03eaa5fb)

### 이슈

- closes: #186 

---

## PR 유형

어떤 변경 사항이 있나요?

- [X] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경, 주석 변경)
- [ ] 코드 리팩토링
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 파일 혹은 폴더명 수정, 삭제
- [ ] 배포 관련