### PR TITLE
Refactor: FaqErrorCode 리팩토링 

### DIFF
--- a/module-api/src/main/java/kernel/jdon/faq/error/FaqErrorCode.java
+++ b/module-api/src/main/java/kernel/jdon/faq/error/FaqErrorCode.java
@@ -3,10 +3,12 @@ package kernel.jdon.faq.error;
 import org.springframework.http.HttpStatus;
 
 import kernel.jdon.error.ErrorCode;
+import kernel.jdon.global.exception.ApiException;
+import kernel.jdon.global.exception.BaseThrowException;
 import lombok.AllArgsConstructor;
 
 @AllArgsConstructor
-public enum FaqErrorCode implements ErrorCode {
+public enum FaqErrorCode implements ErrorCode, BaseThrowException<FaqErrorCode.FaqBaseException> {
 	NOT_FOUND_FAQ(HttpStatus.NOT_FOUND, "존재하지 않는 FAQ 입니다.");
 
 	private final HttpStatus httpStatus;
@@ -21,4 +23,17 @@ public enum FaqErrorCode implements ErrorCode {
 	public String getMessage() {
 		return message;
 	}
+
+	@Override
+	public FaqErrorCode.FaqBaseException throwException() {
+		return new FaqErrorCode.FaqBaseException(this);
+	}
+
+	public class FaqBaseException extends ApiException {
+		public FaqBaseException(ErrorCode errorCode) {
+			super(errorCode);
+		}
+	}
+
+
 }

--- a/module-api/src/main/java/kernel/jdon/faq/error/FaqErrorCode.java
+++ b/module-api/src/main/java/kernel/jdon/faq/error/FaqErrorCode.java
@@ -30,10 +30,9 @@ public enum FaqErrorCode implements ErrorCode, BaseThrowException<FaqErrorCode.F
 	}
 
 	public class FaqBaseException extends ApiException {
-		public FaqBaseException(ErrorCode errorCode) {
-			super(errorCode);
+		public FaqBaseException(FaqErrorCode faqErrorCode) {
+			super(faqErrorCode);
 		}
 	}
-
 
 }

--- a/module-api/src/main/java/kernel/jdon/faq/service/FaqService.java
+++ b/module-api/src/main/java/kernel/jdon/faq/service/FaqService.java
@@ -14,7 +14,6 @@ import kernel.jdon.faq.dto.response.FindListFaqResponse;
 import kernel.jdon.faq.dto.response.UpdateFaqResponse;
 import kernel.jdon.faq.error.FaqErrorCode;
 import kernel.jdon.faq.repository.FaqRepository;
-import kernel.jdon.global.exception.ApiException;
 import lombok.RequiredArgsConstructor;
 
 @Service
@@ -25,7 +24,7 @@ public class FaqService {
 
 	private Faq findById(final Long faqId) {
 		return faqRepository.findById(faqId)
-			.orElseThrow(() -> new ApiException(FaqErrorCode.NOT_FOUND_FAQ));
+			.orElseThrow(FaqErrorCode.NOT_FOUND_FAQ::throwException);
 	}
 
 	@Transactional

--- a/module-api/src/main/java/kernel/jdon/global/exception/BaseThrowException.java
+++ b/module-api/src/main/java/kernel/jdon/global/exception/BaseThrowException.java
@@ -1,0 +1,5 @@
+package kernel.jdon.global.exception;
+
+public interface BaseThrowException<T> {
+	 T throwException();
+}

--- a/module-api/src/test/java/kernel/jdon/faq/service/FaqServiceTest.java
+++ b/module-api/src/test/java/kernel/jdon/faq/service/FaqServiceTest.java
@@ -35,8 +35,8 @@ public class FaqServiceTest {
 	private FaqService faqService;
 
 	@Test
-	@DisplayName("findList 메서드가 존재하는 faq 개수만큼 잘 반환하는지")
-	public void givenValidFaqList_whenFindList_thenReturn_whenCorrectFaqList() {
+	@DisplayName("findList 메서드가 존재하는 faq 개수 만큼 데이터를 응답한다.")
+	void givenValidFaqList_whenFindList_thenReturn_whenCorrectFaqList() {
 		// given
 		List<Faq> faqs = Collections.singletonList(Faq.builder().id(1L).title("title1").content("content1").build());
 
@@ -50,7 +50,7 @@ public class FaqServiceTest {
 	}
 
 	@Test
-	@DisplayName("create 메서드가 유효한 faq 정보가 주어졌을 때 FAQ 등록이 잘 동작하는지")
+	@DisplayName("유효한 FAQ 정보가 주어졌을 때 create 메서드가 등록한 FAQ의 ID를 반환한다.")
 	void givenValidCreateRequest_whenCreate_thenReturnCreatedFaqId() throws Exception {
 		// given
 		final String title = "FAQ 제목";
@@ -71,8 +71,8 @@ public class FaqServiceTest {
 	}
 
 	@Test
-	@DisplayName("delete 메서드가 유효한 faq Id가 주어졌을 때 Faq 삭제가 잘 동작하는지")
-	public void givenValidFaqId_whenDelete_thenReturnDeletedFaqId() throws Exception {
+	@DisplayName("유효한 FAQ ID가 주어졌을 때 delete 메서드에서 삭제한 FAQ의 ID를 반환한다.")
+	void givenValidFaqId_whenDelete_thenReturnDeletedFaqId() throws Exception {
 		//given
 		final Long faqId = 1L;
 		Faq faq = Faq.builder().id(1L).title("제목").content("내용").build();
@@ -89,7 +89,7 @@ public class FaqServiceTest {
 	}
 
 	@Test
-	@DisplayName("delete 메서드가 유효하지 않은 faq ID가 주어졌을 때 예외를 잘 발생시키는지")
+	@DisplayName("유효하지 않은 FAQ ID가 주어졌을 때 delete 메서드에서 NOT_FOUND_FAQ 예외를 던진다.")
 	void givenInvalidFaqId_whenDelete_thenThrowException() throws Exception {
 	    //given
 		final Long faqId = 1L;
@@ -104,7 +104,7 @@ public class FaqServiceTest {
 	}
 
 	@Test
-	@DisplayName("update 메서드가 유효한 faq Id가 주어졌을 때 Faq 수정이 잘 동작하는지")
+	@DisplayName("유효한 FAQ ID가 주어졌을 때 update 메서드에서 수정한 FAQ의 ID를 반환한다.")
 	void givenValidFaqId_whenUpdate_thenUpdatedFaqId() throws Exception {
 	    //given
 	    final Long faqId = 1L;
@@ -123,7 +123,7 @@ public class FaqServiceTest {
 	}
 
 	@Test
-	@DisplayName("update 메서드가 유효하지 않은 faq Id가 주어졌을 때 예외가 잘 동작하는지")
+	@DisplayName("유효하지 않은 FAQ ID가 주어졌을 때 update 메서드에서 NOT_FOUND_FAQ 예외를 던진다.")
 	void givenInvalidFaqId_whenUpdate_thenThrowException() throws Exception {
 		// given
 		final Long faqId = 1L;


### PR DESCRIPTION
## 개요

### 요약
- 스프링 멘토님이 추천해주신 예외 발생 방식을 가장 간단한 FAQ 도메인에 시범 적용했습니다.
- 권태관 멘토님이 추천하신 테스트코드의 DisplayName을 수정했습니다.

### 변경한 부분
#### 기존 예외 발생 코드
![image](https://github.com/Kernel360/f1-JDON-Backend/assets/59242594/1772c06d-62e5-4082-b3b7-058fa0763a7c)
#### 변경한 예외 발생 코드
![image](https://github.com/Kernel360/f1-JDON-Backend/assets/59242594/22d95d89-11a4-4bc5-9a29-262de5c93660)

다음과 같은 이유로 위 사항을 수정했습니다.
기존 예외 발생 소스와 같이 관리된다면 log를 작성해야하는 요구사항이 있을경우
두가지 방안이 있을 것 같습니다.
   1. ExceptionHandler 같은 부분에서 ApiException이 발생한 부분을 캐치하는 메서드에서 CofeeChatErrorCode를 인자로 갖는 부분을 분기처리해서  log를 달도록 구현한다.
  = 요구사항을 처리할 수는 있지만 CofeeChatErrorCode가 **호출되는 시점에 log를 작성하지 못해서** ExceptionHandler가 수정되어야하며 CofeeChatErrorCode에서 처리해야할 일을 ExceptionHandler이 처리해야합니다. 또한 다른 도메인 예외마다 요구사항이 추가된다면 ExceptionHandler의 ApiException이 발생한 부분을 캐치하는 메서드에 도메인 ErrorCode 별로 분기 처리하는 등 계속 ExceptionHandler가 수정되어야 합니다. 이로인해 ExceptionHandler가 추가 요구사항이 있는 모든 도메인의 ErrorCode에 의존하게 됩니다.
  결론적으로 매우 비효율적입니다.
  
  2. ApiException 생성자에서 매개변수로 받는 추상화된 ErrorCode가 어떤 것으로 들어오는지 확인하여 로그를 추가한다.
  = ApiException이 생성될 때 도메인 별로 로그를 추가할 수 있으나 이 방법도 1번 방안과 같이 요구사항이 추가될 수록 ApiException 코드가 수정되어야하고 ApiException가 요구사항이 생기는 ErrorCode에 지속적으로 의존하게 됩니다.
![image](https://github.com/Kernel360/f1-JDON-Backend/assets/59242594/471d112f-8e04-4395-9a3e-3670302b50c2)

위와같이 두가지 방법 모두 변경에 취약합니다.
따라서 변경이 필요합니다.

### 변경한 결과

#### FaqBaseException
- FaqErrorCode에서만 사용하기 때문에 이너클래스로 생성했습니다.
- ApiException을 상속받아 FaqBaseException 생성 시 ApiException 생성자로 FaqErrorCode를 전달합니다.

#### BaseThrowException<T>
- 모든 도메인 별 ErrorCode를 던질 수 있도록하는 제네릭 인터페이스로 throwException() 제네릭 메서드를 가지고 있습니다.

#### FaqErrorCode
- BaseThrowException를 implment하여 throwException 메서드를 구현합니다.
- throwException 메서드는 FaqBaseException를 생성하여 자신을 반환합니다.

따라서 사용하는 입장에서는 아래와 같이 사용할 수 있습니다.
![image](https://github.com/Kernel360/f1-JDON-Backend/assets/59242594/22d95d89-11a4-4bc5-9a29-262de5c93660)

1. 이제 더이상 Service에서 ApiException에 의존하지 않습니다.
2. 각 에러코드 호출 시, ErrorCode 자체에서 자신의 호출 전 후 시점을 관리할 수 있어 변경에 더 유연하게 대응할 수 있습니다.
3. 이전 방식보다 가독성이 더 좋아집니다.


### 이슈

- closes: #258 

---

## PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경, 주석 변경)
- [x] 코드 리팩토링
- [ ] 문서 수정
- [x] 테스트 추가, 테스트 리팩토링
- [ ] 파일 혹은 폴더명 수정, 삭제
- [ ] 배포 관련