### PR TITLE
Feature: 커피챗 동시성 제어

### DIFF
--- a/module-api/build.gradle
+++ b/module-api/build.gradle
@@ -27,6 +27,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'com.github.gavlyukovskiy:p6spy-spring-boot-starter:1.9.0'
+    implementation 'org.redisson:redisson-spring-boot-starter:3.26.0'
+
     // validation
     implementation 'org.springframework.boot:spring-boot-starter-validation'
 

--- a/module-api/src/main/java/kernel/jdon/coffeechat/controller/CoffeeChatController.java
+++ b/module-api/src/main/java/kernel/jdon/coffeechat/controller/CoffeeChatController.java
@@ -24,6 +24,7 @@ import kernel.jdon.coffeechat.dto.response.CreateCoffeeChatResponse;
 import kernel.jdon.coffeechat.dto.response.DeleteCoffeeChatResponse;
 import kernel.jdon.coffeechat.dto.response.FindCoffeeChatListResponse;
 import kernel.jdon.coffeechat.dto.response.UpdateCoffeeChatResponse;
+import kernel.jdon.coffeechat.service.CoffeeChatApplyFacade;
 import kernel.jdon.coffeechat.service.CoffeeChatService;
 import kernel.jdon.dto.response.CommonResponse;
 import kernel.jdon.global.annotation.LoginUser;
