### PR TITLE
Fix: request 온 host에 맞게 redirect 주소를 설정하도록 수정

### DIFF
--- a/module-api/src/main/java/kernel/jdon/auth/service/AuthService.java
+++ b/module-api/src/main/java/kernel/jdon/auth/service/AuthService.java
@@ -1,15 +1,10 @@
 package kernel.jdon.auth.service;
 
-import kernel.jdon.auth.dto.SessionUserInfo;
-import kernel.jdon.auth.error.AuthErrorCode;
-import kernel.jdon.config.auth.WithdrawConfig;
-import kernel.jdon.global.exception.ApiException;
-import kernel.jdon.member.domain.SocialProviderType;
-import kernel.jdon.member.error.MemberErrorCode;
-import kernel.jdon.member.repository.MemberRepository;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.*;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.LinkedMultiValueMap;
@@ -17,50 +12,60 @@ import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
 
+import kernel.jdon.auth.dto.SessionUserInfo;
+import kernel.jdon.auth.error.AuthErrorCode;
+import kernel.jdon.config.auth.WithdrawProperties;
+import kernel.jdon.global.exception.ApiException;
+import kernel.jdon.member.domain.SocialProviderType;
+import kernel.jdon.member.error.MemberErrorCode;
+import kernel.jdon.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
 @Service
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
 @Slf4j
 public class AuthService {
 
-    private final MemberRepository memberRepository;
-    private final WithdrawConfig withdrawConfig;
+	private final MemberRepository memberRepository;
+	private final WithdrawProperties withdrawProperties;
 
-    @Transactional
-    public Long withdraw(SessionUserInfo userInfo) {
-        sendDeleteRequestToOAuth2(userInfo);
-        memberRepository.findById(userInfo.getId())
-                .orElseThrow(() -> new ApiException(MemberErrorCode.NOT_FOUND_MEMBER))
-                .withdrawMemberAccount();
+	@Transactional
+	public Long withdraw(SessionUserInfo userInfo) {
+		sendDeleteRequestToOAuth2(userInfo);
+		memberRepository.findById(userInfo.getId())
+			.orElseThrow(() -> new ApiException(MemberErrorCode.NOT_FOUND_MEMBER))
+			.withdrawMemberAccount();
 
-        return userInfo.getId();
-    }
+		return userInfo.getId();
+	}
 
-    private void sendDeleteRequestToOAuth2(SessionUserInfo userInfo) {
-        if (SocialProviderType.KAKAO == userInfo.getSocialProvider()) {
-            deleteKakaoAccount(userInfo);
-        } else if (SocialProviderType.GITHUB == userInfo.getSocialProvider()) {
-            return ;
-        } else {
-            throw new ApiException(AuthErrorCode.UNAUTHORIZED_NOT_MATCH_PROVIDER_TYPE);
-        }
-    }
+	private void sendDeleteRequestToOAuth2(SessionUserInfo userInfo) {
+		if (SocialProviderType.KAKAO == userInfo.getSocialProvider()) {
+			deleteKakaoAccount(userInfo);
+		} else if (SocialProviderType.GITHUB == userInfo.getSocialProvider()) {
+			return;
+		} else {
+			throw new ApiException(AuthErrorCode.UNAUTHORIZED_NOT_MATCH_PROVIDER_TYPE);
+		}
+	}
 
-    private void deleteKakaoAccount(SessionUserInfo userInfo) {
-        HttpHeaders headers = new HttpHeaders();
-        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
-        headers.set("Authorization", "KakaoAK " + withdrawConfig.getAppAdminKey());
+	private void deleteKakaoAccount(SessionUserInfo userInfo) {
+		HttpHeaders headers = new HttpHeaders();
+		headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+		headers.set("Authorization", "KakaoAK " + withdrawProperties.getAppAdminKey());
 
-        MultiValueMap<String, String> requestBody = new LinkedMultiValueMap<>();
-        requestBody.add("target_id_type", "user_id");
-        requestBody.add("target_id", userInfo.getOAuthId());
+		MultiValueMap<String, String> requestBody = new LinkedMultiValueMap<>();
+		requestBody.add("target_id_type", "user_id");
+		requestBody.add("target_id", userInfo.getOAuthId());
 
-        UriComponentsBuilder builder = UriComponentsBuilder.fromHttpUrl(withdrawConfig.getDeleteUserUrl());
+		UriComponentsBuilder builder = UriComponentsBuilder.fromHttpUrl(withdrawProperties.getDeleteUserUrl());
 
-        HttpEntity<MultiValueMap<String, String>> requestEntity = new HttpEntity(requestBody, headers);
+		HttpEntity<MultiValueMap<String, String>> requestEntity = new HttpEntity(requestBody, headers);
 
-        RestTemplate restTemplate = new RestTemplate();
-        ResponseEntity<String> responseEntity = restTemplate
-                .exchange(builder.toUriString(), HttpMethod.POST, requestEntity, String.class);
-    }
+		RestTemplate restTemplate = new RestTemplate();
+		ResponseEntity<String> responseEntity = restTemplate
+			.exchange(builder.toUriString(), HttpMethod.POST, requestEntity, String.class);
+	}
 }

