### PR TITLE
Fix: 커피챗 목록 조회 API host 직군 항목 필드명 변경

### DIFF
--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/coffeechat/core/CoffeeChatInfo.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/coffeechat/core/CoffeeChatInfo.java
@@ -52,7 +52,7 @@ public class CoffeeChatInfo {
 	public static class FindCoffeeChatInfo {
 		private Long coffeeChatId;
 		private String nickname;
-		private String job;
+		private String hostJobCategoryName;
 		private String title;
 		private String activeStatus;
 		@JsonInclude(JsonInclude.Include.NON_NULL)
@@ -68,8 +68,8 @@ public class CoffeeChatInfo {
 			return FindCoffeeChatInfo.builder()
 				.coffeeChatId(readerInfo.getCoffeeChatId())
 				.nickname(readerInfo.getNickname())
-				.job(readerInfo.getJob())
-				.title(readerInfo.getJob())
+				.hostJobCategoryName(readerInfo.getHostJobCategoryName())
+				.title(readerInfo.getTitle())
 				.activeStatus(readerInfo.getActiveStatus())
 				.isDeleted(readerInfo.getIsDeleted())
 				.meetDate(readerInfo.getMeetDate())

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/coffeechat/infrastructure/CoffeeChatReaderInfo.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/coffeechat/infrastructure/CoffeeChatReaderInfo.java
@@ -18,7 +18,7 @@ public class CoffeeChatReaderInfo {
 	public static class FindCoffeeChatListResponse {
 		private Long coffeeChatId;
 		private String nickname;
-		private String job;
+		private String hostJobCategoryName;
 		private String title;
 		private String activeStatus;
 		@JsonInclude(JsonInclude.Include.NON_NULL)
@@ -36,7 +36,7 @@ public class CoffeeChatReaderInfo {
 			LocalDateTime meetDate, LocalDateTime createdDate, Long totalRecruitCount, Long currentRecruitCount) {
 			this.coffeeChatId = coffeeChatId;
 			this.nickname = nickname;
-			this.job = job;
+			this.hostJobCategoryName = job;
 			this.title = title;
 			this.activeStatus = activeStatus.getActiveStatus();
 			this.meetDate = meetDate;

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/coffeechat/presentation/CoffeeChatDto.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/coffeechat/presentation/CoffeeChatDto.java
@@ -46,7 +46,7 @@ public class CoffeeChatDto {
 	public static class FindCoffeeChat {
 		private Long coffeeChatId;
 		private String nickname;
-		private String job;
+		private String hostJobCategoryName;
 		private String title;
 		private String activeStatus;
 		@JsonInclude(JsonInclude.Include.NON_NULL)


### PR DESCRIPTION
## 개요

### 요약

커피챗 목록 조회 API host 직군 항목 필드명 변경

### 변경한 부분

기존 job이라는 항목명은 의미가 추상적이여서 구체적인 hostJobCategoryName으로  변경하였습니다.

### 변경한 결과

<img width="645" alt="image" src="https://github.com/Kernel360/f1-JDON-Backend/assets/59242594/6ccd0170-e630-4d0b-8763-f53104e94b58">



### 이슈

- closes: #323 

---

## PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경, 주석 변경)
- [ ] 코드 리팩토링
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 파일 혹은 폴더명 수정, 삭제
- [ ] 배포 관련