### PR TITLE
Fix: 커피챗 상세와 목록조회에서 누락된 항목을 포함하도록 수정

### DIFF
--- a/module-api/src/main/java/kernel/jdon/coffeechat/dto/response/FindCoffeeChatListResponse.java
+++ b/module-api/src/main/java/kernel/jdon/coffeechat/dto/response/FindCoffeeChatListResponse.java
@@ -31,10 +31,12 @@ public class FindCoffeeChatListResponse {
 		return FindCoffeeChatListResponse.builder()
 			.coffeeChatId(coffeeChat.getId())
 			.nickname(coffeeChat.getMember().getNickname())
+			.job((coffeeChat.getMember().getJobCategory().getName()))
 			.title(coffeeChat.getTitle())
 			.status(coffeeChat.getCoffeeChatStatus().getActiveStatus())
 			.isDeleted(coffeeChat.isDeleted())
 			.meetDate(coffeeChat.getMeetDate())
+			.createdDate(coffeeChat.getCreatedDate())
 			.totalRecruitCount(coffeeChat.getTotalRecruitCount())
 			.currentRecruitCount(coffeeChat.getCurrentRecruitCount())
 			.build();

--- a/module-api/src/main/java/kernel/jdon/coffeechat/dto/response/FindCoffeeChatResponse.java
+++ b/module-api/src/main/java/kernel/jdon/coffeechat/dto/response/FindCoffeeChatResponse.java
@@ -16,6 +16,7 @@ public class FindCoffeeChatResponse {
 
 	private Long coffeeChatId;
 	private String nickname;
+	private String job;
 	private String title;
 	private String content;
 	private Long viewCount;
@@ -27,12 +28,12 @@ public class FindCoffeeChatResponse {
 	private String openChatUrl;
 	private Long totalRecruitCount;
 	private Long currentRecruitCount;
-	private String job;
 
 	public static FindCoffeeChatResponse of(CoffeeChat coffeeChat) {
 		return FindCoffeeChatResponse.builder()
 			.coffeeChatId(coffeeChat.getId())
 			.nickname(coffeeChat.getMember().getNickname())
+			.job(String.valueOf(coffeeChat.getMember().getJobCategory().getName()))
 			.title(coffeeChat.getTitle())
 			.content(coffeeChat.getContent())
 			.viewCount(coffeeChat.getViewCount())


### PR DESCRIPTION
### 요약

커피챗 상세,목록조회 응답 Dto에 누락된 항목이 있어 추가했습니다.
### 변경한 부분

- FindCoffeeChatListResponse
  - 개설자 JobCategory와 createdDate를 포함하도록 수정
- FindCoffeeChatResponse
  - 개설자 JobCategory를 포함하도록 수정

### 이슈

- closes: #217 

---

## PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [X] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경, 주석 변경)
- [ ] 코드 리팩토링
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 파일 혹은 폴더명 수정, 삭제
- [ ] 배포 관련