### PR TITLE
Feature: JD 상세조회 API 구현

### DIFF
--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/jd/application/JdFacade.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/jd/application/JdFacade.java
@@ -1,0 +1,17 @@
+package kernel.jdon.moduleapi.domain.jd.application;
+
+import org.springframework.stereotype.Service;
+
+import kernel.jdon.moduleapi.domain.jd.core.JdInfo;
+import kernel.jdon.moduleapi.domain.jd.core.JdService;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class JdFacade {
+	private final JdService jdService;
+
+	public JdInfo.FindWantedJdResponse getJd(final Long jdId) {
+		return jdService.getJd(jdId);
+	}
+}

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/jd/core/JdInfo.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/jd/core/JdInfo.java
@@ -1,0 +1,26 @@
+package kernel.jdon.moduleapi.domain.jd.core;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class JdInfo {
+
+	@Getter
+	@Builder
+	public static class FindWantedJdResponse {
+		private Long id;
+		private String title;
+		private String company;
+		private String imageUrl;
+		private String jdUrl;
+		private String requirements;
+		private String mainTasks;
+		private String intro;
+		private String benefits;
+		private String preferredPoints;
+		private String jobCategoryName;
+	}
+}

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/jd/core/JdInfo.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/jd/core/JdInfo.java
@@ -1,5 +1,8 @@
 package kernel.jdon.moduleapi.domain.jd.core;
 
+import java.util.List;
+
+import kernel.jdon.skill.domain.Skill;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -22,5 +25,17 @@ public class JdInfo {
 		private String benefits;
 		private String preferredPoints;
 		private String jobCategoryName;
+		private List<FindSkill> skillList;
+	}
+
+	@Getter
+	public static class FindSkill {
+		private Long id;
+		private String keyword;
+
+		public FindSkill(Skill skill) {
+			this.id = skill.getId();
+			this.keyword = skill.getKeyword();
+		}
 	}
 }

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/jd/core/JdInfoMapper.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/jd/core/JdInfoMapper.java
@@ -1,0 +1,28 @@
+package kernel.jdon.moduleapi.domain.jd.core;
+
+import org.mapstruct.InjectionStrategy;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.ReportingPolicy;
+
+import kernel.jdon.wantedjd.domain.WantedJd;
+
+@Mapper(
+	componentModel = "spring",
+	injectionStrategy = InjectionStrategy.CONSTRUCTOR,
+	unmappedSourcePolicy = ReportingPolicy.WARN
+)
+public interface JdInfoMapper {
+	@Mapping(source = "wantedJd.id", target = "id")
+	@Mapping(source = "wantedJd.title", target = "title")
+	@Mapping(source = "wantedJd.companyName", target = "company")
+	@Mapping(source = "wantedJd.imageUrl", target = "imageUrl")
+	@Mapping(source = "wantedJd.detailUrl", target = "jdUrl")
+	@Mapping(source = "wantedJd.requirements", target = "requirements")
+	@Mapping(source = "wantedJd.mainTasks", target = "mainTasks")
+	@Mapping(source = "wantedJd.intro", target = "intro")
+	@Mapping(source = "wantedJd.benefits", target = "benefits")
+	@Mapping(source = "wantedJd.preferredPoints", target = "preferredPoints")
+	@Mapping(expression = "java(wantedJd.getJobCategory().getName())", target = "jobCategoryName")
+	JdInfo.FindWantedJdResponse of(WantedJd wantedJd);
+}

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/jd/core/JdInfoMapper.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/jd/core/JdInfoMapper.java
@@ -1,5 +1,7 @@
 package kernel.jdon.moduleapi.domain.jd.core;
 
+import java.util.List;
+
 import org.mapstruct.InjectionStrategy;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
