### PR TITLE
Refactor: 인프런 크롤링에서 동적으로 크롤링 시간 조정

### DIFF
--- a/module-crawler/src/main/java/kernel/jdon/crawler/config/ScrapingInflearnConfig.java
+++ b/module-crawler/src/main/java/kernel/jdon/crawler/config/ScrapingInflearnConfig.java
@@ -11,6 +11,15 @@ import lombok.RequiredArgsConstructor;
 public class ScrapingInflearnConfig {
 	private final String url;
 	private final int maxCoursesPerKeyword;
-	private final int sleepTimeMillis;
 	private final int maxCoursesPerPage;
+	private final Sleep sleep;
+
+	@Getter
+	@RequiredArgsConstructor
+	public static class Sleep {
+		private final int minInitial;
+		private final int maxInitial;
+		private final int max;
+		private final int increment;
+	}
 }

--- a/module-crawler/src/main/java/kernel/jdon/crawler/inflearn/service/InflearnCrawlerService.java
+++ b/module-crawler/src/main/java/kernel/jdon/crawler/inflearn/service/InflearnCrawlerService.java
@@ -4,7 +4,6 @@ import static kernel.jdon.util.StringUtil.*;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Random;
 
 import org.jsoup.nodes.Element;
 import org.jsoup.select.Elements;
@@ -13,6 +12,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import kernel.jdon.crawler.config.ScrapingInflearnConfig;
 import kernel.jdon.crawler.inflearn.search.CourseSearchSort;
+import kernel.jdon.crawler.inflearn.service.infrastructure.DynamicSleepTimeManager;
 import kernel.jdon.crawler.inflearn.service.infrastructure.InflearnCourseCounter;
 import kernel.jdon.crawler.inflearn.service.infrastructure.LastPageDiscriminator;
 import kernel.jdon.crawler.wanted.skill.BackendSkillType;
