### PR TITLE
Refactor: 커피챗의 상태를 비교하는 로직을 엔터티로 캡슐화

### DIFF
--- a/module-api/src/main/java/kernel/jdon/coffeechat/service/CoffeeChatService.java
+++ b/module-api/src/main/java/kernel/jdon/coffeechat/service/CoffeeChatService.java
@@ -47,7 +47,7 @@ public class CoffeeChatService {
 	private CoffeeChat findExistAndOpenCoffeeChat(Long coffeeChatId) {
 
 		CoffeeChat findCoffeeChat = findExistCoffeeChat(coffeeChatId);
-		if (findCoffeeChat.getCoffeeChatStatus() != CoffeeChatActiveStatus.OPEN) {
+		if (findCoffeeChat.isNotOpen()) {
 			throw new ApiException(CoffeeChatErrorCode.NOT_OPEN_COFFEECHAT);
 		}
 

--- a/module-domain/src/main/java/kernel/jdon/coffeechat/domain/CoffeeChat.java
+++ b/module-domain/src/main/java/kernel/jdon/coffeechat/domain/CoffeeChat.java
@@ -112,6 +112,10 @@ public class CoffeeChat extends AbstractEntity {
 		updateStatusByRecruitCount();
 	}
 
+	public boolean isNotOpen() {
+		return coffeeChatStatus != CoffeeChatActiveStatus.OPEN;
+	}
+
 	public boolean isExpired() {
 		return this.meetDate.isBefore(LocalDateTime.now());
 	}


### PR DESCRIPTION
### 요약

기존에 OPEN 상태인 커피챗을 조회할 때 서비스계층에서 커피챗의 상태를 get 해온뒤 CoffeeChatStatus Enum과 비교했습니다.
이 로직을 엔터티 내로 캡슐화하여 가독성과 유지보수성을 증대했습니다.

### 변경한 부분

- CoffeeChat엔터티 내 isNotOpen 메서드를 추가했습니다.
- CoffeeChatService에서 모집중인지 검증이 필요할경우 엔터티내 해당 메서드를 통해 검증합니다.


### 이슈

- closes: #296 

---

## PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경, 주석 변경)
- [X] 코드 리팩토링
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 파일 혹은 폴더명 수정, 삭제
- [ ] 배포 관련