@@ -37,6 +38,7 @@ import lombok.extern.slf4j.Slf4j;
 public class CoffeeChatController {
 
 	private final CoffeeChatService coffeeChatService;
+	private final CoffeeChatApplyFacade coffeeChatApplyFacade;
 
 	@GetMapping("/api/v1/coffeechats/{id}")
 	public ResponseEntity<CommonResponse> get(@PathVariable(name = "id") Long coffeeChatId) {
@@ -113,7 +115,7 @@ public class CoffeeChatController {
 		@PathVariable(name = "id") Long coffeeChatId,
 		@LoginUser SessionUserInfo sessionUser) {
 
-		ApplyCoffeeChatResponse response = coffeeChatService.apply(coffeeChatId, sessionUser.getId());
+		ApplyCoffeeChatResponse response = coffeeChatApplyFacade.apply(coffeeChatId, sessionUser.getId());
 
 		return ResponseEntity.ok().body(CommonResponse.of(response));
 	}

--- a/module-api/src/main/java/kernel/jdon/coffeechat/error/CoffeeChatErrorCode.java
+++ b/module-api/src/main/java/kernel/jdon/coffeechat/error/CoffeeChatErrorCode.java
@@ -13,6 +13,8 @@ public enum CoffeeChatErrorCode implements ErrorCode {
 	CANNOT_JOIN_OWN_COFFEECHAT(HttpStatus.CONFLICT, "본인이 개설한 커피챗에 참여할 수 없습니다."),
 	EXPIRED_COFFEECHAT(HttpStatus.CONFLICT, "지난 일자의 커피챗은 수정할 수 없습니다."),
 	MEET_DATE_ISBEFORE_NOW(HttpStatus.BAD_REQUEST, "지금보다 이전 시점으로 설정할 수 없습니다."),
+	LOCK_ACQUISITION_FAILURE(HttpStatus.SERVICE_UNAVAILABLE, "현재 많은 요청으로 인해 처리가 지연되고 있습니다. 잠시 후 다시 시도해주세요."),
+	THREAD_INTERRUPTED(HttpStatus.SERVICE_UNAVAILABLE, "처리 중 문제가 발생했습니다. 잠시 후 다시 시도해주세요."),
 	ALREADY_JOINED_COFFEECHAT(HttpStatus.CONFLICT, "이미 참여한 커피챗 입니다.");
 
 	private final HttpStatus httpStatus;

--- a/module-api/src/main/java/kernel/jdon/coffeechat/service/CoffeeChatApplyFacade.java
+++ b/module-api/src/main/java/kernel/jdon/coffeechat/service/CoffeeChatApplyFacade.java
@@ -1,0 +1,38 @@
+package kernel.jdon.coffeechat.service;
+
+import java.util.concurrent.TimeUnit;
+
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
+import org.springframework.stereotype.Service;
+
+import kernel.jdon.coffeechat.error.CoffeeChatErrorCode;
+import kernel.jdon.global.exception.ApiException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class CoffeeChatApplyFacade {
+
+	private final CoffeeChatService coffeeChatService;
+	private final RedissonClient redissonClient;
+
+	public void apply(final Long coffeeChatId, final Long memberId) {
+		RLock lock = redissonClient.getLock(String.format("apply:coffeeChat:%d", coffeeChatId));
+		try {
+			boolean available = lock.tryLock(3, 1, TimeUnit.SECONDS);
+			if (!available) {
+				log.info("커피챗 신청 중 lock 획득 실패, coffeeChatId={} memberId={}", coffeeChatId, memberId);
+				throw new ApiException(CoffeeChatErrorCode.LOCK_ACQUISITION_FAILURE);
+			}
+			coffeeChatService.apply(coffeeChatId, memberId);
+		} catch (InterruptedException e) {
+			log.info("커피챗 신청 중 lock 획득 중 thread interrupted, coffeeChatId={} memberId={}", coffeeChatId, memberId);
+			throw new ApiException(CoffeeChatErrorCode.THREAD_INTERRUPTED, e);
+		} finally {
+			lock.unlock();
+		}
+	}
+}

--- a/module-api/src/main/java/kernel/jdon/coffeechat/service/CoffeeChatApplyFacade.java
+++ b/module-api/src/main/java/kernel/jdon/coffeechat/service/CoffeeChatApplyFacade.java
@@ -6,7 +6,9 @@ import org.redisson.api.RLock;
 import org.redisson.api.RedissonClient;
 import org.springframework.stereotype.Service;
 
+import kernel.jdon.coffeechat.dto.response.ApplyCoffeeChatResponse;
 import kernel.jdon.coffeechat.error.CoffeeChatErrorCode;
+import kernel.jdon.config.redis.CoffeeChatLockConfig;
 import kernel.jdon.global.exception.ApiException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -18,18 +20,22 @@ public class CoffeeChatApplyFacade {
 
 	private final CoffeeChatService coffeeChatService;
 	private final RedissonClient redissonClient;
+	private final CoffeeChatLockConfig lockConfig;
 
-	public void apply(final Long coffeeChatId, final Long memberId) {
+	public ApplyCoffeeChatResponse apply(final Long coffeeChatId, final Long memberId) {
 		RLock lock = redissonClient.getLock(String.format("apply:coffeeChat:%d", coffeeChatId));
 		try {
-			boolean available = lock.tryLock(3, 1, TimeUnit.SECONDS);
+			boolean available = lock.tryLock(lockConfig.getWaitTime(), lockConfig.getLeaseTime(),
+				TimeUnit.SECONDS);
 			if (!available) {
 				log.info("커피챗 신청 중 lock 획득 실패, coffeeChatId={} memberId={}", coffeeChatId, memberId);
 				throw new ApiException(CoffeeChatErrorCode.LOCK_ACQUISITION_FAILURE);
 			}
-			coffeeChatService.apply(coffeeChatId, memberId);
+
+			return coffeeChatService.apply(coffeeChatId, memberId);
+			
 		} catch (InterruptedException e) {
-			log.info("커피챗 신청 중 lock 획득 중 thread interrupted, coffeeChatId={} memberId={}", coffeeChatId, memberId);
+			log.info("커피챗 신청 lock 획득 중 thread interrupted, coffeeChatId={} memberId={}", coffeeChatId, memberId);
 			throw new ApiException(CoffeeChatErrorCode.THREAD_INTERRUPTED, e);
 		} finally {
 			lock.unlock();

--- a/module-api/src/main/java/kernel/jdon/config/redis/CoffeeChatLockConfig.java
+++ b/module-api/src/main/java/kernel/jdon/config/redis/CoffeeChatLockConfig.java
@@ -1,0 +1,15 @@
+package kernel.jdon.config.redis;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+@ConfigurationProperties(prefix = "redis.lock.coffee-chat")
+public class CoffeeChatLockConfig {
+	private final Long waitTime;
+	private final Long leaseTime;
+
+}

--- a/module-api/src/main/java/kernel/jdon/global/exception/ApiException.java
+++ b/module-api/src/main/java/kernel/jdon/global/exception/ApiException.java
@@ -10,4 +10,9 @@ public class ApiException extends RuntimeException {
 	public ApiException(ErrorCode errorCode) {
 		this.errorCode = errorCode;
 	}
+
+	public ApiException(ErrorCode errorCode, Throwable cause) {
+		super(errorCode.getMessage(), cause);
+		this.errorCode = errorCode;
+	}
 }

--- a/module-api/src/main/resources/application-dev.yml
+++ b/module-api/src/main/resources/application-dev.yml
@@ -64,3 +64,9 @@ redirect-url:
       guest: http://localhost:3000/oauth/info?
   logout:
     success: http://localhost:3000
+
+redis:
+  lock:
+    coffee-chat:
+      wait-time: 5
+      lease-time: 1

--- a/module-api/src/main/resources/application-local.yml
+++ b/module-api/src/main/resources/application-local.yml
@@ -64,3 +64,9 @@ redirect-url:
       guest: http://localhost:3000/oauth/info?
   logout:
     success: http://localhost:3000
+
+redis:
+  lock:
+    coffee-chat:
+      wait-time: 5
+      lease-time: 1

--- a/module-api/src/main/resources/application-prod.yml
+++ b/module-api/src/main/resources/application-prod.yml
@@ -64,3 +64,9 @@ redirect-url:
       guest: https://jdon.kr/oauth/info?
   logout:
     success: https://jdon.kr
+
+redis:
+  lock:
+    coffee-chat:
+      wait-time: 5
+      lease-time: 1

--- a/module-api/src/test/java/kernel/jdon/moduleapi/coffeechat/controller/CoffeeChatControllerTest.java
+++ b/module-api/src/test/java/kernel/jdon/moduleapi/coffeechat/controller/CoffeeChatControllerTest.java
@@ -1,4 +1,4 @@
-package kernel.jdon.coffeechat.controller;
+package kernel.jdon.moduleapi.coffeechat.controller;
 
 import static org.mockito.Mockito.*;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.*;
@@ -20,6 +20,7 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import kernel.jdon.coffeechat.controller.CoffeeChatController;
 import kernel.jdon.coffeechat.dto.request.CreateCoffeeChatRequest;
 import kernel.jdon.coffeechat.dto.request.UpdateCoffeeChatRequest;
 import kernel.jdon.coffeechat.dto.response.CreateCoffeeChatResponse;

--- a/module-api/src/test/java/kernel/jdon/moduleapi/coffeechat/service/CoffeeChatServiceTest.java
+++ b/module-api/src/test/java/kernel/jdon/moduleapi/coffeechat/service/CoffeeChatServiceTest.java
@@ -1,0 +1,78 @@
+package kernel.jdon.moduleapi.coffeechat.service;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.time.LocalDateTime;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import kernel.jdon.coffeechat.domain.CoffeeChat;
+import kernel.jdon.coffeechat.repository.CoffeeChatRepository;
+import kernel.jdon.coffeechat.service.CoffeeChatApplyFacade;
+import kernel.jdon.member.domain.Gender;
+import kernel.jdon.member.domain.Member;
+import kernel.jdon.member.domain.MemberAccountStatus;
+import kernel.jdon.member.domain.MemberRole;
+import kernel.jdon.member.domain.SocialProviderType;
+import kernel.jdon.member.repository.MemberRepository;
+
+@SpringBootTest
+class CoffeeChatServiceTest {
+	@Autowired
+	CoffeeChatRepository coffeeChatRepository;
+	@Autowired
+	MemberRepository memberRepository;
+	@Autowired
+	CoffeeChatApplyFacade coffeeChatApplyFacade;
+
+	@DisplayName("동시에 여러 사용자가 커피챗을 신청할때, 총 모집인원을 초과하지 않는다.")
+	@Test
+	void givenConcurrentRequests_whenApplyCoffeeChat_thenShouldNotExceedTotalRecruitCount() throws
+		InterruptedException {
+
+		Member guestMember = Member.builder()
+			.id(1L)
+			.nickname("참여자")
+			.email("b@gmail.com")
+			.birth("2024-01-01")
+			.gender(Gender.MALE)
+			.role(MemberRole.ROLE_USER)
+			.joinDate(LocalDateTime.now().minusDays(1))
+			.accountStatus(MemberAccountStatus.ACTIVE)
+			.socialProvider(SocialProviderType.KAKAO)
+			.build();
+		memberRepository.save(guestMember);
+
+		CoffeeChat coffeeChat = CoffeeChat.builder()
+			.title("커피챗 제목")
+			.content("커피챗 내용")
+			.meetDate(LocalDateTime.now().plusDays(2))
+			.openChatUrl("http://open.com")
+			.totalRecruitCount(5L)
+			.build();
+		CoffeeChat savedCoffeeChat = coffeeChatRepository.save(coffeeChat);
+		ExecutorService executorService = Executors.newFixedThreadPool(32);
+		CountDownLatch latch = new CountDownLatch(100);
+
+		for (int i = 0; i < 100; i++) {
+			executorService.submit(() -> {
+				try {
+					coffeeChatApplyFacade.apply(savedCoffeeChat.getId(), guestMember.getId());
+				} finally {
+					latch.countDown();
+				}
+			});
+		}
+		latch.await();
+
+		CoffeeChat actual = coffeeChatRepository.findById(savedCoffeeChat.getId()).orElseThrow();
+		assertThat(actual.getCurrentRecruitCount()).isEqualTo(5L);
+	}
+
+}

--- a/module-api/src/test/resources/application.yml
+++ b/module-api/src/test/resources/application.yml
@@ -52,3 +52,8 @@ redirect-url:
       guest: http://localhost:3000/oauth/info?
   logout:
     success: http://localhost:3000/main
+redis:
+  lock:
+    coffee-chat:
+      wait-time: 5
+      lease-time: 1

--- a/module-api/src/test/resources/application.yml
+++ b/module-api/src/test/resources/application.yml
@@ -8,14 +8,47 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: create
 
     properties:
       hibernate:
         #        show-sql: true
         format_sql: true
 
+  security:
+    oauth2:
+      client:
+        registration:
+          kakao:
+            client-name: kakao
+            client-id: ${KAKAO_CLIENT_ID}
+            client-secret: ${KAKAO_CLIENT_SECRET}
+            redirect-uri: http://localhost:1221/login/oauth2/code/kakao
+            authorization-grant-type: authorization_code
+            client-authentication-method: client_secret_post
+            scope: account_email
+          github:
+            client-name: github
+            client-id: ${GITHUB_CLIENT_ID}
+            client-secret: ${GITHUB_CLIENT_SECRET}
+            redirect-uri: http://localhost:1221/login/oauth2/code/github
+            scope: user:email
+        provider:
+          kakao:
+            authorization-uri: https://kauth.kakao.com/oauth/authorize
+            token-uri: https://kauth.kakao.com/oauth/token
+            user-info-uri: https://kapi.kakao.com/v2/user/me
+            user-name-attribute: id
+
 logging.level:
   org.hibernate.SQL: debug
   #  org.hibernate.type: trace
   org.springframework.security: debug
+
+redirect-url:
+  login:
+    success:
+      member: http://localhost:3000/oauth/login/success
+      guest: http://localhost:3000/oauth/info?
+  logout:
+    success: http://localhost:3000/main

--- a/module-domain/src/main/java/kernel/jdon/coffeechat/domain/CoffeeChat.java
+++ b/module-domain/src/main/java/kernel/jdon/coffeechat/domain/CoffeeChat.java
@@ -74,8 +74,9 @@ public class CoffeeChat extends BaseEntity {
 	private List<CoffeeChatMember> coffeeChatMemberList = new ArrayList<>();
 
 	@Builder
-	public CoffeeChat(String title, String content, LocalDateTime meetDate, String openChatUrl,
+	public CoffeeChat(Long id, String title, String content, LocalDateTime meetDate, String openChatUrl,
 		Long totalRecruitCount, Member member) {
+		this.id = id;
 		this.title = title;
 		this.content = content;
 		this.totalRecruitCount = totalRecruitCount;


### PR DESCRIPTION
### 요약

- 총 모집인원이 한정되어 있는 커피챗에 동시에 여러 인원이 참여신청하는 경우 동시성 이슈가 발생할 수 있습니다.
- 이를 레디스를 활용해서 해결했습니다.


### Redis를 선택한 이유
- 배경
  - 프로젝트 최초 기획부터 다중서버 분산환경으로 확장을 고려
  - 세션방식 로그인을 채택했고, 분산환경을 고려했기에 세션 클러스터링을 위해 Redis를 도입했음
- 고려한 선택지
   -  Synchronized 키워드
       - Synchronized는 하나의 JVM 내에서만 동기화를 보장합니다. 따라서 여러 서버에 분산된 애플리케이션에서는 synchronized 키워드만으로는 동시성 제어를 할 수 없습니다. 그래서 실무에서도 잘 쓰지 않습니다.
   -  MySQL의 네임드락 기능
       - 락을 획득하는 과정에서 커넥션풀을 사용해야 합니다. 기존 비즈니스 로직 상에서 쓰는 커넥션풀을 같이 쓰면 기존 로직에 영향이 갈 수 있기에 별도 커넥션풀을 관리해야 한다는 단점으로 제외했습니다.
   -  Redis
       - 메모리 기반으로 db보다 빠르게 락을 획득하고 반납할 수 있다
       - 별도의 커넥션풀을 관리하지 않아도 된다
       - 분산락을 위한 편리한 인터페이스를 지원한다
 - Lettuce VS Redisson 
   - 자바에서 redis를 쓰기위해 주요 사용되는 여러 라이브러리들이 있는데 그중 대표적인 2가지가 Lettuce와 Redisson입니다.
   그중 아래 특성을 고려해서 Redisson 을 채택했습니다.
     - Lettuce는 공식적으로 분산락을 위한 기능을 제공하지는 않고 직접 구현해서 사용해야 합니다. 락을 획득에 실패하면 지속적으로 획득 요청을 보내는 스핀락 형태로 구성하게 됩니다. 이는 Redis에 부하를 발생시킵니다. 또, 락 획득 대기시간이나 락 점유시간에 대해 만료시간을 제공하지 않습니다.
     - Redisson은 락 획득을 스핀락 방식이 아닌 pub/sub 방식을 이용합니다. 락 획득에 실패하면 락 획득을 위해 특정 채널을 subscribe하고 대기합니다. 락이 해제되면 해당 채널에 락이 해제되었음을 알리는 이벤트를 publish하게되고 그때 락 획득을 재시도합니다. 스핀락과 달리 지속적으로 락 획득 요청을 보내지 않기 때문에 Redis에 큰 부하를 발생시키지 않습니다. 
   또, RLock 이라는 락을 위한 인터페이스를 제공하여 락 획득 대기시간, 락 점유시간 등을 설정할 수 있기 때문에 손쉽게 분산락을 구현할 수 있습니다.

### 변경한 부분
- Redisson 라이브러리 의존성 추가
- API 모듈 내 테스트 
  - 기존 테스트 실행시 yml 파일에 security 관련 설정이 없어 오류가 나서 추가했습니다.
  - 동시성 적용여부를 확인을 위한 임시 통합테스트 작성했습니다.
    - 5명이 정원인 커피챗에 100명이 동시에 신청하는 상황을 가정하였는데 테스트 편의상 100명의 회원을 생성하지 않기 위해
    중복신청을 validate하는 로직을 주석처리하고 한명의 회원이 100번 신청하도록 했습니다.
    
- CoffeeChatApplyFacade 클래스 생성 (추후 AOP 적용해서 Facade없이 어노테이션을 쓰도록 리팩토링 예정입니다)
  - CoffeeChatService내 apply 메서드의 비즈니스 로직과 동시성을 위한 락 획득 로직을 구분하기 위해
  - 트랜잭션 레벨을 구분하여 데이터 정합성 보장을 위해
    - CoffeeChatService 내 apply는  @Transactional이 선언되어 있습니다. 락 획득 로직을 해당 메서드에 포함하면 다음과 같은 문제가 생길 수 있습니다. 락을 해제하는 로직이 수행되고 난 이후 해당 메서드가 종료됩니다. 그 때 변경사항이 커밋되고 db에 반영되게 됩니다.
    - 아래 이미지 예시와 같이 변경사항이 커밋되기 이전에 다른 클라이언트가 락을 획득해서 트랜잭션을 시작할 수 있기에 정합성이 맞지 않을 수 있습니다.
    - 따라서, 변경사항이 커밋된 이후 락을 해제할 수 있도록 트랜잭션 레벨이 구분이 필요해서 Facade 클래스를 따로 생성했습니다.
![image](https://github.com/Kernel360/f1-JDON-Backend/assets/111513287/238f5ed4-d2b9-4b00-82e5-9f55b35b1da7)
- ApiException내 생성자 추가
  - 락 획득 과정에서 발생할 수 있는 체크예외 InterruptedException을 런타임 예외(ApiException)로 던지면서 root cause를 포함하기 위해
- 락 획득 대기시간과 락 점유시간을 yml 파일을 통해 클래스로 관리하도록하고 각 환경별 yml 파일에 반영했습니다.


### 변경한 결과
- 중복신청 검증로직을 주석처리하고 테스트 실행시 테스트 성공
![image](https://github.com/Kernel360/f1-JDON-Backend/assets/111513287/0149ae65-b4ce-4612-bb81-e0dabc8e2b22)
- 아래와 같이 연결테이블에 insert하는 쿼리가 5회만 발생
![image](https://github.com/Kernel360/f1-JDON-Backend/assets/111513287/328c184d-d761-4e5b-94a9-14e789e70a76)


### 이슈

- closes: #251 

---

## PR 유형

어떤 변경 사항이 있나요?

- [X] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경, 주석 변경)
- [X] 코드 리팩토링
- [ ] 문서 수정
- [X] 테스트 추가, 테스트 리팩토링
- [ ] 파일 혹은 폴더명 수정, 삭제
- [ ] 배포 관련