### PR TITLE
Bug: 커피챗 목록 조회에서 삭제된 커피챗 조회되는 현상 수정

### DIFF
--- a/module-api/src/main/java/kernel/jdon/coffeechat/repository/CoffeeChatRepositoryImpl.java
+++ b/module-api/src/main/java/kernel/jdon/coffeechat/repository/CoffeeChatRepositoryImpl.java
@@ -48,6 +48,7 @@ public class CoffeeChatRepositoryImpl implements CustomCoffeeChatRepository {
 			.join(jobCategory)
 			.on(member.jobCategory.eq(jobCategory))
 			.where(
+				excludeDeleteCoffeeChat(),
 				coffeeChatTitleContains(coffeeChatCondition.getKeyword()),
 				memberJobCategoryEq(coffeeChatCondition.getJobCategory())
 			)
@@ -64,6 +65,7 @@ public class CoffeeChatRepositoryImpl implements CustomCoffeeChatRepository {
 			.join(member)
 			.on(coffeeChat.member.eq(member))
 			.where(
+				excludeDeleteCoffeeChat(),
 				coffeeChatTitleContains(coffeeChatCondition.getKeyword()),
 				memberJobCategoryEq(coffeeChatCondition.getJobCategory())
 			)
@@ -89,6 +91,10 @@ public class CoffeeChatRepositoryImpl implements CustomCoffeeChatRepository {
 
 	private BooleanExpression coffeeChatTitleContains(String keyword) {
 		return hasText(keyword) ? coffeeChat.title.contains(keyword) : null;
+	}
+
+	private BooleanExpression excludeDeleteCoffeeChat() {
+		return coffeeChat.isDeleted.eq(false);
 	}
 
 }


### PR DESCRIPTION
## 개요

### 요약
- 커피챗 목록 조회에서 삭제된 커피챗 조회되는 현상 수정

### 변경한 부분
- 커피챗 목록 조회 SQL 조건절에 `is_deleted = false` 조건을 추가하였습니다.
  - excludeDeleteCoffeeChat() 메서드 추가

### 변경한 결과
API 요청 시 삭제된 커피챗이 조회되지 않는 것을 확인했습니다.
![image](https://github.com/Kernel360/f1-JDON-Backend/assets/59242594/eb0dcef7-3570-4921-9f13-bee84cba424c)

<img width="673" alt="image" src="https://github.com/Kernel360/f1-JDON-Backend/assets/59242594/73751705-a1ca-43d8-b0a9-3d1381627551">


### 이슈

- closes: #282 

---

## PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경, 주석 변경)
- [ ] 코드 리팩토링
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 파일 혹은 폴더명 수정, 삭제
- [ ] 배포 관련