--- a/module-api/src/main/java/kernel/jdon/auth/service/AuthService.java
+++ b/module-api/src/main/java/kernel/jdon/auth/service/AuthService.java
@@ -27,7 +27,6 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 @Slf4j
 public class AuthService {
-
 	private final MemberRepository memberRepository;
 	private final WithdrawProperties withdrawProperties;
 

--- a/module-api/src/main/java/kernel/jdon/auth/service/JdonOAuth2UserService.java
+++ b/module-api/src/main/java/kernel/jdon/auth/service/JdonOAuth2UserService.java
@@ -19,6 +19,7 @@ import kernel.jdon.auth.dto.UserInfoFromOAuth2;
 import kernel.jdon.auth.error.AuthErrorCode;
 import kernel.jdon.global.exception.AuthException;
 import kernel.jdon.member.domain.Member;
+import kernel.jdon.member.domain.MemberRole;
 import kernel.jdon.member.domain.SocialProviderType;
 import kernel.jdon.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
@@ -56,9 +57,9 @@ public class JdonOAuth2UserService extends DefaultOAuth2UserService {
 			checkRightSocialProvider(findMember, userInfo.getSocialProvider());
 			httpSession.setAttribute("USER", SessionUserInfo.of(findMember, userInfo));
 			findMember.updateLastLoginDate();
-			authorities = List.of(new SimpleGrantedAuthority("ROLE_USER"));
+			authorities = List.of(new SimpleGrantedAuthority(MemberRole.ROLE_USER.name()));
 		} else {
-			authorities = List.of(new SimpleGrantedAuthority("ROLE_TEMPORARY_USER"));
+			authorities = List.of(new SimpleGrantedAuthority(MemberRole.ROLE_GUEST.name()));
 		}
 		return new JdonOAuth2User(authorities, user.getAttributes(), getUserNameAttributeName(userRequest),
 			userInfo.getEmail(), userInfo.getSocialProvider());

--- a/module-api/src/main/java/kernel/jdon/auth/service/LoginUserArgumentResolver.java
+++ b/module-api/src/main/java/kernel/jdon/auth/service/LoginUserArgumentResolver.java
@@ -1,5 +1,7 @@
 package kernel.jdon.auth.service;
 
+import java.util.Objects;
+
 import org.springframework.core.MethodParameter;
 import org.springframework.stereotype.Component;
 import org.springframework.web.bind.support.WebDataBinderFactory;
@@ -8,11 +10,8 @@ import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.method.support.ModelAndViewContainer;
 
 import jakarta.servlet.http.HttpSession;
-import kernel.jdon.auth.dto.UserInfoFromOAuth2;
-import kernel.jdon.global.annotation.LoginUser;
 import kernel.jdon.auth.dto.SessionUserInfo;
-import kernel.jdon.member.domain.Member;
-import kernel.jdon.member.domain.SocialProviderType;
+import kernel.jdon.global.annotation.LoginUser;
 import lombok.RequiredArgsConstructor;
 
 @Component
@@ -23,7 +22,8 @@ public class LoginUserArgumentResolver implements HandlerMethodArgumentResolver 
 
 	@Override
 	public boolean supportsParameter(MethodParameter parameter) {
-		boolean isLoginUserAnnotation = parameter.getParameterAnnotation(LoginUser.class) != null;
+
+		boolean isLoginUserAnnotation = Objects.nonNull(parameter.getParameterAnnotation(LoginUser.class));
 		boolean isUserClass = SessionUserInfo.class.equals(parameter.getParameterType());
 
 		return isLoginUserAnnotation && isUserClass;
@@ -33,12 +33,6 @@ public class LoginUserArgumentResolver implements HandlerMethodArgumentResolver 
 	public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer,
 		NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
 
-		return  httpSession.getAttribute("USER");
-		// SessionUserInfo sessionUserInfo = (SessionUserInfo) httpSession.getAttribute("USER");
-		// if (sessionUserInfo == null) {
-		// 	return SessionUserInfo.of(Member.builder().id(30L).build(), UserInfoFromOAuth2.of(null, null, null));
-		// } else {
-		// 	return sessionUserInfo;
-		// }
+		return httpSession.getAttribute("USER");
 	}
 }

--- a/module-api/src/main/java/kernel/jdon/coffeechat/controller/CoffeeChatController.java
+++ b/module-api/src/main/java/kernel/jdon/coffeechat/controller/CoffeeChatController.java
@@ -30,7 +30,6 @@ import kernel.jdon.dto.response.CommonResponse;
 import kernel.jdon.global.annotation.LoginUser;
 import kernel.jdon.global.page.CustomPageResponse;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.java.Log;
 import lombok.extern.slf4j.Slf4j;
 
 @RestController
@@ -45,8 +44,9 @@ public class CoffeeChatController {
 	public ResponseEntity<CommonResponse> get(
 		@PathVariable(name = "id") Long coffeeChatId,
 		@LoginUser SessionUserInfo sessionUser) {
+		Long userId = sessionUser == null ? null : sessionUser.getId();
 
-		return ResponseEntity.ok().body(CommonResponse.of(coffeeChatService.find(coffeeChatId, sessionUser.getId())));
+		return ResponseEntity.ok().body(CommonResponse.of(coffeeChatService.find(coffeeChatId, userId)));
 	}
 
 	@PostMapping("/api/v1/coffeechats")

--- a/module-api/src/main/java/kernel/jdon/config/auth/JdonAuthExceptionHandler.java
+++ b/module-api/src/main/java/kernel/jdon/config/auth/JdonAuthExceptionHandler.java
@@ -11,7 +11,6 @@ import org.springframework.security.web.authentication.AuthenticationFailureHand
 import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.HandlerExceptionResolver;
 
-import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import kernel.jdon.auth.error.AuthErrorCode;
@@ -32,24 +31,24 @@ public class JdonAuthExceptionHandler
 
 	@Override
 	public void commence(HttpServletRequest request, HttpServletResponse response,
-		AuthenticationException authException) throws IOException, ServletException {
+		AuthenticationException authException) {
 		resolver.resolveException(request, response, null, new AuthException(AuthErrorCode.UNAUTHORIZED));
 	}
 
 	@Override
 	public void handle(HttpServletRequest request, HttpServletResponse response,
-		AccessDeniedException accessDeniedException) throws IOException, ServletException {
+		AccessDeniedException accessDeniedException) {
 		resolver.resolveException(request, response, null, new AuthException(AuthErrorCode.FORBIDDEN));
 	}
 
 	@Override
 	public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response,
-		AuthenticationException exception) throws IOException, ServletException {
+		AuthenticationException exception) throws IOException {
 		if (AuthErrorCode.UNAUTHORIZED_OAUTH_RETURN_NULL_EMAIL == ((AuthException)exception).getErrorCode()) {
-			response.sendRedirect(loginRedirectUrlProperties.getFailureNotFoundEmail());
+			response.sendRedirect(loginRedirectUrlProperties.getFailureNotFoundEmail(request.getHeader("Referer")));
 		}
 		if (AuthErrorCode.UNAUTHORIZED_NOT_MATCH_PROVIDER_TYPE == ((AuthException)exception).getErrorCode()) {
-			response.sendRedirect(loginRedirectUrlProperties.getFailureNotMatchProvider());
+			response.sendRedirect(loginRedirectUrlProperties.getFailureNotMatchProvider(request.getHeader("Referer")));
 		}
 	}
 }

