### PR TITLE
Feature: 커피챗 목록조회 API 구현

### DIFF
--- a/module-api/src/main/java/kernel/jdon/coffeechat/controller/CoffeeChatController.java
+++ b/module-api/src/main/java/kernel/jdon/coffeechat/controller/CoffeeChatController.java
@@ -1,9 +1,6 @@
 package kernel.jdon.coffeechat.controller;
 
 import java.net.URI;
-import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.List;
 
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
@@ -14,9 +11,12 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import kernel.jdon.auth.dto.SessionUserInfo;
+import kernel.jdon.coffeechat.dto.request.CoffeeChatCondition;
+import kernel.jdon.coffeechat.dto.request.CoffeeChatSortCondition;
 import kernel.jdon.coffeechat.dto.request.CreateCoffeeChatRequest;
 import kernel.jdon.coffeechat.dto.request.UpdateCoffeeChatRequest;
 import kernel.jdon.coffeechat.dto.response.ApplyCoffeeChatResponse;
@@ -79,24 +79,16 @@ public class CoffeeChatController {
 	}
 
 	@GetMapping("/api/v1/coffeechats")
-	public ResponseEntity<CommonResponse> getCoffeeChatList() {
-		List<FindCoffeeChatListResponse> list = new ArrayList<>();
-		for (long i = 10; i <= 20; i++) {
-			FindCoffeeChatListResponse response = FindCoffeeChatListResponse.builder()
-				.coffeeChatId(i)
-				.nickname("김영한" + i)
-				.job("backend")
-				.title("주니어 백엔드 개발자를 대상으로 커피챗을 엽니다." + i)
-				.status("모집중")
-				.meetDate(LocalDateTime.now().plusMinutes(i))
-				.createdDate(LocalDateTime.now())
-				.currentRecruitCount(5L)
-				.totalRecruitCount(i)
-				.build();
-			list.add(response);
-		}
+	public ResponseEntity<CommonResponse> getCoffeeChatList(
+		@PageableDefault(size = 12) Pageable pageable,
+		@RequestParam(value = "sort", defaultValue = "") CoffeeChatSortCondition sort,
+		@RequestParam(value = "keyword", defaultValue = "") String keyword,
+		@RequestParam(value = "jobCategory", defaultValue = "") Long jobCategory) {
 
-		return ResponseEntity.ok(CommonResponse.of(list));
+		CustomPageResponse<FindCoffeeChatListResponse> response =
+			coffeeChatService.findCoffeeChatList(pageable, new CoffeeChatCondition(sort, keyword, jobCategory));
+
+		return ResponseEntity.ok(CommonResponse.of(response));
 	}
 
 	@PutMapping("/api/v1/coffeechats/{id}")

--- a/module-api/src/main/java/kernel/jdon/coffeechat/dto/request/CoffeeChatCondition.java
+++ b/module-api/src/main/java/kernel/jdon/coffeechat/dto/request/CoffeeChatCondition.java
@@ -1,0 +1,12 @@
+package kernel.jdon.coffeechat.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class CoffeeChatCondition {
+	private CoffeeChatSortCondition sort;
+	private String keyword;
+	private Long jobCategory;
+}

--- a/module-api/src/main/java/kernel/jdon/coffeechat/dto/request/CoffeeChatSortCondition.java
+++ b/module-api/src/main/java/kernel/jdon/coffeechat/dto/request/CoffeeChatSortCondition.java
@@ -1,0 +1,24 @@
+package kernel.jdon.coffeechat.dto.request;
+
+import static org.springframework.util.StringUtils.*;
+
+import java.util.Arrays;
+
+public enum CoffeeChatSortCondition {
+	CREATED_DATE("createdDate"),
+	VIEW_COUNT("viewCount");
+
+	private final String webNaming;
+
+	CoffeeChatSortCondition(String webNaming) {
+		this.webNaming = webNaming;
+	}
+
+	public static CoffeeChatSortCondition of(String webNaming) {
+		if (!hasText(webNaming)) return null;
+		return Arrays.stream(values())
+			.filter(name -> name.webNaming.equals(webNaming))
+			.findFirst()
+			.orElseThrow();
+	}
+}

--- a/module-api/src/main/java/kernel/jdon/coffeechat/dto/response/FindCoffeeChatListResponse.java
+++ b/module-api/src/main/java/kernel/jdon/coffeechat/dto/response/FindCoffeeChatListResponse.java
@@ -3,23 +3,24 @@ package kernel.jdon.coffeechat.dto.response;
 import java.time.LocalDateTime;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.querydsl.core.annotations.QueryProjection;
 
 import kernel.jdon.coffeechat.domain.CoffeeChat;
-import lombok.AllArgsConstructor;
+import kernel.jdon.coffeechat.domain.CoffeeChatActiveStatus;
 import lombok.Builder;
 import lombok.Getter;
 
 @Getter
-@Builder
-@AllArgsConstructor
 public class FindCoffeeChatListResponse {
 
 	private Long coffeeChatId;
 	private String nickname;
 	private String job;
 	private String title;
-	private String status;
-	private boolean isDeleted;
+	private String activeStatus;
+	@JsonInclude(JsonInclude.Include.NON_NULL)
+	private Boolean isDeleted;
 	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm", timezone = "Asia/Seoul")
 	private LocalDateTime meetDate;
 	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm", timezone = "Asia/Seoul")
@@ -27,20 +28,49 @@ public class FindCoffeeChatListResponse {
 	private Long totalRecruitCount;
 	private Long currentRecruitCount;
 
+	@Builder
+	public FindCoffeeChatListResponse(Long coffeeChatId, String nickname, String job, String title, String activeStatus,
+		boolean isDeleted, LocalDateTime meetDate, LocalDateTime createdDate, Long totalRecruitCount, Long currentRecruitCount) {
+		this.coffeeChatId = coffeeChatId;
+		this.nickname = nickname;
+		this.job = job;
+		this.title = title;
+		this.activeStatus = activeStatus;
+		this.isDeleted = isDeleted;
+		this.meetDate = meetDate;
+		this.createdDate = createdDate;
+		this.totalRecruitCount = totalRecruitCount;
+		this.currentRecruitCount = currentRecruitCount;
+	}
+
+
+	@QueryProjection
+	public FindCoffeeChatListResponse(Long coffeeChatId, String nickname, String job, String title, CoffeeChatActiveStatus activeStatus,
+		LocalDateTime meetDate, LocalDateTime createdDate, Long totalRecruitCount, Long currentRecruitCount) {
+		this.coffeeChatId = coffeeChatId;
+		this.nickname = nickname;
+		this.job = job;
+		this.title = title;
+		this.activeStatus = activeStatus.getActiveStatus();
+		this.meetDate = meetDate;
+		this.createdDate = createdDate;
+		this.totalRecruitCount = totalRecruitCount;
+		this.currentRecruitCount = currentRecruitCount;
+	}
+
 	public static FindCoffeeChatListResponse of(CoffeeChat coffeeChat) {
 		return FindCoffeeChatListResponse.builder()
 			.coffeeChatId(coffeeChat.getId())
 			.nickname(coffeeChat.getMember().getNickname())
 			.job((coffeeChat.getMember().getJobCategory().getName()))
 			.title(coffeeChat.getTitle())
-			.status(coffeeChat.getCoffeeChatStatus().getActiveStatus())
+			.activeStatus(coffeeChat.getCoffeeChatStatus().getActiveStatus())
 			.isDeleted(coffeeChat.isDeleted())
 			.meetDate(coffeeChat.getMeetDate())
 			.createdDate(coffeeChat.getCreatedDate())
 			.totalRecruitCount(coffeeChat.getTotalRecruitCount())
 			.currentRecruitCount(coffeeChat.getCurrentRecruitCount())
 			.build();
-
 	}
 
 }

--- a/module-api/src/main/java/kernel/jdon/coffeechat/repository/CoffeeChatRepository.java
+++ b/module-api/src/main/java/kernel/jdon/coffeechat/repository/CoffeeChatRepository.java
@@ -7,7 +7,7 @@ import org.springframework.data.domain.Pageable;
 
 import kernel.jdon.coffeechat.domain.CoffeeChat;
 
-public interface CoffeeChatRepository extends CoffeeChatDomainRepository {
+public interface CoffeeChatRepository extends CoffeeChatDomainRepository, CustomCoffeeChatRepository {
 
 	Optional<CoffeeChat> findByIdAndIsDeletedFalse(Long id);
 

--- a/module-api/src/main/java/kernel/jdon/coffeechat/repository/CoffeeChatRepositoryImpl.java
+++ b/module-api/src/main/java/kernel/jdon/coffeechat/repository/CoffeeChatRepositoryImpl.java
@@ -1,0 +1,94 @@
+package kernel.jdon.coffeechat.repository;
+
+import static kernel.jdon.coffeechat.domain.QCoffeeChat.*;
+import static kernel.jdon.coffeechat.dto.request.CoffeeChatSortCondition.*;
+import static kernel.jdon.jobcategory.domain.QJobCategory.*;
+import static kernel.jdon.member.domain.QMember.*;
+import static org.springframework.util.StringUtils.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import kernel.jdon.coffeechat.dto.request.CoffeeChatCondition;
+import kernel.jdon.coffeechat.dto.request.CoffeeChatSortCondition;
+import kernel.jdon.coffeechat.dto.response.FindCoffeeChatListResponse;
+import kernel.jdon.coffeechat.dto.response.QFindCoffeeChatListResponse;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class CoffeeChatRepositoryImpl implements CustomCoffeeChatRepository {
+	private final JPAQueryFactory jpaQueryFactory;
+
+	@Override
+	public Page<FindCoffeeChatListResponse> findCoffeeChatList(Pageable pageable,
+		CoffeeChatCondition coffeeChatCondition) {
+		List<FindCoffeeChatListResponse> content = jpaQueryFactory
+			.select(new QFindCoffeeChatListResponse(
+				coffeeChat.id,
+				member.nickname,
+				jobCategory.name,
+				coffeeChat.title,
+				coffeeChat.coffeeChatStatus,
+				coffeeChat.meetDate,
+				coffeeChat.createdDate,
+				coffeeChat.totalRecruitCount,
+				coffeeChat.currentRecruitCount))
+			.from(coffeeChat)
+			.join(member)
+			.on(coffeeChat.member.eq(member))
+			.join(jobCategory)
+			.on(member.jobCategory.eq(jobCategory))
+			.where(
+				coffeeChatTitleContains(coffeeChatCondition.getKeyword()),
+				memberJobCategoryEq(coffeeChatCondition.getJobCategory())
+			)
+			.orderBy(
+				coffeeChatSort(coffeeChatCondition.getSort())
+			)
+			.offset(pageable.getOffset())
+			.limit(pageable.getPageSize())
+			.fetch();
+
+		Long totalCount = jpaQueryFactory
+			.select(coffeeChat.count())
+			.from(coffeeChat)
+			.join(member)
+			.on(coffeeChat.member.eq(member))
+			.where(
+				coffeeChatTitleContains(coffeeChatCondition.getKeyword()),
+				memberJobCategoryEq(coffeeChatCondition.getJobCategory())
+			)
+			.fetchOne();
+
+		return new PageImpl<>(content, pageable, totalCount);
+
+	}
+
+	private OrderSpecifier[] coffeeChatSort(CoffeeChatSortCondition sort) {
+		ArrayList<Object> orderSpecifiers = new ArrayList<>();
+		if (VIEW_COUNT == sort)
+			orderSpecifiers.add(new OrderSpecifier<>(Order.DESC, coffeeChat.viewCount));
+		else
+			orderSpecifiers.add(new OrderSpecifier<>(Order.DESC, coffeeChat.createdDate));
+
+		return orderSpecifiers.toArray(new OrderSpecifier[orderSpecifiers.size()]);
+	}
+
+	private BooleanExpression memberJobCategoryEq(Long jobCategoryId) {
+		return jobCategoryId != null ? member.jobCategory.id.eq(jobCategoryId) : null;
+	}
+
+	private BooleanExpression coffeeChatTitleContains(String keyword) {
+		return hasText(keyword) ? coffeeChat.title.contains(keyword) : null;
+	}
+
+}

--- a/module-api/src/main/java/kernel/jdon/coffeechat/repository/CustomCoffeeChatRepository.java
+++ b/module-api/src/main/java/kernel/jdon/coffeechat/repository/CustomCoffeeChatRepository.java
@@ -1,0 +1,11 @@
+package kernel.jdon.coffeechat.repository;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import kernel.jdon.coffeechat.dto.request.CoffeeChatCondition;
+import kernel.jdon.coffeechat.dto.response.FindCoffeeChatListResponse;
+
+public interface CustomCoffeeChatRepository {
+	Page<FindCoffeeChatListResponse> findCoffeeChatList(Pageable pageable, CoffeeChatCondition coffeeChatCondition);
+}

--- a/module-api/src/main/java/kernel/jdon/coffeechat/service/CoffeeChatService.java
+++ b/module-api/src/main/java/kernel/jdon/coffeechat/service/CoffeeChatService.java
@@ -7,6 +7,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import kernel.jdon.coffeechat.domain.CoffeeChat;
 import kernel.jdon.coffeechat.domain.CoffeeChatActiveStatus;
+import kernel.jdon.coffeechat.dto.request.CoffeeChatCondition;
 import kernel.jdon.coffeechat.dto.request.CreateCoffeeChatRequest;
 import kernel.jdon.coffeechat.dto.request.UpdateCoffeeChatRequest;
 import kernel.jdon.coffeechat.dto.response.ApplyCoffeeChatResponse;
@@ -86,6 +87,12 @@ public class CoffeeChatService {
 			.map(FindCoffeeChatListResponse::of);
 
 		return CustomPageResponse.of(guestCoffeeChatPage);
+	}
+
+	public CustomPageResponse findCoffeeChatList(Pageable pageable, CoffeeChatCondition coffeeChatCondition) {
+		Page<FindCoffeeChatListResponse> findCoffeeChatList = coffeeChatRepository.findCoffeeChatList(pageable,
+			coffeeChatCondition);
+		return CustomPageResponse.of(findCoffeeChatList);
 	}
 
 	@Transactional

--- a/module-api/src/main/java/kernel/jdon/config/WebConfig.java
+++ b/module-api/src/main/java/kernel/jdon/config/WebConfig.java
@@ -3,10 +3,13 @@ package kernel.jdon.config;
 import java.util.List;
 
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.format.FormatterRegistry;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 import kernel.jdon.auth.service.LoginUserArgumentResolver;
+import kernel.jdon.coffeechat.dto.request.CoffeeChatSortCondition;
 import lombok.RequiredArgsConstructor;
 
 @Configuration
@@ -18,5 +21,17 @@ public class WebConfig implements WebMvcConfigurer {
 	@Override
 	public void addArgumentResolvers(List<HandlerMethodArgumentResolver> argumentResolvers) {
 		argumentResolvers.add(loginUserArgumentResolver);
+	}
+
+	@Override
+	public void addFormatters(FormatterRegistry registry) {
+		registry.addConverter(new CoffeeChatSortConverter());
+	}
+
+	private static class CoffeeChatSortConverter implements Converter<String, CoffeeChatSortCondition> {
+		@Override
+		public CoffeeChatSortCondition convert(String source) {
+			return CoffeeChatSortCondition.of(source);
+		}
 	}
 }


### PR DESCRIPTION
## 개요

### 요약
- [커피챗 목록 조회하기](https://www.notion.so/7c7962a4b1104cc5a6a79d172596863c?pvs=4) API 구현
### 변경한 부분
- 입력되는 커피챗 제목, 정렬 조건, 직군 조건에 따라 동적으로 SQL을 변경하도록 querydsl을 사용하여 동적쿼리를 구현하였습니다.
### FindCoffeeChatListResponse
- 내가 신청, 참여한 커피챗조회에서 사용하는 `FindCoffeeChatListResponse`를 재사용하기위해 커피챗 목록조회 API에 없는 항목인 isDeleted를 반환하지 않도록 `@JsonInclude(JsonInclude.Include.NON_NULL)`어노테이션을 추가하고 필드 타입을 null을 담을 수 있는 Boolean 레퍼런스 타입으로 수정했습니다.
-  커피챗 목록조회 API에서 반환하는 필드를 인자로 받는 생성자를 추가하고 `@QueryProjection` 어노테이션을 통해 DTO를 Q타입으로 생성하였습니다.

### CoffeeChatRepositoryImpl 
- findCoffeeChatList 메서드에서 메인쿼리에서 커피챗 등록자의 닉네임을 가져오기 위해 coffeechat과 member, 커피챗 등록자의 직군명을 가져오기위해 member와 jobcategory를 조인합니다. 
- Count쿼리에서는 커피챗 등록자의 직군명을 가져올 필요가 없기 때문에 member와 jobcategory와 조인없이 coffeechat과 member만을 조인하도록 하여 최종적으로 조인연산을 줄이도록 했습니다.

### CoffeeChatController
- 정적인 정렬조건 데이터를 서버에서 일관성있게 관리할 수 있도록 CoffeeChatSortCondition enum 클래스를 생성했습니다.
- getCoffeeChatList 메서드에서 쿼리파라미터에 포함된 정렬 조건을 enum타입으로 바로 바인딩할 수 있도록 커스텀 하였습니다.
  - WebConfig의 내부클래스인 CoffeeChatSortConverter 클래스에서 Converter를 오버라이딩하여 CoffeeChatSortCondition을 생성합니다.
  -  WebConfig에서 addFormatters를 오버라이딩하고 CoffeeChatSortConverter 클래스를 생성합니다. 

### 변경한 결과
![image](https://github.com/Kernel360/f1-JDON-Backend/assets/59242594/fe8df803-337a-404f-be90-6a8ea42da4b6)

### 이슈

- closes: #243 

---

## PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경, 주석 변경)
- [ ] 코드 리팩토링
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 파일 혹은 폴더명 수정, 삭제
- [ ] 배포 관련