@@ -31,13 +31,6 @@ public class InflearnCrawlerService implements CrawlerService {
 	private final CourseScraperService courseScraperService;
 	private final CourseParserService courseParserService;
 	private final CourseStorageService courseStorageService;
-	private static final int MAX_COURSES_PER_KEYWORD = 3;
-	private static final int MIN_INITIAL_SLEEP_TIME = 1000;
-	private static final int MAX_INITIAL_SLEEP_TIME = 3000;
-	private static final int MAX_SLEEP_TIME = 10000;
-	private static final int INCREMENT_SLEEP_TIME = 1000;
-	private int dynamicSleepTime = MIN_INITIAL_SLEEP_TIME;
-	private final Random random = new Random();
 
 	@Transactional
 	@Override
@@ -55,11 +48,12 @@ public class InflearnCrawlerService implements CrawlerService {
 		final int maxCoursesPerKeyword = scrapingInflearnConfig.getMaxCoursesPerKeyword();
 		InflearnCourseCounter inflearnCourseCounter = new InflearnCourseCounter();
 		LastPageDiscriminator lastPageDiscriminator = new LastPageDiscriminator(scrapingInflearnConfig);
+		DynamicSleepTimeManager sleepTimeManager = new DynamicSleepTimeManager(scrapingInflearnConfig);
 
 		while (inflearnCourseCounter.getSavedCourseCount() < maxCoursesPerKeyword
 			&& !lastPageDiscriminator.isLastPage()) {
 			try {
-				Thread.sleep(dynamicSleepTime);
+				Thread.sleep(sleepTimeManager.getDynamicSleepTime());
 			} catch (InterruptedException e) {
 				Thread.currentThread().interrupt();
 				break;
@@ -67,26 +61,25 @@ public class InflearnCrawlerService implements CrawlerService {
 			String currentUrl = createInflearnSearchUrl(skillKeyword, pageNum);
 			log.info("currentUrl: {}", currentUrl);
 
-			boolean isSuccess = scrapeAndParsePage(currentUrl, skillKeyword, pageNum, state);
-			adjustDynamicSleepTime(isSuccess);
+			boolean isSuccess = scrapeAndParsePage(currentUrl, skillKeyword, inflearnCourseCounter,
+				lastPageDiscriminator);
+			sleepTimeManager.adjustSleepTime(isSuccess);
 
-			if (isSuccess && state.getSavedCourseCount() < MAX_COURSES_PER_KEYWORD) {
+			if (isSuccess && inflearnCourseCounter.getSavedCourseCount() < maxCoursesPerKeyword) {
 				pageNum++;
 			}
 		}
-		saveCourseInfo(skillKeyword, state);
+
+		saveCourseInfo(skillKeyword, inflearnCourseCounter);
 	}
 
-	private boolean scrapeAndParsePage(String currentUrl, String skillKeyword, int pageNum,
-		InflearnCrawlerState state) {
+	private boolean scrapeAndParsePage(String currentUrl, String skillKeyword,
+		InflearnCourseCounter inflearnCourseCounter, LastPageDiscriminator lastPageDiscriminator) {
 		try {
 			Elements scrapeCourseElements = courseScraperService.scrapeCourses(currentUrl);
 			int coursesCount = scrapeCourseElements.size();
 			lastPageDiscriminator.checkIfLastPageBasedOnCourseCount(coursesCount);
-
 			parseAndCreateCourses(scrapeCourseElements, currentUrl, skillKeyword, inflearnCourseCounter);
-			state.checkIfLastPageBasedOnCourseCount(coursesCount);
-			parseAndCreateCourses(scrapeCourseElements, currentUrl, skillKeyword, pageNum, state);
 			return true;
 		} catch (Exception e) {
 			log.error("페이지 처리 중 오류 발생: {}", currentUrl, e);
@@ -94,27 +87,11 @@ public class InflearnCrawlerService implements CrawlerService {
 		}
 	}
 
-			if (inflearnCourseCounter.getSavedCourseCount() < maxCoursesPerKeyword) {
-				pageNum++;
-			}
-		}
-	private void adjustDynamicSleepTime(boolean requestSuccess) {
-		if (requestSuccess) {
-			dynamicSleepTime =
-				MIN_INITIAL_SLEEP_TIME + random.nextInt(MAX_INITIAL_SLEEP_TIME - MIN_INITIAL_SLEEP_TIME + 1);
-		} else {
-			dynamicSleepTime = Math.min(dynamicSleepTime + INCREMENT_SLEEP_TIME, MAX_SLEEP_TIME);
-		}
-	}
-
+	private void saveCourseInfo(String skillKeyword, InflearnCourseCounter inflearnCourseCounter) {
 		if (!inflearnCourseCounter.getNewCourses().isEmpty()) {
 			courseStorageService.createInflearnCourseAndInflearnJdSkill(skillKeyword,
 				inflearnCourseCounter.getNewCourses());
 			inflearnCourseCounter.resetState();
-	private void saveCourseInfo(String skillKeyword, InflearnCrawlerState state) {
-		if (!state.getNewCourses().isEmpty()) {
-			courseStorageService.createInflearnCourseAndInflearnJdSkill(skillKeyword, state.getNewCourses());
-			state.resetState();
 		}
 	}
 

--- a/module-crawler/src/main/java/kernel/jdon/crawler/inflearn/service/InflearnCrawlerService.java
+++ b/module-crawler/src/main/java/kernel/jdon/crawler/inflearn/service/InflearnCrawlerService.java
@@ -30,6 +30,11 @@ public class InflearnCrawlerService implements CrawlerService {
 	private final CourseScraperService courseScraperService;
 	private final CourseParserService courseParserService;
 	private final CourseStorageService courseStorageService;
+	private static final int MAX_COURSES_PER_KEYWORD = 3;
+	private static final int INITIAL_SLEEP_TIME = 2000;
+	private static final int MAX_SLEEP_TIME = 10000;
+	private static final int INCREMENT_SLEEP_TIME = 1000;
+	private int dynamicSleepTime = INITIAL_SLEEP_TIME;
 
 	@Transactional
 	@Override
@@ -51,7 +56,7 @@ public class InflearnCrawlerService implements CrawlerService {
 		while (inflearnCourseCounter.getSavedCourseCount() < maxCoursesPerKeyword
 			&& !lastPageDiscriminator.isLastPage()) {
 			try {
-				Thread.sleep(scrapingInflearnConfig.getSleepTimeMillis());
+				Thread.sleep(dynamicSleepTime);
 			} catch (InterruptedException e) {
 				Thread.currentThread().interrupt();
 				break;
@@ -59,21 +64,53 @@ public class InflearnCrawlerService implements CrawlerService {
 			String currentUrl = createInflearnSearchUrl(skillKeyword, pageNum);
 			log.info("currentUrl: {}", currentUrl);
 
+			boolean isSuccess = scrapeAndParsePage(currentUrl, skillKeyword, pageNum, state);
+			adjustDynamicSleepTime(isSuccess);
+
+			if (isSuccess && state.getSavedCourseCount() < MAX_COURSES_PER_KEYWORD) {
+				pageNum++;
+			}
+		}
+		saveCourseInfo(skillKeyword, state);
+	}
+
+	private boolean scrapeAndParsePage(String currentUrl, String skillKeyword, int pageNum,
+		InflearnCrawlerState state) {
+		try {
 			Elements scrapeCourseElements = courseScraperService.scrapeCourses(currentUrl);
 			int coursesCount = scrapeCourseElements.size();
 			lastPageDiscriminator.checkIfLastPageBasedOnCourseCount(coursesCount);
 
 			parseAndCreateCourses(scrapeCourseElements, currentUrl, skillKeyword, inflearnCourseCounter);
+			state.checkIfLastPageBasedOnCourseCount(coursesCount);
+			parseAndCreateCourses(scrapeCourseElements, currentUrl, skillKeyword, pageNum, state);
+			return true;
+		} catch (Exception e) {
+			log.error("페이지 처리 중 오류 발생: {}", currentUrl, e);
+			return false;
+		}
+	}
 
 			if (inflearnCourseCounter.getSavedCourseCount() < maxCoursesPerKeyword) {
 				pageNum++;
 			}
 		}
+	private void adjustDynamicSleepTime(boolean requestSuccess) {
+		if (requestSuccess) {
+			dynamicSleepTime = INITIAL_SLEEP_TIME;
+		} else {
+			dynamicSleepTime = Math.min(dynamicSleepTime + INCREMENT_SLEEP_TIME, MAX_SLEEP_TIME);
+		}
+	}
 
 		if (!inflearnCourseCounter.getNewCourses().isEmpty()) {
 			courseStorageService.createInflearnCourseAndInflearnJdSkill(skillKeyword,
 				inflearnCourseCounter.getNewCourses());
 			inflearnCourseCounter.resetState();
+	private void saveCourseInfo(String skillKeyword, InflearnCrawlerState state) {
+		if (!state.getNewCourses().isEmpty()) {
+			courseStorageService.createInflearnCourseAndInflearnJdSkill(skillKeyword, state.getNewCourses());
+			state.resetState();
 		}
 	}
 

--- a/module-crawler/src/main/java/kernel/jdon/crawler/inflearn/service/InflearnCrawlerService.java
+++ b/module-crawler/src/main/java/kernel/jdon/crawler/inflearn/service/InflearnCrawlerService.java
@@ -4,6 +4,7 @@ import static kernel.jdon.util.StringUtil.*;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Random;
 
 import org.jsoup.nodes.Element;
 import org.jsoup.select.Elements;
@@ -31,10 +32,12 @@ public class InflearnCrawlerService implements CrawlerService {
 	private final CourseParserService courseParserService;
 	private final CourseStorageService courseStorageService;
 	private static final int MAX_COURSES_PER_KEYWORD = 3;
-	private static final int INITIAL_SLEEP_TIME = 2000;
+	private static final int MIN_INITIAL_SLEEP_TIME = 1000;
+	private static final int MAX_INITIAL_SLEEP_TIME = 3000;
 	private static final int MAX_SLEEP_TIME = 10000;
 	private static final int INCREMENT_SLEEP_TIME = 1000;
-	private int dynamicSleepTime = INITIAL_SLEEP_TIME;
+	private int dynamicSleepTime = MIN_INITIAL_SLEEP_TIME;
+	private final Random random = new Random();
 
 	@Transactional
 	@Override
@@ -97,7 +100,8 @@ public class InflearnCrawlerService implements CrawlerService {
 		}
 	private void adjustDynamicSleepTime(boolean requestSuccess) {
 		if (requestSuccess) {
-			dynamicSleepTime = INITIAL_SLEEP_TIME;
+			dynamicSleepTime =
+				MIN_INITIAL_SLEEP_TIME + random.nextInt(MAX_INITIAL_SLEEP_TIME - MIN_INITIAL_SLEEP_TIME + 1);
 		} else {
 			dynamicSleepTime = Math.min(dynamicSleepTime + INCREMENT_SLEEP_TIME, MAX_SLEEP_TIME);
 		}

--- a/module-crawler/src/main/java/kernel/jdon/crawler/inflearn/service/infrastructure/DynamicSleepTimeManager.java
+++ b/module-crawler/src/main/java/kernel/jdon/crawler/inflearn/service/infrastructure/DynamicSleepTimeManager.java
@@ -1,0 +1,32 @@
+package kernel.jdon.crawler.inflearn.service.infrastructure;
+
+import java.util.Random;
+
+import kernel.jdon.crawler.config.ScrapingInflearnConfig;
+import lombok.Getter;
+
+@Getter
+public class DynamicSleepTimeManager {
+	private int dynamicSleepTime;
+	private final int minInitial;
+	private final int maxInitial;
+	private final int max;
+	private final int increment;
+	private final Random random = new Random();
+
+	public DynamicSleepTimeManager(ScrapingInflearnConfig scrapingInflearnConfig) {
+		this.minInitial = scrapingInflearnConfig.getSleep().getMinInitial();
+		this.maxInitial = scrapingInflearnConfig.getSleep().getMaxInitial();
+		this.max = scrapingInflearnConfig.getSleep().getMax();
+		this.increment = scrapingInflearnConfig.getSleep().getIncrement();
+		this.dynamicSleepTime = this.minInitial;
+	}
+
+	public void adjustSleepTime(boolean requestSuccess) {
+		if (requestSuccess) {
+			dynamicSleepTime = minInitial + random.nextInt(maxInitial - minInitial + 1);
+		} else {
+			dynamicSleepTime = Math.min(dynamicSleepTime + increment, max);
+		}
+	}
+}

--- a/module-crawler/src/main/resources/application.yml
+++ b/module-crawler/src/main/resources/application.yml
@@ -27,7 +27,11 @@ scraping:
     url: https://www.inflearn.com/courses
     max_courses_per_keyword: 3
     max_courses_per_page: 24
-    sleep_time_millis: 2000
+    sleep: # 단위 millis
+      min_initial: 1000
+      max_initial: 3000
+      max: 10000
+      increment: 1000
 
   wanted:
     url:


### PR DESCRIPTION
## 개요

### 요약
- 크롤링 요청 보낼 때의 대기 시간을 동적으로 조정했습니다.
  - 연속적으로 성공적인 요청 후 대기 시간을 줄이고, 실패한 요청이 있으면 대기 시간을 늘리는 방식을 사용했습니다.   
![image](https://github.com/Kernel360/f1-JDON-Backend/assets/86637372/8673149a-a89c-4137-a2d0-9ad62b44d118)
![image](https://github.com/Kernel360/f1-JDON-Backend/assets/86637372/bea808c3-a6c8-40df-af24-ca031f2e6554)

  - `INITIAL_SLEEP_TIME`을 무작위로 생성함으로써 클롤러 요청의 패턴을 불규칙하게 만들어 크롤러 탐지를 어렵게 바꿨습니다.
![image](https://github.com/Kernel360/f1-JDON-Backend/assets/86637372/527c1bc6-550b-4e5e-8e54-bea7854b498e)

### 변경한 부분
- `Thread.sleep(2000)` -> `Thread.sleep(dynamicSleepTime)`으로 변경하였습니다.

### 변경한 결과
- 클로링해온 결과는 같습니다.
![image](https://github.com/Kernel360/f1-JDON-Backend/assets/86637372/45d8adfd-8902-4414-98d9-91749fb9a4fa)


### 이슈

- closes: # 206

---

## PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경, 주석 변경)
- [ ] 코드 리팩토링
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 파일 혹은 폴더명 수정, 삭제
- [ ] 배포 관련