### PR TITLE
BugFix: 커피챗 상세조회 시 응답DTO에 커피챗 개설자 식별자를 포함

### DIFF
--- a/module-api/src/main/java/kernel/jdon/coffeechat/dto/response/FindCoffeeChatResponse.java
+++ b/module-api/src/main/java/kernel/jdon/coffeechat/dto/response/FindCoffeeChatResponse.java
@@ -15,6 +15,7 @@ import lombok.Getter;
 public class FindCoffeeChatResponse {
 
 	private Long coffeeChatId;
+	private Long hostId;
 	private String nickname;
 	private String job;
 	private String title;
@@ -32,6 +33,7 @@ public class FindCoffeeChatResponse {
 	public static FindCoffeeChatResponse of(CoffeeChat coffeeChat) {
 		return FindCoffeeChatResponse.builder()
 			.coffeeChatId(coffeeChat.getId())
+			.hostId(coffeeChat.getMember().getId())
 			.nickname(coffeeChat.getMember().getNickname())
 			.job(coffeeChat.getMember().getJobCategory().getName())
 			.title(coffeeChat.getTitle())


### PR DESCRIPTION
### 요약

커피챗 상세 조회 시 로그인한 유저가 개설자인지 여부에 따라 UI를 다르게 그려야 하므로
명확하게 구분하기 위해서 응답 Dto에 개설자의 Id도 포함하도록 했습니다

### 이슈

- closes: #223 

---

## PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [X] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경, 주석 변경)
- [ ] 코드 리팩토링
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 파일 혹은 폴더명 수정, 삭제
- [ ] 배포 관련