### PR TITLE
Fix: userId 고정시켰던 api 일부 되돌림

### DIFF
--- a/module-api/src/main/java/kernel/jdon/coffeechat/controller/CoffeeChatController.java
+++ b/module-api/src/main/java/kernel/jdon/coffeechat/controller/CoffeeChatController.java
@@ -46,7 +46,7 @@ public class CoffeeChatController {
 	public ResponseEntity<CommonResponse> save(
 		@RequestBody CreateCoffeeChatRequest request,
 		@LoginUser SessionUserInfo sessionUser) {
-		CreateCoffeeChatResponse response = coffeeChatService.create(request, 2L); // sessionUser.getId());
+		CreateCoffeeChatResponse response = coffeeChatService.create(request,  sessionUser.getId());
 		URI uri = URI.create("/v1/coffeechats/" + response.getCoffeeChatId());
 
 		return ResponseEntity.created(uri).body(CommonResponse.of(response));

--- a/module-api/src/main/java/kernel/jdon/config/auth/OAuth2SecurityConfig.java
+++ b/module-api/src/main/java/kernel/jdon/config/auth/OAuth2SecurityConfig.java
@@ -6,6 +6,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.web.cors.CorsConfiguration;
 
@@ -40,9 +41,9 @@ public class OAuth2SecurityConfig {
 		http.exceptionHandling(exceptionConfig -> exceptionConfig
 			.authenticationEntryPoint(jdonAuthExceptionHandler)
 			.accessDeniedHandler(jdonAuthExceptionHandler));
-		http.csrf().disable();
+		http.csrf(AbstractHttpConfigurer::disable);
 		http.authorizeHttpRequests(config -> config
-			// .requestMatchers("/api/v1/member").hasAnyRole("USER")
+			.requestMatchers("/api/v1/member").hasAnyRole("USER")
 			.requestMatchers("api/**").permitAll()
 			.anyRequest().permitAll());
 		http.oauth2Login(oauth2Configurer -> oauth2Configurer

--- a/module-api/src/main/java/kernel/jdon/member/controller/MemberController.java
+++ b/module-api/src/main/java/kernel/jdon/member/controller/MemberController.java
@@ -27,7 +27,7 @@ public class MemberController {
 
 	@GetMapping("/api/v1/member")
 	public ResponseEntity<CommonResponse> get(@LoginUser SessionUserInfo sessionUser) {
-		Long memberId = /*sessionUser.getId();*/2L;
+		Long memberId = sessionUser.getId();
 		FindMemberResponse findMemberResponse = memberService.find(memberId);
 
 		return ResponseEntity.ok(CommonResponse.of(findMemberResponse));
@@ -36,7 +36,7 @@ public class MemberController {
 	@PutMapping("/api/v1/member")
 	public ResponseEntity<CommonResponse> modify(@LoginUser SessionUserInfo user,
 		@RequestBody UpdateMemberRequest updateMemberRequest) {
-		UpdateMemberResponse updateMemberResponse = memberService.update(/*user.getId()*/2L, updateMemberRequest);
+		UpdateMemberResponse updateMemberResponse = memberService.update(user.getId(), updateMemberRequest);
 
 		return ResponseEntity.ok(CommonResponse.of(updateMemberResponse));
 	}

--- a/module-api/src/main/java/kernel/jdon/skill/controller/SkillController.java
+++ b/module-api/src/main/java/kernel/jdon/skill/controller/SkillController.java
@@ -30,7 +30,7 @@ public class SkillController {
 
 	@GetMapping("/api/v1/skills/member")
 	public ResponseEntity<CommonResponse> getMemberSkillList(@LoginUser SessionUserInfo sessionUser) {
-		Long memberId = /*sessionUser.getId()*/2L;
+		Long memberId = sessionUser.getId();
 		FindListMemberSkillResponse findMemberSkillList = skillService.findMemberSkillList(memberId);
 
 		return ResponseEntity.ok(CommonResponse.of(findMemberSkillList));


### PR DESCRIPTION
## 개요

### 요약

### 변경한 부분
- favorite 도메인을 제외한 다른 api를 원래대로 sessionUserInfo를 사용하도록 되돌렸습니다. 

### 변경한 결과

### 이슈

- closes: #

---

## PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경, 주석 변경)
- [ ] 코드 리팩토링
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 파일 혹은 폴더명 수정, 삭제
- [ ] 배포 관련