### PR TITLE
Fix: login 없이 test를 위해서 풀어놨던 api별 권한 재설정

### DIFF
--- a/module-api/src/main/java/kernel/jdon/config/auth/OAuth2SecurityConfig.java
+++ b/module-api/src/main/java/kernel/jdon/config/auth/OAuth2SecurityConfig.java
@@ -27,7 +27,7 @@ public class OAuth2SecurityConfig {
 
 	@Bean
 	public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
-		String[] permitAllGET = {
+		final String[] permitAllGET = {
 			"/oauth2/authorization/**",
 			"/api/v1/coffeechats/**",
 			"/api/v1/skills/hot",
@@ -36,11 +36,11 @@ public class OAuth2SecurityConfig {
 			"/api/v1/faqs",
 			"/api/v1/skills/search",
 		};
-		String[] permitAllPOST = {
+		final String[] permitAllPOST = {
 			"/api/v1/register",
 			"/api/v1/nickname/duplicate",
 		};
-		String[] authenticatedGET = {
+		final String[] authenticatedGET = {
 			"/api/v1/coffeechats/guest",
 			"/api/v1/coffeechats/host",
 			"/api/v1/skills/member",

--- a/module-api/src/main/java/kernel/jdon/config/auth/OAuth2SecurityConfig.java
+++ b/module-api/src/main/java/kernel/jdon/config/auth/OAuth2SecurityConfig.java
@@ -34,17 +34,17 @@ public class OAuth2SecurityConfig {
 			"/api/v1/skills/job-category/**",
 			"/api/v1/job-categories",
 			"/api/v1/faqs",
-			"/api/v1/skills/search?**",
+			"/api/v1/skills/search",
 		};
 		String[] permitAllPOST = {
 			"/api/v1/register",
 			"/api/v1/nickname/duplicate",
-			"/api/v1/verify-email"
 		};
 		String[] authenticatedGET = {
 			"/api/v1/coffeechats/guest",
 			"/api/v1/coffeechats/host",
-			"/api/v1/skills/member"
+			"/api/v1/skills/member",
+			"/api/v1/logout"
 		};
 
 		http.cors(corsCustomizer -> corsCustomizer.configurationSource(request -> {


### PR DESCRIPTION
## 개요

### 요약

### 변경한 부분
securityConfig에 API 별로 권한 설정

### 변경한 결과
<img width="858" alt="image" src="https://github.com/Kernel360/f1-JDON-Backend/assets/68376744/9fea04b5-14f0-42b1-8f1f-b1e246080998">
이제 login 하지 않은 유저가 보내면 안될 요청을 보내면 sessionUserInfo null 로 인한 500 에러가 아니라 401 혹은 403 에러로 반환됩니다. 

지옥의 test 완료했습니다
![image](https://github.com/Kernel360/f1-JDON-Backend/assets/68376744/f045d0d3-6a75-4d1a-b4e7-a4034d627253)


### 이슈

- closes: #259 

---

## PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경, 주석 변경)
- [ ] 코드 리팩토링
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 파일 혹은 폴더명 수정, 삭제
- [ ] 배포 관련