--- a/module-api/src/main/java/kernel/jdon/config/auth/JdonAuthExceptionHandler.java
+++ b/module-api/src/main/java/kernel/jdon/config/auth/JdonAuthExceptionHandler.java
@@ -22,12 +22,12 @@ public class JdonAuthExceptionHandler
 	implements AuthenticationEntryPoint, AccessDeniedHandler, AuthenticationFailureHandler {
 
 	private final HandlerExceptionResolver resolver;
-	private final LoginRedirectUrlConfig loginRedirectUrlConfig;
+	private final LoginRedirectUrlProperties loginRedirectUrlProperties;
 
 	public JdonAuthExceptionHandler(@Qualifier("handlerExceptionResolver") HandlerExceptionResolver resolver,
-		LoginRedirectUrlConfig config) {
+		LoginRedirectUrlProperties config) {
 		this.resolver = resolver;
-		this.loginRedirectUrlConfig = config;
+		this.loginRedirectUrlProperties = config;
 	}
 
 	@Override
@@ -46,10 +46,10 @@ public class JdonAuthExceptionHandler
 	public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response,
 		AuthenticationException exception) throws IOException, ServletException {
 		if (AuthErrorCode.UNAUTHORIZED_OAUTH_RETURN_NULL_EMAIL == ((AuthException)exception).getErrorCode()) {
-			response.sendRedirect(loginRedirectUrlConfig.getFailureNotFoundEmail());
+			response.sendRedirect(loginRedirectUrlProperties.getFailureNotFoundEmail());
 		}
 		if (AuthErrorCode.UNAUTHORIZED_NOT_MATCH_PROVIDER_TYPE == ((AuthException)exception).getErrorCode()) {
-			response.sendRedirect(loginRedirectUrlConfig.getFailureNotMatchProvider());
+			response.sendRedirect(loginRedirectUrlProperties.getFailureNotMatchProvider());
 		}
 	}
 }

--- a/module-api/src/main/java/kernel/jdon/config/auth/JdonAuthExceptionHandler.java
+++ b/module-api/src/main/java/kernel/jdon/config/auth/JdonAuthExceptionHandler.java
@@ -1,8 +1,10 @@
 package kernel.jdon.config.auth;
 
 import java.io.IOException;
+import java.io.PrintWriter;
 
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.http.MediaType;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.AuthenticationEntryPoint;
@@ -11,10 +13,14 @@ import org.springframework.security.web.authentication.AuthenticationFailureHand
 import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.HandlerExceptionResolver;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import kernel.jdon.auth.error.AuthErrorCode;
+import kernel.jdon.dto.response.ErrorResponse;
+import kernel.jdon.error.ErrorCode;
 import kernel.jdon.global.exception.AuthException;
 
 @Component
