### PR TITLE
Feature: 유저의 로그인 상태를 확인할 수 있는 API 구현

### DIFF
--- a/module-api/src/main/java/kernel/jdon/auth/controller/AuthController.java
+++ b/module-api/src/main/java/kernel/jdon/auth/controller/AuthController.java
@@ -1,5 +1,14 @@
 package kernel.jdon.auth.controller;
 
+import java.net.URI;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
 import kernel.jdon.auth.dto.SessionUserInfo;
 import kernel.jdon.auth.dto.request.RegisterRequest;
 import kernel.jdon.auth.dto.response.RegisterResponse;
@@ -10,13 +19,6 @@ import kernel.jdon.global.annotation.LoginUser;
 import kernel.jdon.member.service.MemberService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RestController;
-
-import java.net.URI;
 
 @Slf4j
 @RestController
@@ -41,5 +43,11 @@ public class AuthController {
 		Long withdrawMemberId = authService.withdraw(sessionUser);
 
 		return ResponseEntity.ok(CommonResponse.of(WithdrawResponse.of(withdrawMemberId)));
+	}
+
+	@GetMapping("/api/v1/authenticate")
+	public ResponseEntity<Void> authenticate() {
+
+		return ResponseEntity.noContent().build();
 	}
 }

--- a/module-api/src/main/java/kernel/jdon/auth/service/JdonOAuth2UserService.java
+++ b/module-api/src/main/java/kernel/jdon/auth/service/JdonOAuth2UserService.java
@@ -1,16 +1,8 @@
 package kernel.jdon.auth.service;
 
-import jakarta.servlet.http.HttpSession;
-import kernel.jdon.auth.dto.JdonOAuth2User;
-import kernel.jdon.auth.dto.SessionUserInfo;
-import kernel.jdon.auth.dto.UserInfoFromOAuth2;
-import kernel.jdon.auth.error.AuthErrorCode;
-import kernel.jdon.global.exception.UnAuthorizedException;
-import kernel.jdon.member.domain.Member;
-import kernel.jdon.member.domain.SocialProviderType;
-import kernel.jdon.member.repository.MemberRepository;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
+import java.util.List;
+import java.util.Map;
+
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
@@ -20,8 +12,17 @@ import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.List;
-import java.util.Map;
+import jakarta.servlet.http.HttpSession;
+import kernel.jdon.auth.dto.JdonOAuth2User;
+import kernel.jdon.auth.dto.SessionUserInfo;
+import kernel.jdon.auth.dto.UserInfoFromOAuth2;
+import kernel.jdon.auth.error.AuthErrorCode;
+import kernel.jdon.global.exception.AuthException;
+import kernel.jdon.member.domain.Member;
+import kernel.jdon.member.domain.SocialProviderType;
+import kernel.jdon.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @Service
@@ -82,12 +83,12 @@ public class JdonOAuth2UserService extends DefaultOAuth2UserService {
 
 	private void isEmailExist(String email) {
 		if (email == null)
-			throw new UnAuthorizedException(AuthErrorCode.UNAUTHORIZED_OAUTH_RETURN_NULL_EMAIL);
+			throw new AuthException(AuthErrorCode.UNAUTHORIZED_OAUTH_RETURN_NULL_EMAIL);
 	}
 
 	private void checkRightSocialProvider(Member findMember, SocialProviderType socialProvider) {
 		if (!findMember.isRightSocialProvider(socialProvider))
-			throw new UnAuthorizedException(AuthErrorCode.UNAUTHORIZED_NOT_MATCH_PROVIDER_TYPE);
+			throw new AuthException(AuthErrorCode.UNAUTHORIZED_NOT_MATCH_PROVIDER_TYPE);
 	}
 
 	private SocialProviderType getSocialProvider(OAuth2UserRequest userRequest) {

--- a/module-api/src/main/java/kernel/jdon/config/auth/JdonAuthExceptionHandler.java
+++ b/module-api/src/main/java/kernel/jdon/config/auth/JdonAuthExceptionHandler.java
@@ -1,54 +1,50 @@
 package kernel.jdon.config.auth;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import jakarta.servlet.ServletException;
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
-import kernel.jdon.auth.dto.AuthExceptionResponse;
-import kernel.jdon.auth.error.AuthErrorCode;
-import kernel.jdon.error.ErrorCode;
-import kernel.jdon.global.exception.UnAuthorizedException;
-import org.springframework.http.MediaType;
+import java.io.IOException;
+
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.security.web.access.AccessDeniedHandler;
 import org.springframework.security.web.authentication.AuthenticationFailureHandler;
 import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerExceptionResolver;
 
-import java.io.IOException;
-import java.io.PrintWriter;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import kernel.jdon.auth.error.AuthErrorCode;
+import kernel.jdon.global.exception.AuthException;
 
 @Component
-public class JdonAuthExceptionHandler implements AuthenticationEntryPoint, AccessDeniedHandler, AuthenticationFailureHandler {
+public class JdonAuthExceptionHandler
+	implements AuthenticationEntryPoint, AccessDeniedHandler, AuthenticationFailureHandler {
 
-    private void throwAuthException(HttpServletResponse response, ErrorCode authErrorCode, String redirectUri) throws
-            IOException {
-        AuthExceptionResponse exceptionResponse = new AuthExceptionResponse(
-                authErrorCode.getHttpStatus().value(), authErrorCode.getMessage(), redirectUri);
-        String exceptionResponseJson = new ObjectMapper().writeValueAsString(exceptionResponse);
-        response.setStatus(authErrorCode.getHttpStatus().value());
-        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
-        response.setCharacterEncoding("utf-8");
-        PrintWriter write = response.getWriter();
-        write.write(exceptionResponseJson);
-        write.flush();
-    }
+	private final HandlerExceptionResolver resolver;
 
-    @Override
-    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException, ServletException {
-        throwAuthException(response, AuthErrorCode.UNAUTHORIZED, "/");
-    }
+	public JdonAuthExceptionHandler(@Qualifier("handlerExceptionResolver") HandlerExceptionResolver resolver) {
+		this.resolver = resolver;
+	}
 
-    @Override
-    public void handle(HttpServletRequest request, HttpServletResponse response, AccessDeniedException accessDeniedException) throws IOException, ServletException {
-        throwAuthException(response, AuthErrorCode.FORBIDDEN, "/");
-    }
+	@Override
+	public void commence(HttpServletRequest request, HttpServletResponse response,
+		AuthenticationException authException) throws IOException, ServletException {
+		resolver.resolveException(request, response, null, new AuthException(AuthErrorCode.UNAUTHORIZED));
+	}
 
-    @Override
-    public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response, AuthenticationException exception) throws IOException, ServletException {
-        if (exception instanceof UnAuthorizedException) {
-            throwAuthException(response, ((UnAuthorizedException) exception).getErrorCode(), "/");
-        }
-    }
+	@Override
+	public void handle(HttpServletRequest request, HttpServletResponse response,
+		AccessDeniedException accessDeniedException) throws IOException, ServletException {
+		resolver.resolveException(request, response, null, new AuthException(AuthErrorCode.FORBIDDEN));
+	}
+
+	@Override
+	public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response,
+		AuthenticationException exception) throws IOException, ServletException {
+		if (exception instanceof AuthException) {
+			resolver.resolveException(request, response, null,
+				new AuthException(((AuthException)exception).getErrorCode()));
+		}
+	}
 }

--- a/module-api/src/main/java/kernel/jdon/config/auth/OAuth2SecurityConfig.java
+++ b/module-api/src/main/java/kernel/jdon/config/auth/OAuth2SecurityConfig.java
@@ -50,13 +50,14 @@ public class OAuth2SecurityConfig {
 		http.cors(corsCustomizer -> corsCustomizer.configurationSource(request -> {
 			CorsConfiguration config = new CorsConfiguration();
 			config.setAllowedOrigins(List.of("http://localhost:3000", "https://localhost:3000",
-				"https://jdon.kr", "https://jdon.netlify.app"));
+				"https://jdon.kr", "https://jdon.netlify.app", "https://jdon-test.netlify.app/"));
 			config.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE"));
 			config.setAllowedHeaders(List.of("*"));
 			config.setAllowCredentials(true);
 			config.setMaxAge(3600L);
 
-			return config;}));
+			return config;
+		}));
 		http.exceptionHandling(exceptionConfig -> exceptionConfig
 			.authenticationEntryPoint(jdonAuthExceptionHandler)
 			.accessDeniedHandler(jdonAuthExceptionHandler));

