### PR TITLE
Fix: 커피챗 상세조회 시 작성자 여부 응답 DTO에 포함

### DIFF
--- a/module-api/src/main/java/kernel/jdon/coffeechat/controller/CoffeeChatController.java
+++ b/module-api/src/main/java/kernel/jdon/coffeechat/controller/CoffeeChatController.java
@@ -30,6 +30,7 @@ import kernel.jdon.dto.response.CommonResponse;
 import kernel.jdon.global.annotation.LoginUser;
 import kernel.jdon.global.page.CustomPageResponse;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.java.Log;
 import lombok.extern.slf4j.Slf4j;
 
 @RestController
@@ -41,15 +42,18 @@ public class CoffeeChatController {
 	private final CoffeeChatApplyFacade coffeeChatApplyFacade;
 
 	@GetMapping("/api/v1/coffeechats/{id}")
-	public ResponseEntity<CommonResponse> get(@PathVariable(name = "id") Long coffeeChatId) {
+	public ResponseEntity<CommonResponse> get(
+		@PathVariable(name = "id") Long coffeeChatId,
+		@LoginUser SessionUserInfo sessionUser) {
 
-		return ResponseEntity.ok().body(CommonResponse.of(coffeeChatService.find(coffeeChatId)));
+		return ResponseEntity.ok().body(CommonResponse.of(coffeeChatService.find(coffeeChatId, sessionUser.getId())));
 	}
 
 	@PostMapping("/api/v1/coffeechats")
 	public ResponseEntity<CommonResponse> save(
 		@RequestBody CreateCoffeeChatRequest request,
 		@LoginUser SessionUserInfo sessionUser) {
+
 		log.info("request: {}", request.toString());
 		log.info("sessionUser: {}", sessionUser.getId());
 		CreateCoffeeChatResponse response = coffeeChatService.create(request, sessionUser.getId());

--- a/module-api/src/main/java/kernel/jdon/coffeechat/dto/response/FindCoffeeChatResponse.java
+++ b/module-api/src/main/java/kernel/jdon/coffeechat/dto/response/FindCoffeeChatResponse.java
@@ -16,6 +16,7 @@ public class FindCoffeeChatResponse {
 
 	private Long coffeeChatId;
 	private Long hostId;
+	private Boolean isAuthor;
 	private String nickname;
 	private String job;
 	private String title;
@@ -30,10 +31,11 @@ public class FindCoffeeChatResponse {
 	private Long totalRecruitCount;
 	private Long currentRecruitCount;
 
-	public static FindCoffeeChatResponse of(CoffeeChat coffeeChat) {
+	public static FindCoffeeChatResponse of(CoffeeChat coffeeChat, Boolean isAuthor) {
 		return FindCoffeeChatResponse.builder()
 			.coffeeChatId(coffeeChat.getId())
 			.hostId(coffeeChat.getMember().getId())
+			.isAuthor(isAuthor)
 			.nickname(coffeeChat.getMember().getNickname())
 			.job(coffeeChat.getMember().getJobCategory().getName())
 			.title(coffeeChat.getTitle())

--- a/module-api/src/main/java/kernel/jdon/coffeechat/service/CoffeeChatService.java
+++ b/module-api/src/main/java/kernel/jdon/coffeechat/service/CoffeeChatService.java
@@ -61,11 +61,12 @@ public class CoffeeChatService {
 	}
 
 	@Transactional
-	public FindCoffeeChatResponse find(Long coffeeChatId) {
+	public FindCoffeeChatResponse find(Long coffeeChatId, Long memberId) {
 		CoffeeChat findCoffeeChat = findExistCoffeeChat(coffeeChatId);
+		Boolean isAuthor = findCoffeeChat.getMember().getId().equals(memberId);
 		increaseViewCount(findCoffeeChat);
 
-		return FindCoffeeChatResponse.of(findCoffeeChat);
+		return FindCoffeeChatResponse.of(findCoffeeChat, isAuthor);
 	}
 
 	private void increaseViewCount(CoffeeChat coffeeChat) {

--- a/module-api/src/test/java/kernel/jdon/moduleapi/coffeechat/controller/CoffeeChatControllerTest.java
+++ b/module-api/src/test/java/kernel/jdon/moduleapi/coffeechat/controller/CoffeeChatControllerTest.java
@@ -12,6 +12,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockHttpSession;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
@@ -20,6 +21,7 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import kernel.jdon.auth.dto.SessionUserInfo;
 import kernel.jdon.coffeechat.controller.CoffeeChatController;
 import kernel.jdon.coffeechat.dto.request.CreateCoffeeChatRequest;
 import kernel.jdon.coffeechat.dto.request.UpdateCoffeeChatRequest;
@@ -27,6 +29,7 @@ import kernel.jdon.coffeechat.dto.response.CreateCoffeeChatResponse;
 import kernel.jdon.coffeechat.dto.response.DeleteCoffeeChatResponse;
 import kernel.jdon.coffeechat.dto.response.FindCoffeeChatResponse;
 import kernel.jdon.coffeechat.dto.response.UpdateCoffeeChatResponse;
+import kernel.jdon.coffeechat.service.CoffeeChatApplyFacade;
 import kernel.jdon.coffeechat.service.CoffeeChatService;
 
 @WebMvcTest(CoffeeChatController.class)
@@ -34,6 +37,9 @@ class CoffeeChatControllerTest {
 
 	@MockBean
 	private CoffeeChatService coffeeChatService;
+
+	@MockBean
+	private CoffeeChatApplyFacade coffeeChatApplyFacade;
 
 	@Autowired
 	private MockMvc mockMvc;
@@ -73,11 +79,18 @@ class CoffeeChatControllerTest {
 		//given
 		Long coffeeChatId = 1L;
 		FindCoffeeChatResponse response = findCoffeeChatResponse();
-		when(coffeeChatService.find(coffeeChatId)).thenReturn(response);
+		when(coffeeChatService.find(coffeeChatId, 1L)).thenReturn(response);
+
+		SessionUserInfo sessionUser = mock(SessionUserInfo.class);
+		when(sessionUser.getId()).thenReturn(1L);
+
+		MockHttpSession session = new MockHttpSession();
+		session.setAttribute("USER", sessionUser);
 
 		//when
 		ResultActions resultActions = mockMvc.perform(
-			MockMvcRequestBuilders.get("/api/v1/coffeechats/{id}", coffeeChatId));
+			MockMvcRequestBuilders.get("/api/v1/coffeechats/{id}", coffeeChatId)
+				.session(session));
 
 		//then
 		resultActions.andExpect(status().isOk())


### PR DESCRIPTION
### 요약

커피챗 상세조회 시 신청자/개설자 여부에 따라 ui를 다르게 그려야 하므로
응답DTO에 로그인 유저가 작성자인지 여부를 포함하도록 했습니다.

### 변경한 부분

- CoffeechatController에서 로그인 유저 정보를 받아옵니다.
- CoffeeChatService에서 작성자 여부를 판단해서 dto를 반환하도록 했습니다.
- 서비스 메서드 시그니처가 변경됨에 따라 컨트롤러 테스트 코드도 수정했습니다.

### 변경한 결과

![image](https://github.com/Kernel360/f1-JDON-Backend/assets/111513287/78450d1c-940a-4b51-a6ad-d99da045b804)


### 이슈

- closes: #288 

---

## PR 유형

어떤 변경 사항이 있나요?

- [X] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경, 주석 변경)
- [ ] 코드 리팩토링
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 파일 혹은 폴더명 수정, 삭제
- [ ] 배포 관련