@@ -22,9 +28,27 @@ public class JdonAuthExceptionHandler
 	implements AuthenticationEntryPoint, AccessDeniedHandler, AuthenticationFailureHandler {
 
 	private final HandlerExceptionResolver resolver;
+	private final LoginRedirectUrlConfig loginRedirectUrlConfig;
 
-	public JdonAuthExceptionHandler(@Qualifier("handlerExceptionResolver") HandlerExceptionResolver resolver) {
+	public JdonAuthExceptionHandler(@Qualifier("handlerExceptionResolver") HandlerExceptionResolver resolver,
+		LoginRedirectUrlConfig config) {
 		this.resolver = resolver;
+		this.loginRedirectUrlConfig = config;
+	}
+
+	private void throwAuthException(HttpServletRequest request, HttpServletResponse response,
+		ErrorCode authErrorCode) throws
+		IOException {
+		AuthException e = new AuthException(authErrorCode);
+		ErrorResponse errorResponse = ErrorResponse.of(e.getErrorCode(), request);
+
+		String exceptionResponseJson = new ObjectMapper().writeValueAsString(errorResponse);
+		response.setStatus(authErrorCode.getHttpStatus().value());
+		response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+		response.setCharacterEncoding("utf-8");
+		PrintWriter write = response.getWriter();
+		write.write(exceptionResponseJson);
+		write.flush();
 	}
 
 	@Override
@@ -42,9 +66,11 @@ public class JdonAuthExceptionHandler
 	@Override
 	public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response,
 		AuthenticationException exception) throws IOException, ServletException {
-		if (exception instanceof AuthException) {
-			resolver.resolveException(request, response, null,
-				new AuthException(((AuthException)exception).getErrorCode()));
+		if (AuthErrorCode.UNAUTHORIZED_OAUTH_RETURN_NULL_EMAIL == ((AuthException)exception).getErrorCode()) {
+			response.sendRedirect(loginRedirectUrlConfig.getFailureNotFoundEmail());
+		}
+		if (AuthErrorCode.UNAUTHORIZED_NOT_MATCH_PROVIDER_TYPE == ((AuthException)exception).getErrorCode()) {
+			response.sendRedirect(loginRedirectUrlConfig.getFailureNotMatchProvider());
 		}
 	}
 }

--- a/module-api/src/main/java/kernel/jdon/config/auth/JdonAuthExceptionHandler.java
+++ b/module-api/src/main/java/kernel/jdon/config/auth/JdonAuthExceptionHandler.java
@@ -1,10 +1,8 @@
 package kernel.jdon.config.auth;
 
 import java.io.IOException;
-import java.io.PrintWriter;
 
 import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.http.MediaType;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.AuthenticationEntryPoint;
@@ -13,14 +11,10 @@ import org.springframework.security.web.authentication.AuthenticationFailureHand
 import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.HandlerExceptionResolver;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import kernel.jdon.auth.error.AuthErrorCode;
-import kernel.jdon.dto.response.ErrorResponse;
-import kernel.jdon.error.ErrorCode;
 import kernel.jdon.global.exception.AuthException;
 
 @Component
@@ -34,21 +28,6 @@ public class JdonAuthExceptionHandler
 		LoginRedirectUrlConfig config) {
 		this.resolver = resolver;
 		this.loginRedirectUrlConfig = config;
-	}
-
-	private void throwAuthException(HttpServletRequest request, HttpServletResponse response,
-		ErrorCode authErrorCode) throws
-		IOException {
-		AuthException e = new AuthException(authErrorCode);
-		ErrorResponse errorResponse = ErrorResponse.of(e.getErrorCode(), request);
-
-		String exceptionResponseJson = new ObjectMapper().writeValueAsString(errorResponse);
-		response.setStatus(authErrorCode.getHttpStatus().value());
-		response.setContentType(MediaType.APPLICATION_JSON_VALUE);
-		response.setCharacterEncoding("utf-8");
-		PrintWriter write = response.getWriter();
-		write.write(exceptionResponseJson);
-		write.flush();
 	}
 
 	@Override

--- a/module-api/src/main/java/kernel/jdon/config/auth/JdonLogoutSuccessHandler.java
+++ b/module-api/src/main/java/kernel/jdon/config/auth/JdonLogoutSuccessHandler.java
@@ -1,0 +1,30 @@
+package kernel.jdon.config.auth;
+
+import java.io.IOException;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.logout.CookieClearingLogoutHandler;
+import org.springframework.security.web.authentication.logout.LogoutSuccessHandler;
+import org.springframework.stereotype.Component;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class JdonLogoutSuccessHandler implements LogoutSuccessHandler {
+	private final LogoutRedirectUrlProperties logoutRedirectUrlProperties;
+
+	@Override
+	public void onLogoutSuccess(HttpServletRequest request, HttpServletResponse response,
+		Authentication authentication) throws IOException {
+		new CookieClearingLogoutHandler("JSESSIONID");
+		HttpSession session = request.getSession();
+		if (session != null) {
+			session.invalidate();
+		}
+		response.sendRedirect(logoutRedirectUrlProperties.getSuccess(request.getHeader("Referer")));
+	}
+}

--- a/module-api/src/main/java/kernel/jdon/config/auth/JdonOAuth2AuthenticationSuccessHandler.java
+++ b/module-api/src/main/java/kernel/jdon/config/auth/JdonOAuth2AuthenticationSuccessHandler.java
@@ -1,60 +1,61 @@
 package kernel.jdon.config.auth;
 
-import jakarta.servlet.ServletException;
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
-import kernel.jdon.auth.dto.JdonOAuth2User;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.authority.SimpleGrantedAuthority;
-import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
-import org.springframework.stereotype.Component;
+import static kernel.jdon.auth.encrypt.AesUtil.*;
+import static kernel.jdon.auth.encrypt.HmacUtil.*;
+import static kernel.jdon.util.StringUtil.*;
 
 import java.io.IOException;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 
-import static kernel.jdon.auth.encrypt.AesUtil.encryptAESCBC;
-import static kernel.jdon.auth.encrypt.HmacUtil.generateHMAC;
-import static kernel.jdon.util.StringUtil.createQueryString;
-import static kernel.jdon.util.StringUtil.joinToString;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import kernel.jdon.auth.dto.JdonOAuth2User;
+import kernel.jdon.member.domain.MemberRole;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 @Component
 @RequiredArgsConstructor
 @Slf4j
 public class JdonOAuth2AuthenticationSuccessHandler implements AuthenticationSuccessHandler {
-    private final LoginRedirectUrlConfig loginRedirectUrlConfig;
+	private final LoginRedirectUrlConfig loginRedirectUrlConfig;
 
-    @Override
-    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException {
-        JdonOAuth2User jdonOAuth2User = (JdonOAuth2User) authentication.getPrincipal();
-        if (isTemporaryUser(jdonOAuth2User)) {
-            String query = createUserInfoString(jdonOAuth2User.getEmail(), jdonOAuth2User.getSocialProviderType());
-            String encodedQueryString = createEncryptQueryString(query);;
-            response.sendRedirect(joinToString(loginRedirectUrlConfig.getSuccess().getGuest(), encodedQueryString));
-        } else {
-            response.sendRedirect(loginRedirectUrlConfig.getSuccess().getMember());
-        }
-    }
+	@Override
+	public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
+		Authentication authentication) throws IOException {
+		JdonOAuth2User jdonOAuth2User = (JdonOAuth2User)authentication.getPrincipal();
+		if (isTemporaryUser(jdonOAuth2User)) {
+			String query = createUserInfoString(jdonOAuth2User.getEmail(), jdonOAuth2User.getSocialProviderType());
+			String encodedQueryString = createEncryptQueryString(query);
+			response.sendRedirect(joinToString(loginRedirectUrlConfig.getSuccess().getGuest(), encodedQueryString));
+			return;
+		}
+		response.sendRedirect(loginRedirectUrlConfig.getSuccess().getMember());
+	}
 
