### PR TITLE
Refactor: 원티드 스크래핑 비즈니스로직 리팩토링

### DIFF
--- a/module-crawler/src/main/java/kernel/jdon/crawler/config/ScrapingWantedProperties.java
+++ b/module-crawler/src/main/java/kernel/jdon/crawler/config/ScrapingWantedProperties.java
@@ -8,15 +8,15 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 @ConfigurationProperties(prefix = "scraping.wanted")
-public class ScrapingWantedConfig {
-	private final MaxFetchJdListConfig maxFetchJdList;
+public class ScrapingWantedProperties {
+	private final MaxFetchJdList maxFetchJdList;
 	private final Limit limit;
 	private final Sleep sleep;
 	private final Url url;
 
 	@Getter
 	@RequiredArgsConstructor
-	public static class MaxFetchJdListConfig {
+	public static class MaxFetchJdList {
 		private final int size;
 		private final int offset;
 	}
@@ -46,5 +46,37 @@ public class ScrapingWantedConfig {
 	public static class Api {
 		private final String detail;
 		private final String list;
+	}
+
+	public String getDetailUrl() {
+		return this.url.detail;
+	}
+
+	public String getApiDetailUrl() {
+		return this.url.api.detail;
+	}
+
+	public String getApiListUrl() {
+		return this.url.api.list;
+	}
+
+	public int getMaxFetchJdListOffset() {
+		return this.maxFetchJdList.offset;
+	}
+
+	public int getMaxFetchJdListSize() {
+		return this.maxFetchJdList.size;
+	}
+
+	public int getSleepTimeMillis() {
+		return this.sleep.timeMillis;
+	}
+
+	public int getSleepThresholdCount() {
+		return this.sleep.thresholdCount;
+	}
+
+	public int getLimitFailCount() {
+		return this.limit.failCount;
 	}
 }

--- a/module-crawler/src/main/java/kernel/jdon/crawler/wanted/search/JobSearchJobPosition.java
+++ b/module-crawler/src/main/java/kernel/jdon/crawler/wanted/search/JobSearchJobPosition.java
@@ -1,16 +1,23 @@
 package kernel.jdon.crawler.wanted.search;
 
+import java.util.Arrays;
+import java.util.List;
+
 import kernel.jdon.crawler.common.search.SearchCondition;
+import kernel.jdon.crawler.wanted.skill.BackendSkillType;
+import kernel.jdon.crawler.wanted.skill.FrontendSkillType;
+import kernel.jdon.crawler.wanted.skill.SkillType;
 import lombok.AllArgsConstructor;
 
 @AllArgsConstructor
 public enum JobSearchJobPosition implements SearchCondition {
-	JOB_POSITION_FRONTEND("669", "프론트엔드 개발자"),
-	JOB_POSITION_SERVER("872", "서버 개발자");
+	JOB_POSITION_FRONTEND("669", "프론트엔드 개발자", Arrays.asList(FrontendSkillType.values())),
+	JOB_POSITION_SERVER("872", "서버 개발자", Arrays.asList(BackendSkillType.values()));
 
 	public final static String SEARCH_KEY = "job_ids";
 	private final String searchValue;
 	private final String description;
+	private final List<SkillType> skillTypeList;
 
 	public static JobSearchJobPosition[] getAllPositions() {
 		return values();
@@ -24,5 +31,9 @@ public enum JobSearchJobPosition implements SearchCondition {
 	@Override
 	public String getSearchValue() {
 		return this.searchValue;
+	}
+
+	public List<SkillType> getSkillTypeList() {
+		return this.skillTypeList;
 	}
 }

--- a/module-crawler/src/main/java/kernel/jdon/crawler/wanted/service/WantedCrawlerService.java
+++ b/module-crawler/src/main/java/kernel/jdon/crawler/wanted/service/WantedCrawlerService.java
@@ -2,15 +2,15 @@ package kernel.jdon.crawler.wanted.service;
 
 import static kernel.jdon.util.StringUtil.*;
 
-import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.client.RestTemplate;
 
-import kernel.jdon.crawler.config.ScrapingWantedConfig;
+import kernel.jdon.crawler.config.ScrapingWantedProperties;
 import kernel.jdon.crawler.global.error.code.WantedErrorCode;
 import kernel.jdon.crawler.global.error.exception.CrawlerException;
 import kernel.jdon.crawler.wanted.dto.response.WantedJobDetailResponse;
@@ -27,8 +27,6 @@ import kernel.jdon.crawler.wanted.search.JobSearchLocation;
 import kernel.jdon.crawler.wanted.search.JobSearchSort;
 import kernel.jdon.crawler.wanted.service.infrastructure.JobDetailProcessingCounter;
 import kernel.jdon.crawler.wanted.service.infrastructure.JobListProcessingCounter;
-import kernel.jdon.crawler.wanted.skill.BackendSkillType;
-import kernel.jdon.crawler.wanted.skill.FrontendSkillType;
 import kernel.jdon.crawler.wanted.skill.SkillType;
 import kernel.jdon.jobcategory.domain.JobCategory;
 import kernel.jdon.skill.domain.Skill;
@@ -42,7 +40,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class WantedCrawlerService {
 	private final RestTemplate restTemplate;
-	private final ScrapingWantedConfig scrapingWantedConfig;
+	private final ScrapingWantedProperties scrapingWantedProperties;
 	private final WantedJdRepository wantedJdRepository;
 	private final WantedJdSkillRepository wantedJdSkillRepository;
 	private final SkillRepository skillRepository;
@@ -67,7 +65,7 @@ public class WantedCrawlerService {
 
 	private void processJobDetails(final JobSearchJobPosition jobPosition, final JobCategory jobCategory,
 		final Set<Long> fetchJobIds) throws InterruptedException {
-		JobDetailProcessingCounter jobProcessingCounter = new JobDetailProcessingCounter(scrapingWantedConfig);
+		JobDetailProcessingCounter jobProcessingCounter = new JobDetailProcessingCounter(scrapingWantedProperties);
 
 		for (Long jobDetailId : fetchJobIds) {
 			if (jobProcessingCounter.isBreakRequired()) {
@@ -97,7 +95,9 @@ public class WantedCrawlerService {
 		List<WantedJobDetailResponse.WantedSkill> wantedDetailSkillList =
 			jobDetailResponse.getJob().getSkill();
 
+		// todo : 기술 이력을 쌓는 로직은 비동기로 처리하도록 고려 가능(ApplicationEventPublisher)
 		createSkillHistory(jobCategory, savedWantedJd, wantedDetailSkillList);
+
 		createWantedJdSkill(jobPosition, jobCategory, savedWantedJd, wantedDetailSkillList);
 	}
 
@@ -108,7 +108,7 @@ public class WantedCrawlerService {
 	private void createSkillHistory(final JobCategory jobCategory, final WantedJd wantedJd,
 		List<WantedJobDetailResponse.WantedSkill> wantedDetailSkillList) {
 		for (WantedJobDetailResponse.WantedSkill wantedJdDetailSkill : wantedDetailSkillList) {
-			SkillHistory skillHistory = new SkillHistory(wantedJdDetailSkill.getKeyword(), jobCategory, wantedJd);
+			final SkillHistory skillHistory = new SkillHistory(wantedJdDetailSkill.getKeyword(), jobCategory, wantedJd);
 
 			skillHistoryRepository.save(skillHistory);
 		}
@@ -116,34 +116,18 @@ public class WantedCrawlerService {
 
 	private void createWantedJdSkill(final JobSearchJobPosition jobPosition, final JobCategory jobCategory, WantedJd wantedJd,
 		List<WantedJobDetailResponse.WantedSkill> wantedDetailSkillList) {
-		//TODO : 전략패턴으로 리팩토링 필요
-		SkillType[] skillTypes = (jobPosition == JobSearchJobPosition.JOB_POSITION_SERVER)
-			? BackendSkillType.values()
-			: FrontendSkillType.values();
-
 		for (WantedJobDetailResponse.WantedSkill wantedSkill : wantedDetailSkillList) {
 			String skillKeyword = wantedSkill.getKeyword();
-			boolean isSkillInJobPosition = Arrays.stream(skillTypes)
-				.anyMatch(skillType -> skillType.getKeyword().equalsIgnoreCase(skillKeyword));
-			Skill findSkill = null;
 
-			if (isSkillInJobPosition) {
-				SkillType matchedSkillType = Arrays.stream(skillTypes)
-					.filter(skillType -> skillType.getKeyword().equalsIgnoreCase(skillKeyword))
-					.findFirst()
-					.get();
+			final Optional<SkillType> findSkillType = jobPosition.getSkillTypeList().stream()
+				.filter(skillType -> skillType.getKeyword().equalsIgnoreCase(skillKeyword))
+				.findFirst();
 
-				findSkill = findByJobCategoryIdAndKeyword(jobCategory, matchedSkillType.getKeyword());
-			} else {
-				findSkill = findByJobCategoryIdAndKeyword(jobCategory, SkillType.getOrderKeyword());
-			}
+			final Skill findSkill = findSkillType
+				.map(skillType -> findByJobCategoryIdAndKeyword(jobCategory, skillType.getKeyword()))
+				.orElseGet(() -> findByJobCategoryIdAndKeyword(jobCategory, SkillType.getOrderKeyword()));
 
-			WantedJdSkill wantedJdSkill = WantedJdSkill.builder()
-				.wantedJd(wantedJd)
-				.skill(findSkill)
-				.build();
-
-			wantedJdSkillRepository.save(wantedJdSkill);
+			wantedJdSkillRepository.save(new WantedJdSkill(findSkill, wantedJd));
 		}
 	}
 
@@ -161,7 +145,7 @@ public class WantedCrawlerService {
 
 	private void addWantedJobDetailResponse(final WantedJobDetailResponse jobDetailResponse, final JobCategory jobCategory,
 		final Long jobDetailId) {
-		final String jobUrlDetail = scrapingWantedConfig.getUrl().getDetail();
+		final String jobUrlDetail = scrapingWantedProperties.getDetailUrl();
 		jobDetailResponse.addDetailInfo(joinToString(jobUrlDetail, jobDetailId), jobCategory);
 	}
 
@@ -170,25 +154,26 @@ public class WantedCrawlerService {
 	}
 
 	private WantedJobDetailResponse fetchJobDetail(final Long jobId) {
-		final String jobApiDetailUrl = scrapingWantedConfig.getUrl().getApi().getDetail();
+		final String jobApiDetailUrl = scrapingWantedProperties.getApiDetailUrl();
 		final String jobDetailUrl = joinToString(jobApiDetailUrl, jobId);
 
 		return restTemplate.getForObject(jobDetailUrl, WantedJobDetailResponse.class);
 	}
 
 	private Set<Long> fetchJobIdList(final JobSearchJobPosition jobPosition) {
-		JobListProcessingCounter jobListCounter = new JobListProcessingCounter(scrapingWantedConfig);
+		JobListProcessingCounter jobListCounter = new JobListProcessingCounter(scrapingWantedProperties);
 
-		while (jobListCounter.isBelowSizeLimit()) {
+		while (jobListCounter.isMaxFetchSizeLimit()) {
 			WantedJobListResponse jobListResponse = fetchJobList(jobPosition, jobListCounter.getOffset());
 
+			// todo : 일급 컬렉션을 고려 가능
 			List<Long> jobIdList = jobListResponse.getData().stream()
 				.map(WantedJobListResponse.Data::getId)
 				.toList();
 
 			jobListCounter.addFetchedJobIds(jobIdList);
 
-			if (jobListCounter.isBelowOffsetLimit(jobIdList.size())) {
+			if (jobListCounter.isMaxFetchOffsetLimit(jobIdList.size())) {
 				break;
 			}
 
@@ -205,8 +190,8 @@ public class WantedCrawlerService {
 	}
 
 	private String createJobListUrl(final JobSearchJobPosition jobPosition, final int offset) {
-		final int maxFetchJDListOffset = scrapingWantedConfig.getMaxFetchJdList().getOffset();
-		final String jobApiListUrl = scrapingWantedConfig.getUrl().getApi().getList();
+		final int maxFetchJDListOffset = scrapingWantedProperties.getMaxFetchJdListOffset();
+		final String jobApiListUrl = scrapingWantedProperties.getApiListUrl();
 
 		return joinToString(
 			jobApiListUrl,
@@ -221,7 +206,7 @@ public class WantedCrawlerService {
 	}
 
 	private void performSleep() throws InterruptedException {
-		final int sleepTimeMillis = scrapingWantedConfig.getSleep().getTimeMillis();
+		final int sleepTimeMillis = scrapingWantedProperties.getSleepTimeMillis();
 		Thread.sleep(sleepTimeMillis);
 	}
 }

--- a/module-crawler/src/main/java/kernel/jdon/crawler/wanted/service/infrastructure/JobDetailProcessingCounter.java
+++ b/module-crawler/src/main/java/kernel/jdon/crawler/wanted/service/infrastructure/JobDetailProcessingCounter.java
@@ -1,6 +1,6 @@
 package kernel.jdon.crawler.wanted.service.infrastructure;
 
-import kernel.jdon.crawler.config.ScrapingWantedConfig;
+import kernel.jdon.crawler.config.ScrapingWantedProperties;
 
 public class JobDetailProcessingCounter {
 	private final int thresholdCount;
@@ -8,9 +8,9 @@ public class JobDetailProcessingCounter {
 	private int sleepCount = 0;
 	private int consecutiveFailCount = 0;
 
-	public JobDetailProcessingCounter(ScrapingWantedConfig scrapingWantedConfig) {
-		this.thresholdCount = scrapingWantedConfig.getSleep().getThresholdCount();
-		this.failLimitCount = scrapingWantedConfig.getLimit().getFailCount();
+	public JobDetailProcessingCounter(ScrapingWantedProperties scrapingWantedProperties) {
+		this.thresholdCount = scrapingWantedProperties.getSleepThresholdCount();
+		this.failLimitCount = scrapingWantedProperties.getLimitFailCount();
 	}
 
 	public void incrementSleepCounter() {

--- a/module-crawler/src/main/java/kernel/jdon/crawler/wanted/service/infrastructure/JobListProcessingCounter.java
+++ b/module-crawler/src/main/java/kernel/jdon/crawler/wanted/service/infrastructure/JobListProcessingCounter.java
@@ -4,7 +4,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 
-import kernel.jdon.crawler.config.ScrapingWantedConfig;
+import kernel.jdon.crawler.config.ScrapingWantedProperties;
 
 public class JobListProcessingCounter {
 	private final int maxFetchJDListSize;
@@ -12,16 +12,16 @@ public class JobListProcessingCounter {
 	private int offset = 0;
 	private Set<Long> fetchedJobIds = new LinkedHashSet<>();
 
-	public JobListProcessingCounter(ScrapingWantedConfig scrapingWantedConfig) {
-		this.maxFetchJDListSize = scrapingWantedConfig.getMaxFetchJdList().getSize();
-		this.maxFetchJDListOffset = scrapingWantedConfig.getMaxFetchJdList().getOffset();
+	public JobListProcessingCounter(final ScrapingWantedProperties scrapingWantedProperties) {
+		this.maxFetchJDListSize = scrapingWantedProperties.getMaxFetchJdListSize();
+		this.maxFetchJDListOffset = scrapingWantedProperties.getMaxFetchJdListOffset();
 	}
 
-	public boolean isBelowSizeLimit() {
+	public boolean isMaxFetchSizeLimit() {
 		return fetchedJobIds.size() < maxFetchJDListSize;
 	}
 
-	public boolean isBelowOffsetLimit(int jobIdListSize) {
+	public boolean isMaxFetchOffsetLimit(final int jobIdListSize) {
 		return jobIdListSize < maxFetchJDListOffset;
 	}
 
@@ -37,7 +37,7 @@ public class JobListProcessingCounter {
 		return fetchedJobIds;
 	}
 
-	public void addFetchedJobIds(List<Long> jobIdList) {
+	public void addFetchedJobIds(final List<Long> jobIdList) {
 		fetchedJobIds.addAll(jobIdList);
 	}
 }


### PR DESCRIPTION
## 개요

### 요약
- 멘토링때 조언받은 부분에 대한 리팩토링을 적용했습니다.

### 변경한 부분
- application.yml의 프로퍼티 값을 바인딩하는 객체의 클래스명을 좀 더 명확한 의미인 ScrapingWantedConfig -> ScrapingWantedProperties 로 변경하였습니다.
- ScrapingWantedProperties 객체 내부의 값을 사용하는 쪽에서 체이닝해서 가져오는 것이 아니라 ScrapingWantedProperties가 바로 반환할 수 있도록 getter 메서드를 추가하고 사용하는 쪽에서 해당 메서드로 객체에 접근하도록 수정하였습니다.
- JobSearchJobPosition 생성자에 List<SkillType>를 추가하여 직군별 직무 객체인 JobSearchJobPosition가 해당 스킬목록을 가지고 있도록 수정하였습니다.
따라서 WantedCrawlerService.createWantedJdSkill() 에서
```
SkillType[] skillTypes = (jobPosition == JobSearchJobPosition.JOB_POSITION_SERVER)
	? BackendSkillType.values()
	: FrontendSkillType.values();
```
위와 같이 상태에 따라 SkillType을 초기화하지 않도록 수정하였습니다.
- WantedCrawlerService.createWantedJdSkill() 에서 추출한 기술스택이 SkillType(열거형 클래스)에 포함되어있는지 루프를 돌아 체크하고, 사용하는 쪽에서 또 루프를 돌아서 해당 keyword에 접근하던 로직을
```
final Optional<SkillType> findSkillType = jobPosition.getSkillTypeList().stream()
	.filter(skillType -> skillType.getKeyword().equalsIgnoreCase(skillKeyword))
	.findFirst();

final Skill findSkill = findSkillType
	.map(skillType -> findByJobCategoryIdAndKeyword(jobCategory, skillType.getKeyword()))
	.orElseGet(() -> findByJobCategoryIdAndKeyword(jobCategory, SkillType.getOrderKeyword()));
```
위와 같이 1번의 루프를 통해 접근할 수 있도록 수정했습니다.
- 메서드에서 변경될 일이 없는 매개변수에 final 키워드를 추가했습니다.

---
### 추가로 고려할 만한 사항(TODO 주석 포함한 부분)
- 스크래핑후 기술 이력을 저장하는 부분은 ApplicationEventPublisher와 같은 이벤트 형식으로 비동기 처리해도 된다는 멘토링을 받았습니다. 이 부분은 배치로 변경하면서 고려해보도록 하겠습니다.
- 일급컬렉션을 고려할 수 있다는 부분이 있었습니다. 이부분도 배치로 변경하면서 고려해보도록 하겠습니다.

---
### 변경한 결과
- 정상적으로 스크래핑 되는 결과 및 데이터의 저장을 확인하였습니다.
<img width="557" alt="image" src="https://github.com/Kernel360/f1-JDON-Backend/assets/59242594/97ab9b31-d378-4969-8949-0d4f30767daf">


### 이슈

- closes: #277 

---

## PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경, 주석 변경)
- [x] 코드 리팩토링
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 파일 혹은 폴더명 수정, 삭제
- [ ] 배포 관련