### PR TITLE
Bug: skill_history 테이블 유니크 인덱스 키 삭제 

### DIFF
--- a/module-domain/src/main/java/kernel/jdon/skillhistory/domain/SkillHistory.java
+++ b/module-domain/src/main/java/kernel/jdon/skillhistory/domain/SkillHistory.java
@@ -9,7 +9,6 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
-import jakarta.persistence.UniqueConstraint;
 import kernel.jdon.jobcategory.domain.JobCategory;
 import kernel.jdon.wantedjd.domain.WantedJd;
 import lombok.AccessLevel;
@@ -20,10 +19,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Table(name = "skill_history",
-	uniqueConstraints = {
-		@UniqueConstraint(columnNames = {"job_category_id", "wanted_jd_id", "keyword"})
-	})
+@Table(name = "skill_history")
 public class SkillHistory {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)


### PR DESCRIPTION
## 개요

### 요약
- skill_history 테이블 유니크 인덱스 키 삭제
- skillHistory 엔티티 @Table uniqueConstraints 속성 제거

### 변경한 부분
- skillHistory 엔티티 @Table uniqueConstraints 속성을 제거하였습니다.
- skill_history 테이블 유니크 인덱스 키 삭제하였습니다.
  - ✅ application.yml파일에 ddl_auto 속성이 update로 되어있다고 하더라도 유니크키가 지워지지 않습니다. 따라서 직접 DB에서 삭제가 필요합니다. 로컬환경에서 ddl_auto를 create로 변경해 데이터베이스를 초기화하는 방법으로 적용하시거나, 로컬 DB에서도 아래 예시와 같이 삭제하시기 바랍니다.(로컬 DB에 저장된 FK, UK는 직접 확인하셔서 적용해야합니다.)

### 아래는 운영서버 DB에서 skill_history 테이블 유니크 인덱스 키를 삭제한 내역 입니다.
#### skill_history 테이블 유니크 인덱스 키 조회
![image](https://github.com/Kernel360/f1-JDON-Backend/assets/59242594/e99ae333-deb6-4775-8110-20495ded4052)

#### skill_history 유니크키 제거
- skill_history 테이블 유니크 인덱스 키가 외래키 제약조건이 걸려있어 바로 삭제가 불가해서 외래키 제약조건 제거 -> 인덱스 키 제거 -> 삭제한 외래키 제약조건 재등록 합니다.
```
# 1. FKmrhqafug43nxomrtg31jqilli 이름의 외래키를 삭제
ALTER TABLE skill_history DROP FOREIGN KEY FKmrhqafug43nxomrtg31jqilli;

# 2. FKagj3pewuv9e0s3t9yskagvyoq 이름의 외래키를 삭제
ALTER TABLE skill_history DROP FOREIGN KEY FKagj3pewuv9e0s3t9yskagvyoq;

# 3. UKt9ommi1gl0f5wbbuvr9t5yhst 이름의 유니크 인덱스 키를 삭제
ALTER TABLE skill_history DROP INDEX UKt9ommi1gl0f5wbbuvr9t5yhst;

# 4. FKagj3pewuv9e0s3t9yskagvyoq 이름의 외래키를 wanted_jd_id 컬럼에 설정
ALTER TABLE skill_history ADD CONSTRAINT FKagj3pewuv9e0s3t9yskagvyoq FOREIGN KEY (wanted_jd_id) REFERENCES wanted_jd (id);

# 5. FKmrhqafug43nxomrtg31jqilli 이름의 외래키를 job_category_id 컬럼에 설정
ALTER TABLE skill_history ADD CONSTRAINT FKmrhqafug43nxomrtg31jqilli FOREIGN KEY (job_category_id) REFERENCES job_category (id);
```
 
### 변경한 결과

#### 유니크키 삭제 확인
![image](https://github.com/Kernel360/f1-JDON-Backend/assets/59242594/0c771da8-7b6b-4b44-9544-61ccd87b1776)


### 이슈

- closes: #195 

---

## PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경, 주석 변경)
- [ ] 코드 리팩토링
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 파일 혹은 폴더명 수정, 삭제
- [ ] 배포 관련