-    private boolean isTemporaryUser(JdonOAuth2User jdonOAuth2User) {
-        return jdonOAuth2User.getAuthorities().contains(new SimpleGrantedAuthority("ROLE_TEMPORARY_USER"));
-    }
+	private boolean isTemporaryUser(JdonOAuth2User jdonOAuth2User) {
+		return jdonOAuth2User.getAuthorities().contains(new SimpleGrantedAuthority(MemberRole.ROLE_GUEST.name()));
+	}
 
-    private String createUserInfoString(String email, String provider) {
-        return joinToString(createQueryString("email", email), createQueryString("provider", provider));
-    }
+	private String createUserInfoString(String email, String provider) {
+		return joinToString(createQueryString("email", email), createQueryString("provider", provider));
+	}
 
-    private String createEncryptQueryString(String info) {
-        String encoded = null;
-        try {
-            encoded = encryptAESCBC(info);
-            encoded = joinToString(createQueryString("value", URLEncoder.encode(encoded, StandardCharsets.UTF_8)),
-                    createQueryString("hmac", URLEncoder.encode(generateHMAC(encoded), StandardCharsets.UTF_8)));
-        } catch (Exception e) {
-            log.warn(e.getMessage(), e);
-        }
-        return encoded;
-    }
+	private String createEncryptQueryString(String info) {
+		String encoded = null;
+		try {
+			encoded = encryptAESCBC(info);
+			encoded = joinToString(createQueryString("value", URLEncoder.encode(encoded, StandardCharsets.UTF_8)),
+				createQueryString("hmac", URLEncoder.encode(generateHMAC(encoded), StandardCharsets.UTF_8)));
+		} catch (Exception e) {
+			log.warn(e.getMessage(), e);
+		}
+		return encoded;
+	}
 }

--- a/module-api/src/main/java/kernel/jdon/config/auth/JdonOAuth2AuthenticationSuccessHandler.java
+++ b/module-api/src/main/java/kernel/jdon/config/auth/JdonOAuth2AuthenticationSuccessHandler.java
@@ -33,10 +33,11 @@ public class JdonOAuth2AuthenticationSuccessHandler implements AuthenticationSuc
 		if (isTemporaryUser(jdonOAuth2User)) {
 			String query = createUserInfoString(jdonOAuth2User.getEmail(), jdonOAuth2User.getSocialProviderType());
 			String encodedQueryString = createEncryptQueryString(query);
-			response.sendRedirect(joinToString(loginRedirectUrlProperties.getSuccess().getGuest(), encodedQueryString));
+			response.sendRedirect(joinToString(loginRedirectUrlProperties.getSuccessGuest(request.getHeader("Referer")),
+				encodedQueryString));
 			return;
 		}
