### PR TITLE
Feature: 기술 스택 기반 원티드JD 조회 API 식별자 항목 추가

### DIFF
--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/skill/core/SkillInfo.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/skill/core/SkillInfo.java
@@ -76,6 +76,7 @@ public class SkillInfo {
 	@AllArgsConstructor
 	@NoArgsConstructor
 	public static class FindJd {
+		private Long id;
 		private String company;
 		private String title;
 		private String imageUrl;

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/skill/infrastructure/SkillReaderInfo.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/skill/infrastructure/SkillReaderInfo.java
@@ -35,13 +35,15 @@ public class SkillReaderInfo {
 
 	@Getter
 	public static class FindWantedJd {
+		private Long id;
 		private String company;
 		private String title;
 		private String imageUrl;
 		private String jdUrl;
 
 		@QueryProjection
-		public FindWantedJd(String company, String title, String imageUrl, String jdUrl) {
+		public FindWantedJd(Long id, String company, String title, String imageUrl, String jdUrl) {
+			this.id = id;
 			this.company = company;
 			this.title = title;
 			this.imageUrl = imageUrl;

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/skill/infrastructure/SkillRepositoryImpl.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/skill/infrastructure/SkillRepositoryImpl.java
@@ -55,8 +55,9 @@ public class SkillRepositoryImpl implements SkillRepositoryCustom {
 		final int wantedJdCount = 6;
 
 		return jpaQueryFactory
-			.select(new QSkillReaderInfo_FindWantedJd(wantedJd.companyName, wantedJd.title, wantedJd.imageUrl,
-				wantedJd.detailUrl))
+			.select(
+				new QSkillReaderInfo_FindWantedJd(wantedJd.id, wantedJd.companyName, wantedJd.title, wantedJd.imageUrl,
+					wantedJd.detailUrl))
 			.from(wantedJdSkill)
 			.innerJoin(wantedJd)
 			.on(wantedJdSkill.wantedJd.id.eq(wantedJd.id))

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/skill/infrastructure/wantedjd/WantedJdSkillReaderImpl.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/skill/infrastructure/wantedjd/WantedJdSkillReaderImpl.java
@@ -17,8 +17,8 @@ public class WantedJdSkillReaderImpl implements WantedJdSkillReader {
 	@Override
 	public List<SkillInfo.FindJd> findWantedJdListBySkill(String keyword) {
 		return skillRepository.findWantedJdListBySkill(keyword).stream()
-			.map(wantedJd -> new SkillInfo.FindJd(wantedJd.getCompany(), wantedJd.getTitle(), wantedJd.getImageUrl(),
-				wantedJd.getJdUrl()))
+			.map(wantedJd -> new SkillInfo.FindJd(wantedJd.getId(), wantedJd.getCompany(), wantedJd.getTitle(),
+				wantedJd.getImageUrl(), wantedJd.getJdUrl()))
 			.toList();
 	}
 }

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/skill/presentation/SkillController.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/skill/presentation/SkillController.java
@@ -59,7 +59,7 @@ public class SkillController {
 	}
 
 	private Long getSessionUserId(SessionUserInfo sessionUser) {
-		return Optional.of(sessionUser)
+		return Optional.ofNullable(sessionUser)
 			.map(session -> sessionUser.getId())
 			.orElse(null);
 	}

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/skill/presentation/SkillDto.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/skill/presentation/SkillDto.java
@@ -65,6 +65,7 @@ public class SkillDto {
 	@Getter
 	@Builder
 	public static class FindJd {
+		private Long id;
 		private String company;
 		private String title;
 		private String imageUrl;


### PR DESCRIPTION
## 개요

### 요약

기술 스택 기반 원티드JD 조회 API 식별자 항목 추가

### 변경한 부분

JD 상세조회를 기능 추가에 필요한 항목인 API 식별자 항목을 기술 스택 기반 원티드JD 조회 API에 추가하였습니다.

### 변경한 결과

### 이슈

- closes: #316 

---

## PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경, 주석 변경)
- [ ] 코드 리팩토링
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 파일 혹은 폴더명 수정, 삭제
- [ ] 배포 관련