@@ -24,5 +26,5 @@ public interface JdInfoMapper {
 	@Mapping(source = "wantedJd.benefits", target = "benefits")
 	@Mapping(source = "wantedJd.preferredPoints", target = "preferredPoints")
 	@Mapping(expression = "java(wantedJd.getJobCategory().getName())", target = "jobCategoryName")
-	JdInfo.FindWantedJdResponse of(WantedJd wantedJd);
+	JdInfo.FindWantedJdResponse of(WantedJd wantedJd, List<JdInfo.FindSkill> skillList);
 }

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/jd/core/JdReader.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/jd/core/JdReader.java
@@ -1,7 +1,11 @@
 package kernel.jdon.moduleapi.domain.jd.core;
 
+import java.util.List;
+
 import kernel.jdon.wantedjd.domain.WantedJd;
 
 public interface JdReader {
 	WantedJd findWantedJd(final Long jdId);
+
+	List<JdInfo.FindSkill> findSkillListByWantedJd(final WantedJd wantedJd);
 }

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/jd/core/JdReader.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/jd/core/JdReader.java
@@ -1,0 +1,7 @@
+package kernel.jdon.moduleapi.domain.jd.core;
+
+import kernel.jdon.wantedjd.domain.WantedJd;
+
+public interface JdReader {
+	WantedJd findWantedJd(final Long jdId);
+}

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/jd/core/JdService.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/jd/core/JdService.java
@@ -1,0 +1,5 @@
+package kernel.jdon.moduleapi.domain.jd.core;
+
+public interface JdService {
+	JdInfo.FindWantedJdResponse getJd(final Long jdId);
+}

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/jd/core/JdServiceImpl.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/jd/core/JdServiceImpl.java
@@ -1,0 +1,19 @@
+package kernel.jdon.moduleapi.domain.jd.core;
+
+import org.springframework.stereotype.Service;
+
+import kernel.jdon.wantedjd.domain.WantedJd;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class JdServiceImpl implements JdService {
+	private final JdReader jdReader;
+	private final JdInfoMapper jdInfoMapper;
+
+	@Override
+	public JdInfo.FindWantedJdResponse getJd(final Long jdId) {
+		final WantedJd findWantedJd = jdReader.findWantedJd(jdId);
+		return jdInfoMapper.of(findWantedJd);
+	}
+}

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/jd/core/JdServiceImpl.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/jd/core/JdServiceImpl.java
@@ -1,5 +1,7 @@
 package kernel.jdon.moduleapi.domain.jd.core;
 
+import java.util.List;
+
 import org.springframework.stereotype.Service;
 
 import kernel.jdon.wantedjd.domain.WantedJd;
@@ -14,6 +16,8 @@ public class JdServiceImpl implements JdService {
 	@Override
 	public JdInfo.FindWantedJdResponse getJd(final Long jdId) {
 		final WantedJd findWantedJd = jdReader.findWantedJd(jdId);
-		return jdInfoMapper.of(findWantedJd);
+		final List<JdInfo.FindSkill> findSkillList = jdReader.findSkillListByWantedJd(findWantedJd);
+
+		return jdInfoMapper.of(findWantedJd, findSkillList);
 	}
 }

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/jd/error/JdErrorCode.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/jd/error/JdErrorCode.java
@@ -1,0 +1,37 @@
+package kernel.jdon.moduleapi.domain.jd.error;
+
+import org.springframework.http.HttpStatus;
+
+import kernel.jdon.moduleapi.global.exception.ApiException;
+import kernel.jdon.moduleapi.global.exception.BaseThrowException;
+import kernel.jdon.modulecommon.error.ErrorCode;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public enum JdErrorCode implements ErrorCode, BaseThrowException<JdErrorCode.JobBaseException> {
+	NOT_FOUND_JD(HttpStatus.NOT_FOUND, "존재하지 않는 채용 공고 입니다.");
+
+	private final HttpStatus httpStatus;
+	private final String message;
+
+	@Override
+	public HttpStatus getHttpStatus() {
+		return httpStatus;
+	}
+
+	@Override
+	public String getMessage() {
+		return message;
+	}
+
+	@Override
+	public JobBaseException throwException() {
+		return new JobBaseException(this);
+	}
+
+	public class JobBaseException extends ApiException {
+		public JobBaseException(JdErrorCode skillErrorCode) {
+			super(skillErrorCode);
+		}
+	}
+}

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/jd/infrastructure/JdReaderImpl.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/jd/infrastructure/JdReaderImpl.java
@@ -1,7 +1,10 @@
 package kernel.jdon.moduleapi.domain.jd.infrastructure;
 