-		response.sendRedirect(loginRedirectUrlProperties.getSuccess().getMember());
+		response.sendRedirect(loginRedirectUrlProperties.getSuccessMember(request.getHeader("Referer")));
 	}
 
 	private boolean isTemporaryUser(JdonOAuth2User jdonOAuth2User) {

--- a/module-api/src/main/java/kernel/jdon/config/auth/JdonOAuth2AuthenticationSuccessHandler.java
+++ b/module-api/src/main/java/kernel/jdon/config/auth/JdonOAuth2AuthenticationSuccessHandler.java
@@ -24,7 +24,7 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 @Slf4j
 public class JdonOAuth2AuthenticationSuccessHandler implements AuthenticationSuccessHandler {
-	private final LoginRedirectUrlConfig loginRedirectUrlConfig;
+	private final LoginRedirectUrlProperties loginRedirectUrlProperties;
 
 	@Override
 	public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
@@ -33,10 +33,10 @@ public class JdonOAuth2AuthenticationSuccessHandler implements AuthenticationSuc
 		if (isTemporaryUser(jdonOAuth2User)) {
 			String query = createUserInfoString(jdonOAuth2User.getEmail(), jdonOAuth2User.getSocialProviderType());
 			String encodedQueryString = createEncryptQueryString(query);
-			response.sendRedirect(joinToString(loginRedirectUrlConfig.getSuccess().getGuest(), encodedQueryString));
+			response.sendRedirect(joinToString(loginRedirectUrlProperties.getSuccess().getGuest(), encodedQueryString));
 			return;
 		}
-		response.sendRedirect(loginRedirectUrlConfig.getSuccess().getMember());
+		response.sendRedirect(loginRedirectUrlProperties.getSuccess().getMember());
 	}
 
 	private boolean isTemporaryUser(JdonOAuth2User jdonOAuth2User) {

--- a/module-api/src/main/java/kernel/jdon/config/auth/LoginRedirectUrlConfig.java
+++ b/module-api/src/main/java/kernel/jdon/config/auth/LoginRedirectUrlConfig.java
@@ -10,11 +10,35 @@ import lombok.RequiredArgsConstructor;
 @ConfigurationProperties(prefix = "redirect-url.login")
 public class LoginRedirectUrlConfig {
 	private final Success success;
+	private final Failure failure;
+
+	public String getSuccessMember() {
+		return this.success.getMember();
+	}
+
+	public String getSuccessGuest() {
+		return this.success.getGuest();
+	}
+
+	public String getFailureNotFoundEmail() {
+		return this.failure.getNotFoundEmail();
+	}
+
+	public String getFailureNotMatchProvider() {
+		return this.failure.getNotMatchProvider();
+	}
 
 	@Getter
 	@RequiredArgsConstructor
 	public static class Success {
 		private final String member;
 		private final String guest;
+	}
+
+	@Getter
+	@RequiredArgsConstructor
+	public static class Failure {
+		private final String notFoundEmail;
+		private final String notMatchProvider;
 	}
 }

--- a/module-api/src/main/java/kernel/jdon/config/auth/LoginRedirectUrlProperties.java
+++ b/module-api/src/main/java/kernel/jdon/config/auth/LoginRedirectUrlProperties.java
@@ -8,7 +8,7 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 @ConfigurationProperties(prefix = "redirect-url.login")
-public class LoginRedirectUrlConfig {
+public class LoginRedirectUrlProperties {
 	private final Success success;
 	private final Failure failure;
 
@@ -16,29 +16,49 @@ public class LoginRedirectUrlConfig {
 		return this.success.getMember();
 	}
 
+	public String getSuccessLocalMember() {
+		return this.success.getLocalMember();
+	}
+
 	public String getSuccessGuest() {
 		return this.success.getGuest();
+	}
+
+	public String getSuccessLocalGuest() {
+		return this.success.getLocalGuest();
 	}
 
 	public String getFailureNotFoundEmail() {
 		return this.failure.getNotFoundEmail();
 	}
 
+	public String getFailureLocalNotFoundEmail() {
+		return this.failure.getLocalNotFoundEmail();
+	}
+
 	public String getFailureNotMatchProvider() {
 		return this.failure.getNotMatchProvider();
+	}
+
+	public String getFailureLocalNotMatchProvider() {
+		return this.failure.getLocalNotMatchProvider();
 	}
 
 	@Getter
 	@RequiredArgsConstructor
 	public static class Success {
 		private final String member;
+		private final String localMember;
 		private final String guest;
+		private final String localGuest;
 	}
 
 	@Getter
 	@RequiredArgsConstructor
 	public static class Failure {
 		private final String notFoundEmail;
+		private final String localNotFoundEmail;
 		private final String notMatchProvider;
+		private final String localNotMatchProvider;
 	}
 }

--- a/module-api/src/main/java/kernel/jdon/config/auth/LoginRedirectUrlProperties.java
+++ b/module-api/src/main/java/kernel/jdon/config/auth/LoginRedirectUrlProperties.java
@@ -12,36 +12,36 @@ public class LoginRedirectUrlProperties {
 	private final Success success;
 	private final Failure failure;
 
-	public String getSuccessMember() {
+	public String getSuccessMember(String referer) {
+		if (requestFromLocal(referer)) {
+			return this.success.getLocalMember();
+		}
 		return this.success.getMember();
 	}
 
-	public String getSuccessLocalMember() {
-		return this.success.getLocalMember();
-	}
-
-	public String getSuccessGuest() {
+	public String getSuccessGuest(String referer) {
+		if (requestFromLocal(referer)) {
+			return this.success.getLocalGuest();
+		}
 		return this.success.getGuest();
 	}
 
-	public String getSuccessLocalGuest() {
-		return this.success.getLocalGuest();
-	}
-
-	public String getFailureNotFoundEmail() {
+	public String getFailureNotFoundEmail(String referer) {
+		if (requestFromLocal(referer)) {
+			return this.failure.getLocalNotFoundEmail();
+		}
 		return this.failure.getNotFoundEmail();
 	}
 
-	public String getFailureLocalNotFoundEmail() {
-		return this.failure.getLocalNotFoundEmail();
-	}
-
-	public String getFailureNotMatchProvider() {
+	public String getFailureNotMatchProvider(String referer) {
+		if (requestFromLocal(referer)) {
+			return this.failure.getLocalNotMatchProvider();
+		}
 		return this.failure.getNotMatchProvider();
 	}
 
-	public String getFailureLocalNotMatchProvider() {
-		return this.failure.getLocalNotMatchProvider();
+	private boolean requestFromLocal(String referer) {
+		return referer.contains("localhost:3000");
 	}
 
 	@Getter

--- a/module-api/src/main/java/kernel/jdon/config/auth/LogoutRedirectUrlProperties.java
+++ b/module-api/src/main/java/kernel/jdon/config/auth/LogoutRedirectUrlProperties.java
@@ -7,8 +7,8 @@ import lombok.RequiredArgsConstructor;
 
 @Getter
 @RequiredArgsConstructor
-@ConfigurationProperties(prefix = "custom-oauth2.kakao")
-public class WithdrawConfig {
-	private final String appAdminKey;
-	private final String deleteUserUrl;
+@ConfigurationProperties(prefix = "redirect-url.logout")
+public class LogoutRedirectUrlProperties {
+	private final String success;
+	private final String localSuccess;
 }

--- a/module-api/src/main/java/kernel/jdon/config/auth/LogoutRedirectUrlProperties.java
+++ b/module-api/src/main/java/kernel/jdon/config/auth/LogoutRedirectUrlProperties.java
@@ -2,13 +2,18 @@ package kernel.jdon.config.auth;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
-import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
-@Getter
 @RequiredArgsConstructor
 @ConfigurationProperties(prefix = "redirect-url.logout")
 public class LogoutRedirectUrlProperties {
 	private final String success;
 	private final String localSuccess;
+
+	public String getSuccess(String referer) {
+		if (referer.contains("localhost:3000")) {
+			return this.localSuccess;
+		}
+		return this.success;
+	}
 }

--- a/module-api/src/main/java/kernel/jdon/config/auth/OAuth2SecurityConfig.java
+++ b/module-api/src/main/java/kernel/jdon/config/auth/OAuth2SecurityConfig.java
@@ -23,7 +23,7 @@ public class OAuth2SecurityConfig {
 	private final JdonOAuth2UserService jdonOAuth2UserService;
 	private final JdonOAuth2AuthenticationSuccessHandler jdonOAuth2AuthenticationSuccessHandler;
 	private final JdonAuthExceptionHandler jdonAuthExceptionHandler;
-	private final LogoutRedirectUrlProperties logoutRedirectUrlProperties;
+	private final JdonLogoutSuccessHandler jdonLogoutSuccessHandler;
 
 	@Bean
 	public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
@@ -78,9 +78,9 @@ public class OAuth2SecurityConfig {
 				.userService(jdonOAuth2UserService)));
 		http.logout(logoutConfigurer -> logoutConfigurer
 			.logoutUrl("/api/v1/logout")
-			.logoutSuccessUrl(logoutRedirectUrlProperties.getSuccess())
-			.invalidateHttpSession(true)
-			.deleteCookies("JSESSIONID"));
+			.logoutSuccessUrl("http://localhost:3000")
+			.logoutSuccessHandler(jdonLogoutSuccessHandler)
+		);
 
 		return http.build();
 	}

--- a/module-api/src/main/java/kernel/jdon/config/auth/OAuth2SecurityConfig.java
+++ b/module-api/src/main/java/kernel/jdon/config/auth/OAuth2SecurityConfig.java
@@ -23,7 +23,7 @@ public class OAuth2SecurityConfig {
 	private final JdonOAuth2UserService jdonOAuth2UserService;
 	private final JdonOAuth2AuthenticationSuccessHandler jdonOAuth2AuthenticationSuccessHandler;
 	private final JdonAuthExceptionHandler jdonAuthExceptionHandler;
-	private final LogoutRedirectUrlConfig logoutRedirectUrlConfig;
+	private final LogoutRedirectUrlProperties logoutRedirectUrlProperties;
 
 	@Bean
 	public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
@@ -78,7 +78,7 @@ public class OAuth2SecurityConfig {
 				.userService(jdonOAuth2UserService)));
 		http.logout(logoutConfigurer -> logoutConfigurer
 			.logoutUrl("/api/v1/logout")
-			.logoutSuccessUrl(logoutRedirectUrlConfig.getSuccess())
+			.logoutSuccessUrl(logoutRedirectUrlProperties.getSuccess())
 			.invalidateHttpSession(true)
 			.deleteCookies("JSESSIONID"));
 

--- a/module-api/src/main/java/kernel/jdon/config/auth/OAuth2SecurityConfig.java
+++ b/module-api/src/main/java/kernel/jdon/config/auth/OAuth2SecurityConfig.java
@@ -78,7 +78,6 @@ public class OAuth2SecurityConfig {
 				.userService(jdonOAuth2UserService)));
 		http.logout(logoutConfigurer -> logoutConfigurer
 			.logoutUrl("/api/v1/logout")
-			.logoutSuccessUrl("http://localhost:3000")
 			.logoutSuccessHandler(jdonLogoutSuccessHandler)
 		);
 

--- a/module-api/src/main/java/kernel/jdon/config/auth/WithdrawProperties.java
+++ b/module-api/src/main/java/kernel/jdon/config/auth/WithdrawProperties.java
@@ -1,15 +1,14 @@
 package kernel.jdon.config.auth;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.context.annotation.Configuration;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 @Getter
 @RequiredArgsConstructor
-@ConfigurationProperties(prefix = "redirect-url.logout")
-public class LogoutRedirectUrlConfig {
-	private final String success;
-
+@ConfigurationProperties(prefix = "custom-oauth2.kakao")
+public class WithdrawProperties {
+	private final String appAdminKey;
+	private final String deleteUserUrl;
 }

--- a/module-api/src/main/java/kernel/jdon/global/exception/GlobalExceptionHandler.java
+++ b/module-api/src/main/java/kernel/jdon/global/exception/GlobalExceptionHandler.java
@@ -20,7 +20,7 @@ public class GlobalExceptionHandler {
 			.body(ErrorResponse.of(e.getErrorCode(), request));
 	}
 
-	@ExceptionHandler({AuthException.class})
+	@ExceptionHandler(AuthException.class)
 	public ResponseEntity<ErrorResponse> handleAuthenticationException(AuthException e, HttpServletRequest request) {
 		log.warn(e.getMessage(), e);
 		return ResponseEntity.status(e.getErrorCode().getHttpStatus().value())

--- a/module-api/src/main/java/kernel/jdon/global/exception/GlobalExceptionHandler.java
+++ b/module-api/src/main/java/kernel/jdon/global/exception/GlobalExceptionHandler.java
@@ -1,5 +1,6 @@
 package kernel.jdon.global.exception;
 
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -24,5 +25,12 @@ public class GlobalExceptionHandler {
 		log.warn(e.getMessage(), e);
 		return ResponseEntity.status(e.getErrorCode().getHttpStatus().value())
 			.body(ErrorResponse.of(e.getErrorCode(), request));
+	}
+
+	@ExceptionHandler(Exception.class)
+	public ResponseEntity<ErrorResponse> handlerException(Exception e, HttpServletRequest request) {
+		log.warn(e.getMessage(), e);
+		return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR.value())
+			.body(ErrorResponse.of(HttpStatus.INTERNAL_SERVER_ERROR, request));
 	}
 }

--- a/module-api/src/main/resources/application-dev.yml
+++ b/module-api/src/main/resources/application-dev.yml
@@ -67,6 +67,9 @@ redirect-url:
     success:
       member: https://localhost:3000/oauth/login/success
       guest: https://localhost:3000/oauth/info?
+    failure:
+      not-found-email: https://localhost:3000/oauth/login/fail/not-found-email
+      not-match-provider: https://localhost:3000/oauth/login/fail/not-match-provider
   logout:
     success: https://localhost:3000
 

--- a/module-api/src/main/resources/application-dev.yml
+++ b/module-api/src/main/resources/application-dev.yml
@@ -65,13 +65,18 @@ custom-oauth2:
 redirect-url:
   login:
     success:
-      member: https://localhost:3000/oauth/login/success
-      guest: https://localhost:3000/oauth/info?
+      member: https://jdon-test.netlify.app/oauth/login/success
+      local-member: https://localhost:3000/oauth/login/success
+      guest: https://jdon-test.netlify.app/oauth/info?
+      local-guest: https://localhost:3000/oauth/info?
     failure:
-      not-found-email: https://localhost:3000/oauth/login/fail/not-found-email
-      not-match-provider: https://localhost:3000/oauth/login/fail/not-match-provider
+      not-found-email: https://jdon-test.netlify.app/oauth/login/fail/not-found-email
+      local-not-found-email: https://localhost:3000/oauth/login/fail/not-found-email
+      not-match-provider: https://jdon-test.netlify.app/oauth/login/fail/not-match-provider
+      local-not-match-provider: https://localhost:3000/oauth/login/fail/not-match-provider
   logout:
-    success: https://localhost:3000
+    success: https://jdon-test.netlify.app
+    local-success: https://localhost:3000
 
 redis:
   lock:

--- a/module-api/src/main/resources/application-local.yml
+++ b/module-api/src/main/resources/application-local.yml
@@ -41,6 +41,10 @@ spring:
     web:
       pageable:
         max-page-size: 100
+    redis:
+      port: 6379
+      host: 127.0.0.1
+      password: ${REDIS_PASSWORD}
 
 
 logging:
@@ -62,6 +66,9 @@ redirect-url:
     success:
       member: http://localhost:3000/oauth/login/success
       guest: http://localhost:3000/oauth/info?
+    failure:
+      not-found-email: http://localhost:3000/oauth/login/fail/not-found-email
+      not-match-provider: http://localhost:3000/oauth/login/fail/not-match-provider
   logout:
     success: http://localhost:3000
 

--- a/module-api/src/main/resources/application-prod.yml
+++ b/module-api/src/main/resources/application-prod.yml
@@ -66,6 +66,9 @@ redirect-url:
     success:
       member: https://jdon.kr/oauth/login/success
       guest: https://jdon.kr/oauth/info?
+    failure:
+      not-found-email: https://jdon.kr/oauth/login/fail/not-found-email
+      not-match-provider: https://jdon.kr/oauth/login/fail/not-match-provider
   logout:
     success: https://jdon.kr
 

--- a/module-domain/src/main/java/kernel/jdon/member/domain/MemberRole.java
+++ b/module-domain/src/main/java/kernel/jdon/member/domain/MemberRole.java
@@ -3,7 +3,8 @@ package kernel.jdon.member.domain;
 public enum MemberRole {
 
 	ROLE_USER("사용자"),
-	ROLE_ADMIN("관리자");
+	ROLE_ADMIN("관리자"),
+	ROLE_GUEST("게스트");
 
 	private final String role;
 


### PR DESCRIPTION
## 개요

### 요약

### 변경한 부분
### main task 
프론트 개발 환경이 jdon.kr이냐 localhost:3000이냐에 따라 확인하기 위한 redirect 주소를 jdon.kr, 혹은 localhost:3000으로 보내기 위해서 해당되는 yml파일로 계속해서 재 실행시켜야하는 문제가 있었습니다. 따라서 들어온 요청의 referer를 확인하여 이 요청이 localhost:3000으로부터 온 요청이라면 redirect를 localhost:3000으로  아니라면 그 호스트로 던져주도록 수정했습니다. 

따라서 application-dev.yml에 localhost:3000이 host인 곳으로 보내지는 redirect-url를 추가했습니다. 

### sub task
1. 최윤진 멘토님의 코드리뷰를 반영했습니다. 
   - properties의 getter 관련
   - Objects.nonNull() 사용

2. 로그인 중 발생하는 에러에 대해서 프론트 요청으로 error가 아닌 특정 url로 redirect하여 핸들링할 수 있도록 설정했습니다. 

3. 커피챗 상세 조회API 에 대해서 sessionUser가 null일 경우 nullPointerException이 나는데 이 에러가 ExceptionHandling 되지 않고 AuthException으로 던져지고 있어 우선은 SessionUser가 null이면 userId가 null이도록 하여 API가 동작하도록 하고 추가적으로 등록되지 않은 다른 Exception들이 모두 핸들링될 수 있는 Exception.class, 500 을 핸들링하는 핸들러를 추가했습니다. 

### 변경한 결과

### 이슈

- closes: #271 
- closes: #297 

---

## PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경, 주석 변경)
- [ ] 코드 리팩토링
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 파일 혹은 폴더명 수정, 삭제
- [ ] 배포 관련