### PR TITLE
Fix: 메인화면 강의데이터에 회원 별 찜 유무 항목 추가

### DIFF
--- a/module-api/src/main/java/kernel/jdon/skill/controller/SkillController.java
+++ b/module-api/src/main/java/kernel/jdon/skill/controller/SkillController.java
@@ -46,8 +46,10 @@ public class SkillController {
 
 	@GetMapping("/api/v1/skills/search")
 	public ResponseEntity<CommonResponse> getDataListBySkill(
-		@RequestParam(name = "keyword", defaultValue = "") String keyword) {
-		FindListDataBySkillResponse findListDataBySkillResponse = skillService.findDataBySkillList(keyword);
+		@RequestParam(name = "keyword", defaultValue = "") String keyword,
+		@LoginUser SessionUserInfo sessionUser) {
+		Long userId = sessionUser == null ? null : sessionUser.getId();
+		FindListDataBySkillResponse findListDataBySkillResponse = skillService.findDataBySkillList(keyword, userId);
 
 		return ResponseEntity.ok(CommonResponse.of(findListDataBySkillResponse));
 	}

--- a/module-api/src/main/java/kernel/jdon/skill/dto/object/FindLectureDto.java
+++ b/module-api/src/main/java/kernel/jdon/skill/dto/object/FindLectureDto.java
@@ -3,7 +3,6 @@ package kernel.jdon.skill.dto.object;
 import com.querydsl.core.annotations.QueryProjection;
 
 import lombok.AccessLevel;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -19,10 +18,9 @@ public class FindLectureDto {
 	private Integer price;
 	private Boolean isFavorite;
 
-	@Builder
 	@QueryProjection
 	public FindLectureDto(Long lectureId, String title, String lectureUrl, String imageUrl, String instructor,
-		Long studentCount, Integer price) {
+		Long studentCount, Integer price, boolean isFavorite) {
 		this.lectureId = lectureId;
 		this.title = title;
 		this.lectureUrl = lectureUrl;
@@ -30,6 +28,6 @@ public class FindLectureDto {
 		this.instructor = instructor;
 		this.studentCount = studentCount;
 		this.price = price;
-		this.isFavorite = false; // todo 이슈번호 #189에서 수정
+		this.isFavorite = isFavorite;
 	}
 }

--- a/module-api/src/main/java/kernel/jdon/skill/repository/SkillRepositoryCustom.java
+++ b/module-api/src/main/java/kernel/jdon/skill/repository/SkillRepositoryCustom.java
@@ -11,5 +11,5 @@ public interface SkillRepositoryCustom {
 	List<FindHotSkillDto> findHotSkillList();
 	List<FindMemberSkillDto> findMemberSkillList(Long memberId);
 	List<FindWantedJdDto> findWantedJdListBySkill(String keyword);
-	List<FindLectureDto> findInflearnLectureListBySkill(String keyword);
+	List<FindLectureDto> findInflearnLectureListBySkill(String keyword, Long userId);
 }

--- a/module-api/src/main/java/kernel/jdon/skill/service/SkillService.java
+++ b/module-api/src/main/java/kernel/jdon/skill/service/SkillService.java
@@ -44,11 +44,11 @@ public class SkillService {
 		return new FindListJobCategorySkillResponse(findJobCategorySkillList);
 	}
 
-	public FindListDataBySkillResponse findDataBySkillList(String keyword) {
+	public FindListDataBySkillResponse findDataBySkillList(String keyword, Long userId) {
 		keyword = hasText(keyword) ? keyword
 								   : skillRepository.findHotSkillList().get(0).getKeyword();
 		List<FindWantedJdDto> findWantedJdList = skillRepository.findWantedJdListBySkill(keyword);
-		List<FindLectureDto> findLectureList = skillRepository.findInflearnLectureListBySkill(keyword);
+		List<FindLectureDto> findLectureList = skillRepository.findInflearnLectureListBySkill(keyword, userId);
 
 		return FindListDataBySkillResponse.of(keyword, findLectureList, findWantedJdList);
 	}


### PR DESCRIPTION
## 개요

### 요약
- 기술 스택 기반 원티드JD, 인프런 강의 데이터 조회 API의 인프런 강의데이터에 회원 별 찜 유무 항목을 반환하도록 수정했습니다.

### 변경한 부분
- 동적쿼리로 구현하였습니다.
- 로그인하지 않은 경우 SessionUserInfo가 null -> userId가 null일 때 SkillRepositoryImpl에서 isFavorite를 false로 반환하도록 구현했습니다.
- 로그인 한 경우 SkillRepositoryImpl의 isFavoriteLectureByMember 메서드를 통해서 매개변수 userId로 favorite 테이블의 매핑되는 강의 데이터가 존재한다면 true를 반환하도록 구현했습니다.

### 변경한 결과
- 로그인하지 않았다면 isFavorite 항목이 false로 반환됩니다.
- 로그인 상태일 때 찜 한 강의는 true로 반환됩니다. 

### 로그인 하지 않은 경우
#### isFavorite 항목이 false로 반환됩니다.
<img width="715" alt="image" src="https://github.com/Kernel360/f1-JDON-Backend/assets/59242594/0ce4361f-539d-4f25-8e8c-9e7d2c82fbd6">

### 로그인 상태인 경우
#### 찜한 회원 및 강의(회원 pk가 2인 회원이 강의 id 33인 데이터를 찜한 내역)
![image](https://github.com/Kernel360/f1-JDON-Backend/assets/59242594/2773f45c-e209-4266-8c56-4f8a6ff43cca)

#### 강의 id 33에만 true로 들어갑니다.
<img width="613" alt="image" src="https://github.com/Kernel360/f1-JDON-Backend/assets/59242594/3fc3737a-ee95-4e86-a03c-dde943a93af3">



### 이슈

- closes: #199  #189 

---

## PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경, 주석 변경)
- [ ] 코드 리팩토링
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 파일 혹은 폴더명 수정, 삭제
- [ ] 배포 관련