### PR TITLE
Fix: 인프런 강의 url 상세페이지가 담기도록 수정

### DIFF
--- a/module-crawler/src/main/java/kernel/jdon/crawler/config/ScrapingInflearnConfig.java
+++ b/module-crawler/src/main/java/kernel/jdon/crawler/config/ScrapingInflearnConfig.java
@@ -9,6 +9,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 @ConfigurationProperties(prefix = "scraping.inflearn")
 public class ScrapingInflearnConfig {
+	private final String detailUrlPrefix;
 	private final String url;
 	private final int maxCoursesPerKeyword;
 	private final int maxCoursesPerPage;

--- a/module-crawler/src/main/java/kernel/jdon/crawler/inflearn/service/CourseParserService.java
+++ b/module-crawler/src/main/java/kernel/jdon/crawler/inflearn/service/CourseParserService.java
@@ -4,6 +4,7 @@ import org.jsoup.nodes.Element;
 import org.jsoup.select.Elements;
 import org.springframework.stereotype.Service;
 
+import kernel.jdon.crawler.config.ScrapingInflearnConfig;
 import kernel.jdon.crawler.inflearn.converter.EntityConverter;
 import kernel.jdon.crawler.inflearn.util.SkillStandardizer;
 import kernel.jdon.inflearncourse.domain.InflearnCourse;
@@ -14,11 +15,14 @@ import lombok.RequiredArgsConstructor;
 public class CourseParserService {
 
 	private final CourseKeywordAnalysisService courseKeywordAnalysisService;
+	private final ScrapingInflearnConfig scrapingInflearnConfig;
 
-	protected InflearnCourse parseCourse(Element courseElement, String lectureUrl, String skillKeyword) {
+	protected InflearnCourse parseCourse(Element courseElement, String skillKeyword) {
 		Long courseId = Long.parseLong(courseElement.attr("data-productId"));
 		String title = getText(courseElement, "div.course_title");
 		String description = getText(courseElement, "p.course_description");
+		String relativeLecturePath = courseElement.select("a.course_card_front").attr("href");
+		String lectureUrl = scrapingInflearnConfig.getDetailUrlPrefix() + relativeLecturePath;
 
 		if (!courseKeywordAnalysisService.isKeywordPresentInTitleAndDescription(title, description,
 			SkillStandardizer.standardize(skillKeyword))) {

--- a/module-crawler/src/main/java/kernel/jdon/crawler/inflearn/service/InflearnCrawlerService.java
+++ b/module-crawler/src/main/java/kernel/jdon/crawler/inflearn/service/InflearnCrawlerService.java
@@ -117,7 +117,7 @@ public class InflearnCrawlerService implements CrawlerService {
 				break;
 			}
 
-			InflearnCourse parsedCourse = courseParserService.parseCourse(courseElement, lectureUrl, skillKeyword);
+			InflearnCourse parsedCourse = courseParserService.parseCourse(courseElement, skillKeyword);
 
 			if (parsedCourse != null) {
 				inflearnCourseCounter.addNewCourse(parsedCourse);

--- a/module-crawler/src/main/resources/application.yml
+++ b/module-crawler/src/main/resources/application.yml
@@ -25,6 +25,7 @@ decorator:
 scraping:
   inflearn:
     url: https://www.inflearn.com/courses
+    detail_url_prefix: https://www.inflearn.com
     max_courses_per_keyword: 3
     max_courses_per_page: 24
     sleep: # 단위 millis


### PR DESCRIPTION
## 개요

### 요약
- 인프런 강의 url이 목록 페이지로 들어가고 있어서 상세페이지 url이 제대로 들어가도록 수정했습니다.

### 변경한 부분

### 변경한 결과
![image](https://github.com/Kernel360/f1-JDON-Backend/assets/86637372/16cb256e-8743-4f4b-840b-32bfbce2e640)

### 이슈

- closes: #240 

---

## PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경, 주석 변경)
- [ ] 코드 리팩토링
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 파일 혹은 폴더명 수정, 삭제
- [ ] 배포 관련