### PR TITLE
Fix: 마지막 마지막 로그인 datetime DB에 업데이트 하도록 수정

### DIFF
--- a/module-api/src/main/java/kernel/jdon/auth/service/JdonOAuth2UserService.java
+++ b/module-api/src/main/java/kernel/jdon/auth/service/JdonOAuth2UserService.java
@@ -32,6 +32,7 @@ public class JdonOAuth2UserService extends DefaultOAuth2UserService {
 	private final MemberRepository memberRepository;
 	private final HttpSession httpSession;
 
+	@Transactional
 	@Override
 	public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
 		OAuth2User user = super.loadUser(userRequest);
@@ -53,11 +54,11 @@ public class JdonOAuth2UserService extends DefaultOAuth2UserService {
 		if (findMember != null && findMember.isActiveMember()) {
 			checkRightSocialProvider(findMember, userInfo.getSocialProvider());
 			httpSession.setAttribute("USER", SessionUserInfo.of(findMember, userInfo));
+			findMember.updateLastLoginDate();
 			authorities = List.of(new SimpleGrantedAuthority("ROLE_USER"));
 		} else {
 			authorities = List.of(new SimpleGrantedAuthority("ROLE_TEMPORARY_USER"));
 		}
-		log.info("email: {}", userInfo.getEmail());
 		return new JdonOAuth2User(authorities, user.getAttributes(), getUserNameAttributeName(userRequest),
 			userInfo.getEmail(), userInfo.getSocialProvider());
 	}

--- a/module-api/src/main/java/kernel/jdon/config/auth/JdonOAuth2AuthenticationSuccessHandler.java
+++ b/module-api/src/main/java/kernel/jdon/config/auth/JdonOAuth2AuthenticationSuccessHandler.java
@@ -32,7 +32,6 @@ public class JdonOAuth2AuthenticationSuccessHandler implements AuthenticationSuc
         if (isTemporaryUser(jdonOAuth2User)) {
             String query = createUserInfoString(jdonOAuth2User.getEmail(), jdonOAuth2User.getSocialProviderType());
             String encodedQueryString = createEncryptQueryString(query);;
-            log.info("encodedQuery: {}", encodedQueryString);
             response.sendRedirect(joinToString(loginRedirectUrlConfig.getSuccess().getGuest(), encodedQueryString));
         } else {
             response.sendRedirect(loginRedirectUrlConfig.getSuccess().getMember());

--- a/module-api/src/main/resources/application-dev.yml
+++ b/module-api/src/main/resources/application-dev.yml
@@ -63,4 +63,4 @@ redirect-url:
       member: http://localhost:3000/oauth/login/success
       guest: http://localhost:3000/oauth/info?
   logout:
-    success: http://localhost:3000/main
+    success: http://localhost:3000

--- a/module-api/src/main/resources/application-local.yml
+++ b/module-api/src/main/resources/application-local.yml
@@ -63,4 +63,4 @@ redirect-url:
       member: http://localhost:3000/oauth/login/success
       guest: http://localhost:3000/oauth/info?
   logout:
-    success: http://localhost:3000/main
+    success: http://localhost:3000

--- a/module-api/src/main/resources/application-prod.yml
+++ b/module-api/src/main/resources/application-prod.yml
@@ -63,4 +63,4 @@ redirect-url:
       member: https://jdon.kr/oauth/login/success
       guest: https://jdon.kr/oauth/info?
   logout:
-    success: https://jdon.kr/main
+    success: https://jdon.kr

--- a/module-domain/src/main/java/kernel/jdon/member/domain/Member.java
+++ b/module-domain/src/main/java/kernel/jdon/member/domain/Member.java
@@ -122,4 +122,8 @@ public class Member {
 		this.accountStatus = MemberAccountStatus.WITHDRAW;
 		this.withdrawDate = LocalDateTime.now();
 	}
+
+	public void updateLastLoginDate() {
+		this.lastLoginDate = LocalDateTime.now();
+	}
 }


### PR DESCRIPTION
## 개요

### 요약
- [x] 로그인했을 때 마지막 로그인 일시 저장하기
- [x] 쓸데없는 로그 지우기
- [x] 로그아웃 후 redirect 주소 변경하기

### 변경한 부분
- application.yml에 logout 성공 시 redirect 주소 변경했습니다.  이 버전으로 업데이트하면 로그아웃 했을 때 메인 페이지로 넘어갑니다. 
- 로그인했을 때 마지막 로그인 일시를 업데이트하지 않았는데, 이제 업데이트하도록 추가했습니다. 

### 변경한 결과
- lastLoginDate
![image](https://github.com/Kernel360/f1-JDON-Backend/assets/68376744/01032c1c-74be-466e-bacc-5ada192b3c73)
![image](https://github.com/Kernel360/f1-JDON-Backend/assets/68376744/13f70cf9-504c-4adc-b77d-3ceb90ec3035)
- 추가 설명 
  DB에 따로 timezone 설정을 하지 않아 UTC(한국시간 - 9시간) 기준으로 저장되지만 서버에서 값을 가져올 때는 아래사진과 같이 알아서 시간차를 설정하므로 크게 상관은 없습니다. 

### 이슈

- closes: #248 

---

## PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경, 주석 변경)
- [ ] 코드 리팩토링
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 파일 혹은 폴더명 수정, 삭제
- [ ] 배포 관련