### PR TITLE
BugFix: 커피챗 중복 참여신청 시 예외처리

### DIFF
--- a/module-api/src/main/java/kernel/jdon/coffeechat/controller/CoffeeChatController.java
+++ b/module-api/src/main/java/kernel/jdon/coffeechat/controller/CoffeeChatController.java
@@ -46,7 +46,7 @@ public class CoffeeChatController {
 	public ResponseEntity<CommonResponse> save(
 		@RequestBody CreateCoffeeChatRequest request,
 		@LoginUser SessionUserInfo sessionUser) {
-		CreateCoffeeChatResponse response = coffeeChatService.create(request,  sessionUser.getId());
+		CreateCoffeeChatResponse response = coffeeChatService.create(request, sessionUser.getId());
 		URI uri = URI.create("/v1/coffeechats/" + response.getCoffeeChatId());
 
 		return ResponseEntity.created(uri).body(CommonResponse.of(response));
@@ -69,7 +69,7 @@ public class CoffeeChatController {
 		@PageableDefault(size = 12) Pageable pageable) {
 
 		CustomPageResponse<FindCoffeeChatListResponse> response = coffeeChatService.findHostCoffeeChatList(
-			/*sessionUser.getId()*/2L, pageable);
+			sessionUser.getId(), pageable);
 
 		return ResponseEntity.ok().body(CommonResponse.of(response));
 	}
@@ -117,7 +117,7 @@ public class CoffeeChatController {
 		@PathVariable(name = "id") Long coffeeChatId,
 		@LoginUser SessionUserInfo sessionUser) {
 
-		ApplyCoffeeChatResponse response = coffeeChatService.apply(coffeeChatId, /*sessionUser.getId()*/2L);
+		ApplyCoffeeChatResponse response = coffeeChatService.apply(coffeeChatId, sessionUser.getId());
 
 		return ResponseEntity.ok().body(CommonResponse.of(response));
 	}

--- a/module-api/src/main/java/kernel/jdon/coffeechat/error/CoffeeChatErrorCode.java
+++ b/module-api/src/main/java/kernel/jdon/coffeechat/error/CoffeeChatErrorCode.java
@@ -10,10 +10,10 @@ public enum CoffeeChatErrorCode implements ErrorCode {
 	NOT_FOUND_COFFEECHAT(HttpStatus.NOT_FOUND, "존재하지 않는 커피챗 입니다."),
 	NOT_OPEN_COFFEECHAT(HttpStatus.BAD_REQUEST, "모집중이 아닌 커피챗 입니다."),
 	INVALID_RECRUIT_COUNT(HttpStatus.BAD_REQUEST, "유효하지 않은 모집인원 입니다."),
-	CAN_NOT_JOIN_OWN_COFFEECHAT(HttpStatus.BAD_REQUEST, "본인이 개설한 커피챗에 참여할 수 없습니다."),
-	EXPIRED_COFFEECHAT(HttpStatus.BAD_REQUEST, "지난 일자의 커피챗은 수정할 수 없습니다."),
+	CAN_NOT_JOIN_OWN_COFFEECHAT(HttpStatus.CONFLICT, "본인이 개설한 커피챗에 참여할 수 없습니다."),
+	EXPIRED_COFFEECHAT(HttpStatus.CONFLICT, "지난 일자의 커피챗은 수정할 수 없습니다."),
 	MEET_DATE_ISBEFORE_NOW(HttpStatus.BAD_REQUEST, "지금보다 이전 시점으로 설정할 수 없습니다."),
-	ALREADY_JOINED_COFFEECHAT(HttpStatus.BAD_REQUEST, "이미 참여한 커피챗 입니다.");
+	ALREADY_JOINED_COFFEECHAT(HttpStatus.CONFLICT, "이미 참여한 커피챗 입니다.");
 
 	private final HttpStatus httpStatus;
 	private final String message;

--- a/module-api/src/main/java/kernel/jdon/coffeechat/error/CoffeeChatErrorCode.java
+++ b/module-api/src/main/java/kernel/jdon/coffeechat/error/CoffeeChatErrorCode.java
@@ -12,7 +12,9 @@ public enum CoffeeChatErrorCode implements ErrorCode {
 	INVALID_RECRUIT_COUNT(HttpStatus.BAD_REQUEST, "유효하지 않은 모집인원 입니다."),
 	CAN_NOT_JOIN_OWN_COFFEECHAT(HttpStatus.BAD_REQUEST, "본인이 개설한 커피챗에 참여할 수 없습니다."),
 	EXPIRED_COFFEECHAT(HttpStatus.BAD_REQUEST, "지난 일자의 커피챗은 수정할 수 없습니다."),
-	MEET_DATE_ISBEFORE_NOW(HttpStatus.BAD_REQUEST, "지금보다 이전 시점으로 설정할 수 없습니다.");
+	MEET_DATE_ISBEFORE_NOW(HttpStatus.BAD_REQUEST, "지금보다 이전 시점으로 설정할 수 없습니다."),
+	ALREADY_JOINED_COFFEECHAT(HttpStatus.BAD_REQUEST, "이미 참여한 커피챗 입니다.");
+
 	private final HttpStatus httpStatus;
 	private final String message;
 

--- a/module-api/src/main/java/kernel/jdon/coffeechat/service/CoffeeChatService.java
+++ b/module-api/src/main/java/kernel/jdon/coffeechat/service/CoffeeChatService.java
@@ -101,10 +101,21 @@ public class CoffeeChatService {
 		CoffeeChat findCoffeeChat = findExistAndOpenCoffeeChat(coffeeChatId);
 		Member findMember = findMember(memberId);
 
-		checkIfMemberIsHost(findMember, findCoffeeChat);
+		validateApplyRequest(findMember, findCoffeeChat);
 		findCoffeeChat.addCoffeeChatMember(findMember);
 
 		return ApplyCoffeeChatResponse.of(findCoffeeChat.getId());
+	}
+
+	private void validateApplyRequest(Member findMember, CoffeeChat findCoffeeChat) {
+		checkIfMemberIsHost(findMember, findCoffeeChat);
+		checkIfAlreadyJoined(findMember, findCoffeeChat);
+	}
+
+	private void checkIfAlreadyJoined(Member findMember, CoffeeChat findCoffeeChat) {
+		if (coffeeChatMemberRepository.existsByCoffeeChatIdAndMemberId(findCoffeeChat.getId(), findMember.getId())) {
+			throw new ApiException(CoffeeChatErrorCode.ALREADY_JOINED_COFFEECHAT);
+		}
 	}
 
 	private void checkIfMemberIsHost(Member findMember, CoffeeChat findCoffeeChat) {

--- a/module-api/src/main/java/kernel/jdon/coffeechatmember/repsitory/CoffeeChatMemberRepository.java
+++ b/module-api/src/main/java/kernel/jdon/coffeechatmember/repsitory/CoffeeChatMemberRepository.java
@@ -12,4 +12,6 @@ public interface CoffeeChatMemberRepository extends CoffeeChatMemberDomainReposi
 	@Query("select ccm from CoffeeChatMember ccm join fetch ccm.coffeeChat cc join fetch cc.member m join fetch m.jobCategory where ccm.member.id = :memberId")
 	Page<CoffeeChatMember> findAllByMemberId(Long memberId, Pageable pageable);
 
+	boolean existsByCoffeeChatIdAndMemberId(Long coffeeChatId, Long memberId);
+
 }


### PR DESCRIPTION
### 요약

커피챗 신청시 이미 참여한 사람이 신청하는 경우 예외처리

### 변경한 부분

처음엔 메모리에서 객체그래프 탐색을 통해 coffeeChat이 갖고 있는 참여자 목록에 신청자 엔터티가 존재하는지 확인하려고 했으나
커피챗 참여자가 많을수록 모두 메모리에 올려야 하므로 메모리 사용량이 증가할 수 있습니다.

exist 질의를 통해 메모리 사용량을 최소화 하면서 필요한 정보만 확인하도록 했습니다.

- CoffeeChatMemberRepository
  - 기존 참여여부 질의를 위해 쿼리메소드 추가
  
- CoffeeChatService
  - apply 메서드에서 검증로직이 늘어남에 따라 validateApplyRequest 하나의 메서드로 통합했습니다
  - 이미 참여한 커피챗일 경우 예외를 반환합니다
### 변경한 결과
이미 참여한 커피챗에 참여신청시 예외가 발생합니다
![image](https://github.com/Kernel360/f1-JDON-Backend/assets/111513287/fe186dca-e8ee-4e58-a931-db6696b3fc4b)



### 이슈

- closes: #234 

---

## PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [X] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경, 주석 변경)
- [ ] 코드 리팩토링
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 파일 혹은 폴더명 수정, 삭제
- [ ] 배포 관련