+import java.util.List;
+
 import org.springframework.stereotype.Component;
 
+import kernel.jdon.moduleapi.domain.jd.core.JdInfo;
 import kernel.jdon.moduleapi.domain.jd.core.JdReader;
 import kernel.jdon.moduleapi.domain.jd.error.JdErrorCode;
 import kernel.jdon.wantedjd.domain.WantedJd;
@@ -16,5 +19,13 @@ public class JdReaderImpl implements JdReader {
 	public WantedJd findWantedJd(final Long jdId) {
 		return wantedJdRepository.findById(jdId)
 			.orElseThrow(JdErrorCode.NOT_FOUND_JD::throwException);
+	}
+
+	@Override
+	public List<JdInfo.FindSkill> findSkillListByWantedJd(final WantedJd wantedJd) {
+		return wantedJd.getSkillList().stream()
+			.map(wantedJdSkill -> new JdInfo.FindSkill(
+				wantedJdSkill.getSkill()))
+			.toList();
 	}
 }

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/jd/infrastructure/JdReaderImpl.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/jd/infrastructure/JdReaderImpl.java
@@ -1,0 +1,20 @@
+package kernel.jdon.moduleapi.domain.jd.infrastructure;
+
+import org.springframework.stereotype.Component;
+
+import kernel.jdon.moduleapi.domain.jd.core.JdReader;
+import kernel.jdon.moduleapi.domain.jd.error.JdErrorCode;
+import kernel.jdon.wantedjd.domain.WantedJd;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class JdReaderImpl implements JdReader {
+	private final WantedJdRepository wantedJdRepository;
+
+	@Override
+	public WantedJd findWantedJd(final Long jdId) {
+		return wantedJdRepository.findById(jdId)
+			.orElseThrow(JdErrorCode.NOT_FOUND_JD::throwException);
+	}
+}

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/jd/infrastructure/WantedJdRepository.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/jd/infrastructure/WantedJdRepository.java
@@ -1,0 +1,6 @@
+package kernel.jdon.moduleapi.domain.jd.infrastructure;
+
+import kernel.jdon.wantedjd.repository.WantedJdDomainRepository;
+
+public interface WantedJdRepository extends WantedJdDomainRepository {
+}

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/jd/presentation/JdController.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/jd/presentation/JdController.java
@@ -1,0 +1,28 @@
+package kernel.jdon.moduleapi.domain.jd.presentation;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+
+import kernel.jdon.moduleapi.domain.jd.application.JdFacade;
+import kernel.jdon.moduleapi.domain.jd.core.JdInfo;
+import kernel.jdon.modulecommon.dto.response.CommonResponse;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+public class JdController {
+	private final JdFacade jdFacade;
+	private final JdMapper jdMapper;
+
+	@GetMapping("/api/v1/jds/{id}")
+	public ResponseEntity<CommonResponse<JdDto.FindWantedJdResponse>> getJdFacade(
+		@PathVariable(name = "id") Long jdId) {
+		JdInfo.FindWantedJdResponse info = jdFacade.getJd(jdId);
+		JdDto.FindWantedJdResponse response = jdMapper.of(info);
+
+		return ResponseEntity.ok().body(CommonResponse.of(response));
+	}
+
+}

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/jd/presentation/JdController.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/jd/presentation/JdController.java
@@ -17,7 +17,7 @@ public class JdController {
 	private final JdMapper jdMapper;
 
 	@GetMapping("/api/v1/jds/{id}")
-	public ResponseEntity<CommonResponse<JdDto.FindWantedJdResponse>> getJdFacade(
+	public ResponseEntity<CommonResponse<JdDto.FindWantedJdResponse>> getJd(
 		@PathVariable(name = "id") Long jdId) {
 		JdInfo.FindWantedJdResponse info = jdFacade.getJd(jdId);
 		JdDto.FindWantedJdResponse response = jdMapper.of(info);

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/jd/presentation/JdDto.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/jd/presentation/JdDto.java
@@ -1,5 +1,7 @@
 package kernel.jdon.moduleapi.domain.jd.presentation;
 
+import java.util.List;
+
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -21,5 +23,13 @@ public class JdDto {
 		private String benefits;
 		private String preferredPoints;
 		private String jobCategoryName;
+		private List<FindSkill> skillList;
+	}
+
+	@Getter
+	@Builder
+	public static class FindSkill {
+		private Long id;
+		private String keyword;
 	}
 }

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/jd/presentation/JdDto.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/jd/presentation/JdDto.java
@@ -1,0 +1,25 @@
+package kernel.jdon.moduleapi.domain.jd.presentation;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class JdDto {
+	@Getter
+	@Builder
+	public static class FindWantedJdResponse {
+		private Long id;
+		private String title;
+		private String company;
+		private String imageUrl;
+		private String jdUrl;
+		private String requirements;
+		private String mainTasks;
+		private String intro;
+		private String benefits;
+		private String preferredPoints;
+		private String jobCategoryName;
+	}
+}

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/jd/presentation/JdMapper.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/jd/presentation/JdMapper.java
@@ -1,0 +1,16 @@
+package kernel.jdon.moduleapi.domain.jd.presentation;
+
+import org.mapstruct.InjectionStrategy;
+import org.mapstruct.Mapper;
+import org.mapstruct.ReportingPolicy;
+
+import kernel.jdon.moduleapi.domain.jd.core.JdInfo;
+
+@Mapper(
+	componentModel = "spring",
+	injectionStrategy = InjectionStrategy.CONSTRUCTOR,
+	unmappedTargetPolicy = ReportingPolicy.ERROR
+)
+public interface JdMapper {
+	JdDto.FindWantedJdResponse of(JdInfo.FindWantedJdResponse info);
+}

--- a/module-api/src/main/java/kernel/jdon/moduleapi/global/config/auth/OAuth2SecurityConfig.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/global/config/auth/OAuth2SecurityConfig.java
@@ -35,6 +35,7 @@ public class OAuth2SecurityConfig {
 			"/api/v1/job-categories",
 			"/api/v1/faqs",
 			"/api/v1/skills/search",
+			"/api/v1/jds/**",
 			"/api/v1/authenticate"
 		};
 		final String[] permitAllPOST = {

--- a/module-api/src/main/java/kernel/jdon/wantedjd/repository/WantedJdRepository.java
+++ b/module-api/src/main/java/kernel/jdon/wantedjd/repository/WantedJdRepository.java
@@ -1,4 +1,0 @@
-package kernel.jdon.wantedjd.repository;
-
-public interface WantedJdRepository extends WantedJdDomainRepository {
-}

--- a/module-api/src/main/resources/application-dev.yml
+++ b/module-api/src/main/resources/application-dev.yml
@@ -13,6 +13,9 @@ spring:
   jpa:
     hibernate:
       ddl-auto: update
+    properties:
+      hibernate:
+        default_batch_fetch_size: 100
 
   security:
     oauth2:

--- a/module-api/src/main/resources/application-local.yml
+++ b/module-api/src/main/resources/application-local.yml
@@ -12,6 +12,9 @@ spring:
   jpa:
     hibernate:
       ddl-auto: update
+    properties:
+      hibernate:
+        default_batch_fetch_size: 100
 
   security:
     oauth2:

--- a/module-api/src/main/resources/application-prod.yml
+++ b/module-api/src/main/resources/application-prod.yml
@@ -12,6 +12,9 @@ spring:
   jpa:
     hibernate:
       ddl-auto: update
+    properties:
+      hibernate:
+        default_batch_fetch_size: 100
 
   security:
     oauth2:

--- a/module-domain/src/main/java/kernel/jdon/wantedjd/domain/WantedJd.java
+++ b/module-domain/src/main/java/kernel/jdon/wantedjd/domain/WantedJd.java
@@ -1,5 +1,8 @@
 package kernel.jdon.wantedjd.domain;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
@@ -12,9 +15,11 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
 import kernel.jdon.jobcategory.domain.JobCategory;
+import kernel.jdon.wantedjdskill.domain.WantedJdSkill;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -65,15 +70,17 @@ public class WantedJd {
 	@Column(name = "scraping_date", columnDefinition = "TEXT", nullable = false)
 	private String scrapingDate;
 
-	@ManyToOne(fetch = FetchType.LAZY)
+	@ManyToOne(fetch = FetchType.EAGER)
 	@JoinColumn(name = "job_category_id", columnDefinition = "BIGINT")
 	private JobCategory jobCategory;
 
+	@OneToMany(mappedBy = "wantedJd")
+	private List<WantedJdSkill> skillList = new ArrayList<>();
+
 	@Builder
 	public WantedJd(String companyName, String title, Long detailId, String detailUrl, String imageUrl,
-		String requirements,
-		String mainTasks, String intro, String benefits, String preferredPoints, String scrapingDate,
-		JobCategory jobCategory) {
+		String requirements, String mainTasks, String intro, String benefits, String preferredPoints,
+		String scrapingDate, JobCategory jobCategory) {
 		this.companyName = companyName;
 		this.title = title;
 		this.detailId = detailId;

--- a/module-domain/src/main/java/kernel/jdon/wantedjdskill/domain/WantedJdSkill.java
+++ b/module-domain/src/main/java/kernel/jdon/wantedjdskill/domain/WantedJdSkill.java
@@ -12,9 +12,11 @@ import kernel.jdon.skill.domain.Skill;
 import kernel.jdon.wantedjd.domain.WantedJd;
 import lombok.AccessLevel;
 import lombok.Builder;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
+@Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "wanted_jd_skill")
 public class WantedJdSkill {


### PR DESCRIPTION
## 개요

### 요약

- [JD 상세조회](https://www.notion.so/JD-4e7577c6d81645deb6bab3fe32774f2d?pvs=4) API를 구현했습니다.

### 변경한 부분
- WantedJd를 가져올 때 JobCategory 엔티티의 데이터를 즉시 가져올 수 있도록 WantedJd 엔티티에서 참조하고있는 JobCategory 엔티티의 참조 속성을 즉시로딩으로 변경하였습니다.
  - 다대일 관계이기 때문에 항상 즉시 가져와도 문제 없다고 판단했습니다.
- JD 상세조회 API 항목에 기술스택 목록 항목이 누락되어 포함하도록 구현했습니다.
- application.yml에 batchSize를 100으로 설정했습니다.(100개 이하더라도 100개까지 조회, 나머지는 NULL로 in절에 포함됨)
![image](https://github.com/Kernel360/f1-JDON-Backend/assets/59242594/f60cca4f-a07c-47b8-8f01-5445ca84fb5d)


### 변경한 결과
API 정상 호출 확인했습니다.
<img width="646" alt="image" src="https://github.com/Kernel360/f1-JDON-Backend/assets/59242594/4e939ed2-015b-4da5-a379-8c4b0b83a255">
<img width="652" alt="image" src="https://github.com/Kernel360/f1-JDON-Backend/assets/59242594/35148ba9-7f04-43f9-a2f7-f73eb6e1e4f1">

### 이슈

- closes: #321 

---

## PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경, 주석 변경)
- [ ] 코드 리팩토링
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 파일 혹은 폴더명 수정, 삭제
- [ ] 배포 관련