### PR TITLE
Feature: 내가 신청한 커피챗 목록 조회 API

### DIFF
--- a/module-api/src/main/java/kernel/jdon/coffeechat/controller/CoffeeChatController.java
+++ b/module-api/src/main/java/kernel/jdon/coffeechat/controller/CoffeeChatController.java
@@ -59,7 +59,7 @@ public class CoffeeChatController {
 
 		CustomPageResponse<FindCoffeeChatListResponse> response = coffeeChatService.findGuestCoffeeChatList(
 			sessionUser.getId(), pageable);
-		
+
 		return ResponseEntity.ok(CommonResponse.of(response));
 	}
 

--- a/module-api/src/main/java/kernel/jdon/coffeechat/controller/CoffeeChatController.java
+++ b/module-api/src/main/java/kernel/jdon/coffeechat/controller/CoffeeChatController.java
@@ -55,11 +55,11 @@ public class CoffeeChatController {
 	@GetMapping("/api/v1/coffeechats/guest")
 	public ResponseEntity<CommonResponse> getGuestCoffeeChatList(
 		@LoginUser SessionUserInfo sessionUser,
-		@PageableDefault(size = 12) Pageable pageable
-	) {
+		@PageableDefault(size = 12) Pageable pageable) {
+
 		CustomPageResponse<FindCoffeeChatListResponse> response = coffeeChatService.findGuestCoffeeChatList(
 			sessionUser.getId(), pageable);
-
+		
 		return ResponseEntity.ok(CommonResponse.of(response));
 	}
 

--- a/module-api/src/main/java/kernel/jdon/coffeechat/controller/CoffeeChatController.java
+++ b/module-api/src/main/java/kernel/jdon/coffeechat/controller/CoffeeChatController.java
@@ -53,24 +53,14 @@ public class CoffeeChatController {
 	}
 
 	@GetMapping("/api/v1/coffeechats/guest")
-	public ResponseEntity<CommonResponse> getGuestCoffeeChatList() {
-		List<FindCoffeeChatListResponse> list = new ArrayList<>();
-		for (long i = 10; i <= 20; i++) {
-			FindCoffeeChatListResponse response = FindCoffeeChatListResponse.builder()
-				.coffeeChatId(i)
-				.nickname("김영한" + i)
-				.job("backend")
-				.title("주니어 백엔드 개발자를 대상으로 커피챗을 엽니다." + i)
-				.status("모집중")
-				.meetDate(LocalDateTime.now().plusMinutes(i))
-				.createdDate(LocalDateTime.now())
-				.currentRecruitCount(5L)
-				.totalRecruitCount(i)
-				.build();
-			list.add(response);
-		}
+	public ResponseEntity<CommonResponse> getGuestCoffeeChatList(
+		@LoginUser SessionUserInfo sessionUser,
+		@PageableDefault(size = 12) Pageable pageable
+	) {
+		CustomPageResponse<FindCoffeeChatListResponse> response = coffeeChatService.findGuestCoffeeChatList(
+			sessionUser.getId(), pageable);
 
-		return ResponseEntity.ok(CommonResponse.of(list));
+		return ResponseEntity.ok(CommonResponse.of(response));
 	}
 
 	@GetMapping("/api/v1/coffeechats/host")

--- a/module-api/src/main/java/kernel/jdon/coffeechat/dto/response/FindCoffeeChatResponse.java
+++ b/module-api/src/main/java/kernel/jdon/coffeechat/dto/response/FindCoffeeChatResponse.java
@@ -33,7 +33,7 @@ public class FindCoffeeChatResponse {
 		return FindCoffeeChatResponse.builder()
 			.coffeeChatId(coffeeChat.getId())
 			.nickname(coffeeChat.getMember().getNickname())
-			.job(String.valueOf(coffeeChat.getMember().getJobCategory().getName()))
+			.job(coffeeChat.getMember().getJobCategory().getName())
 			.title(coffeeChat.getTitle())
 			.content(coffeeChat.getContent())
 			.viewCount(coffeeChat.getViewCount())

--- a/module-api/src/main/java/kernel/jdon/coffeechat/repository/CoffeeChatRepository.java
+++ b/module-api/src/main/java/kernel/jdon/coffeechat/repository/CoffeeChatRepository.java
@@ -8,13 +8,10 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import kernel.jdon.coffeechat.domain.CoffeeChat;
-import kernel.jdon.coffeechat.domain.CoffeeChatActiveStatus;
 
 public interface CoffeeChatRepository extends CoffeeChatDomainRepository {
 
 	Optional<CoffeeChat> findByIdAndIsDeletedFalse(Long id);
-
-	Optional<CoffeeChat> findByIdAndCoffeeChatStatus(Long id, CoffeeChatActiveStatus status);
 
 	Page<CoffeeChat> findAllByMemberIdAndIsDeletedFalse(Long id, Pageable pageable);
 

--- a/module-api/src/main/java/kernel/jdon/coffeechat/repository/CoffeeChatRepository.java
+++ b/module-api/src/main/java/kernel/jdon/coffeechat/repository/CoffeeChatRepository.java
@@ -4,8 +4,6 @@ import java.util.Optional;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
 import kernel.jdon.coffeechat.domain.CoffeeChat;
 
@@ -15,6 +13,4 @@ public interface CoffeeChatRepository extends CoffeeChatDomainRepository {
 
 	Page<CoffeeChat> findAllByMemberIdAndIsDeletedFalse(Long id, Pageable pageable);
 
-	@Query("SELECT cc FROM CoffeeChat cc JOIN FETCH cc.member m JOIN FETCH m.jobCategory JOIN FETCH cc.coffeeChatMemberList ccm WHERE ccm.member.id = :memberId")
-	Page<CoffeeChat> findAllByMemberId(@Param("memberId") Long memberId, Pageable pageable);
 }

--- a/module-api/src/main/java/kernel/jdon/coffeechat/repository/CoffeeChatRepository.java
+++ b/module-api/src/main/java/kernel/jdon/coffeechat/repository/CoffeeChatRepository.java
@@ -4,6 +4,8 @@ import java.util.Optional;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import kernel.jdon.coffeechat.domain.CoffeeChat;
 import kernel.jdon.coffeechat.domain.CoffeeChatActiveStatus;
@@ -15,4 +17,7 @@ public interface CoffeeChatRepository extends CoffeeChatDomainRepository {
 	Optional<CoffeeChat> findByIdAndCoffeeChatStatus(Long id, CoffeeChatActiveStatus status);
 
 	Page<CoffeeChat> findAllByMemberIdAndIsDeletedFalse(Long id, Pageable pageable);
+
+	@Query("SELECT cc FROM CoffeeChat cc JOIN cc.coffeeChatMemberList ccm WHERE ccm.member.id = :memberId")
+	Page<CoffeeChat> findAllByMemberId(@Param("memberId") Long memberId, Pageable pageable);
 }

--- a/module-api/src/main/java/kernel/jdon/coffeechat/repository/CoffeeChatRepository.java
+++ b/module-api/src/main/java/kernel/jdon/coffeechat/repository/CoffeeChatRepository.java
@@ -18,6 +18,6 @@ public interface CoffeeChatRepository extends CoffeeChatDomainRepository {
 
 	Page<CoffeeChat> findAllByMemberIdAndIsDeletedFalse(Long id, Pageable pageable);
 
-	@Query("SELECT cc FROM CoffeeChat cc JOIN cc.coffeeChatMemberList ccm WHERE ccm.member.id = :memberId")
+	@Query("SELECT cc FROM CoffeeChat cc JOIN FETCH cc.member m JOIN FETCH m.jobCategory JOIN FETCH cc.coffeeChatMemberList ccm WHERE ccm.member.id = :memberId")
 	Page<CoffeeChat> findAllByMemberId(@Param("memberId") Long memberId, Pageable pageable);
 }

--- a/module-api/src/main/java/kernel/jdon/coffeechat/service/CoffeeChatService.java
+++ b/module-api/src/main/java/kernel/jdon/coffeechat/service/CoffeeChatService.java
@@ -51,6 +51,7 @@ public class CoffeeChatService {
 	}
 
 	private Member findMember(Long memberId) {
+		
 		return memberRepository.findById(memberId)
 			.orElseThrow(() -> new ApiException(MemberErrorCode.NOT_FOUND_MEMBER));
 	}
@@ -73,6 +74,14 @@ public class CoffeeChatService {
 			.map(FindCoffeeChatListResponse::of);
 
 		return CustomPageResponse.of(findCoffeeChatPage);
+	}
+
+	public CustomPageResponse findGuestCoffeeChatList(Long memberId, Pageable pageable) {
+		Page<FindCoffeeChatListResponse> guestCoffeeChatPage = coffeeChatRepository.findAllByMemberId(
+				memberId, pageable)
+			.map(FindCoffeeChatListResponse::of);
+
+		return CustomPageResponse.of(guestCoffeeChatPage);
 	}
 
 	@Transactional

--- a/module-api/src/main/java/kernel/jdon/coffeechat/service/CoffeeChatService.java
+++ b/module-api/src/main/java/kernel/jdon/coffeechat/service/CoffeeChatService.java
@@ -17,6 +17,8 @@ import kernel.jdon.coffeechat.dto.response.FindCoffeeChatResponse;
 import kernel.jdon.coffeechat.dto.response.UpdateCoffeeChatResponse;
 import kernel.jdon.coffeechat.error.CoffeeChatErrorCode;
 import kernel.jdon.coffeechat.repository.CoffeeChatRepository;
+import kernel.jdon.coffeechatmember.domain.CoffeeChatMember;
+import kernel.jdon.coffeechatmember.repsitory.CoffeeChatMemberRepository;
 import kernel.jdon.global.exception.ApiException;
 import kernel.jdon.global.page.CustomPageResponse;
 import kernel.jdon.member.domain.Member;
@@ -33,6 +35,7 @@ public class CoffeeChatService {
 
 	private final CoffeeChatRepository coffeeChatRepository;
 	private final MemberRepository memberRepository;
+	private final CoffeeChatMemberRepository coffeeChatMemberRepository;
 
 	private CoffeeChat findExistCoffeeChat(Long coffeeChatId) {
 
@@ -51,7 +54,7 @@ public class CoffeeChatService {
 	}
 
 	private Member findMember(Long memberId) {
-		
+
 		return memberRepository.findById(memberId)
 			.orElseThrow(() -> new ApiException(MemberErrorCode.NOT_FOUND_MEMBER));
 	}
@@ -77,8 +80,9 @@ public class CoffeeChatService {
 	}
 
 	public CustomPageResponse findGuestCoffeeChatList(Long memberId, Pageable pageable) {
-		Page<FindCoffeeChatListResponse> guestCoffeeChatPage = coffeeChatRepository.findAllByMemberId(
+		Page<FindCoffeeChatListResponse> guestCoffeeChatPage = coffeeChatMemberRepository.findAllByMemberId(
 				memberId, pageable)
+			.map(CoffeeChatMember::getCoffeeChat)
 			.map(FindCoffeeChatListResponse::of);
 
 		return CustomPageResponse.of(guestCoffeeChatPage);

--- a/module-api/src/main/java/kernel/jdon/coffeechatmember/repsitory/CoffeeChatMemberRepository.java
+++ b/module-api/src/main/java/kernel/jdon/coffeechatmember/repsitory/CoffeeChatMemberRepository.java
@@ -1,6 +1,15 @@
 package kernel.jdon.coffeechatmember.repsitory;
 
-import kernel.jdon.coffeechat.repository.CoffeeChatDomainRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.Query;
 
-public interface CoffeeChatMemberRepository extends CoffeeChatDomainRepository {
+import kernel.jdon.coffeechatmember.domain.CoffeeChatMember;
+import kernel.jdon.coffeechatmember.repository.CoffeeChatMemberDomainRepository;
+
+public interface CoffeeChatMemberRepository extends CoffeeChatMemberDomainRepository {
+
+	@Query("select ccm from CoffeeChatMember ccm join fetch ccm.coffeeChat cc join fetch cc.member m join fetch m.jobCategory where ccm.member.id = :memberId")
+	Page<CoffeeChatMember> findAllByMemberId(Long memberId, Pageable pageable);
+
 }


### PR DESCRIPTION
### 요약

로그인한 유저가 신청한 커피챗 목록을 조회하는 API를 구현했습니다.
CoffeeChatMember 연결엔터티 Repositroy를 통해 조회하며
N+1 해결을 위해 페치조인을 통해 한번의 쿼리로 조회하도록 했습니다.

### 변경한 부분

- CoffeeChatMemberRepository
  - CoffeeChatMemberdomainRepository를 상속 받도록 수정했습니다
  - N+1 해결을 위해 페치조인을 통해 한번의 쿼리로 조회하도록 했습니다.
- 그 외 사용하지 않는 쿼리메소드나 불필요한 파싱등을 제외했습니다

### 변경한 결과
lazy로딩하던 엔터티들을 페치조인을 통해 한번에 조회합니다.
![image](https://github.com/Kernel360/f1-JDON-Backend/assets/111513287/963d0326-c031-4bbc-b467-b21c49abc07b)

### 이슈

- closes: #202 

---

## PR 유형

어떤 변경 사항이 있나요?

- [X] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경, 주석 변경)
- [X] 코드 리팩토링
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 파일 혹은 폴더명 수정, 삭제
- [ ] 배포 관련