--- a/module-api/src/main/java/kernel/jdon/global/exception/AuthException.java
+++ b/module-api/src/main/java/kernel/jdon/global/exception/AuthException.java
@@ -1,14 +1,15 @@
 package kernel.jdon.global.exception;
 
-import kernel.jdon.error.ErrorCode;
-import lombok.Getter;
 import org.springframework.security.core.AuthenticationException;
 
+import kernel.jdon.error.ErrorCode;
+import lombok.Getter;
+
 @Getter
-public class UnAuthorizedException extends AuthenticationException {
+public class AuthException extends AuthenticationException {
 	private final transient ErrorCode errorCode;
 
-	public UnAuthorizedException(ErrorCode errorCode) {
+	public AuthException(ErrorCode errorCode) {
 		super(errorCode.getMessage());
 		this.errorCode = errorCode;
 	}

--- a/module-api/src/main/java/kernel/jdon/global/exception/GlobalExceptionHandler.java
+++ b/module-api/src/main/java/kernel/jdon/global/exception/GlobalExceptionHandler.java
@@ -18,4 +18,11 @@ public class GlobalExceptionHandler {
 		return ResponseEntity.status(e.getErrorCode().getHttpStatus().value())
 			.body(ErrorResponse.of(e.getErrorCode(), request));
 	}
+
+	@ExceptionHandler({AuthException.class})
+	public ResponseEntity<ErrorResponse> handleAuthenticationException(AuthException e, HttpServletRequest request) {
+		log.warn(e.getMessage(), e);
+		return ResponseEntity.status(e.getErrorCode().getHttpStatus().value())
+			.body(ErrorResponse.of(e.getErrorCode(), request));
+	}
 }


### PR DESCRIPTION
## 개요

### 요약 

### 변경한 부분

- 프론트에서 페이지를 그리기 위해 유저의 로그인 유무를 확인해야하는데 이때 사용할 API를 작성했습니다. 
  인증받은 유저라면 해당 API를 요청했을 때 204가, 인증받은 유저가 아니라면 401 에러가 반환됩니다. 

- auth 로직 중 error가 발생하면 writer를 통해서 error를 리턴하고 있었는데, GlobalExceptionHandler(@RestControllerAdvice) 에서 AuthException을 잡아서 핸들링하도록 수정했습니다.

- 프론트 요청으로 cors 허용 origin  하나 더 추가했습니다. 

- Auth 관련 Exception 클래스의 이름을 좀 더 포괄적으로 `UnAuthorizationException`에서 `AuthException`으로 변경했습니다. 

### 변경한 결과

### 이슈

- closes: #257 
- closes: #271 

---

## PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경, 주석 변경)
- [ ] 코드 리팩토링
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 파일 혹은 폴더명 수정, 삭제
- [ ] 배포 관련