### PR TITLE
Refactor: 찜하기/취소하기, 찜 조회하기 API 페이징 변경

### DIFF
--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/favorite/application/FavoriteFacade.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/favorite/application/FavoriteFacade.java
@@ -1,11 +1,11 @@
 package kernel.jdon.moduleapi.domain.favorite.application;
 
-import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 import kernel.jdon.moduleapi.domain.favorite.core.FavoriteCommand;
 import kernel.jdon.moduleapi.domain.favorite.core.FavoriteInfo;
 import kernel.jdon.moduleapi.domain.favorite.core.FavoriteService;
+import kernel.jdon.moduleapi.global.page.PageInfoRequest;
 import lombok.RequiredArgsConstructor;
 
 @Service
@@ -20,7 +20,14 @@ public class FavoriteFacade {
 		return favoriteService.delete(memberId, request.getLectureId());
 	}
 
-	public FavoriteInfo.FindPageResponse getList(final Long memberId, Pageable pageable) {
-		return favoriteService.getList(memberId, pageable);
+	// public FavoriteInfo.FindPageResponse getList(final Long memberId, Pageable pageable) {
+	// 	return favoriteService.getList(memberId, pageable);
+	// }
+
+	public FavoriteInfo.FindFavoriteListResponse getList(
+		final Long memberId,
+		final PageInfoRequest pageInfoRequest) {
+		
+		return favoriteService.getList(memberId, pageInfoRequest);
 	}
 }

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/favorite/application/FavoriteFacade.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/favorite/application/FavoriteFacade.java
@@ -20,14 +20,10 @@ public class FavoriteFacade {
 		return favoriteService.delete(memberId, request.getLectureId());
 	}
 
-	// public FavoriteInfo.FindPageResponse getList(final Long memberId, Pageable pageable) {
-	// 	return favoriteService.getList(memberId, pageable);
-	// }
-
 	public FavoriteInfo.FindFavoriteListResponse getList(
 		final Long memberId,
 		final PageInfoRequest pageInfoRequest) {
-		
+
 		return favoriteService.getList(memberId, pageInfoRequest);
 	}
 }

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/favorite/core/FavoriteInfo.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/favorite/core/FavoriteInfo.java
@@ -1,7 +1,10 @@
 package kernel.jdon.moduleapi.domain.favorite.core;
 
+import java.util.List;
+
 import jakarta.validation.constraints.NotNull;
-import kernel.jdon.moduleapi.global.page.CustomPageResponse;
+import kernel.jdon.moduleapi.domain.favorite.infrastructure.FavoriteReaderInfo;
+import kernel.jdon.moduleapi.global.page.CustomPageInfo;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -11,13 +14,13 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class FavoriteInfo {
 
-	@Getter
-	@Builder
-	@AllArgsConstructor
-	public static class FindPageResponse {
-		private CustomPageResponse<FindResponse> findPage;
-	}
-
+	// @Getter
+	// @Builder
+	// @AllArgsConstructor
+	// public static class FindPageResponse {
+	// 	private CustomPageResponse<FindResponse> findPage;
+	// }
+	//
 	@Getter
 	@AllArgsConstructor
 	public static class FindResponse {
@@ -28,6 +31,37 @@ public class FavoriteInfo {
 		private String instructor;
 		private Long studentCount;
 		private Integer price;
+	}
+
+	@Getter
+	@AllArgsConstructor
+	public static class FindFavoriteListResponse {
+		private List<FindFavoriteInfo> content;
+		private CustomPageInfo pageInfo;
+	}
+
+	@Getter
+	@AllArgsConstructor
+	public static class FindFavoriteInfo {
+		private Long lectureId;
+		private String title;
+		private String lectureUrl;
+		private String imageUrl;
+		private String instructor;
+		private Long studentCount;
+		private Integer price;
+
+		public static FindFavoriteInfo of(FavoriteReaderInfo.FindFavoriteListResponse favorite) {
+			return new FindFavoriteInfo(
+				favorite.getLectureId(),
+				favorite.getTitle(),
+				favorite.getLectureUrl(),
+				favorite.getImageUrl(),
+				favorite.getInstructor(),
+				favorite.getStudentCount(),
+				favorite.getPrice()
+			);
+		}
 	}
 
 	@Getter

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/favorite/core/FavoriteInfo.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/favorite/core/FavoriteInfo.java
@@ -13,14 +13,7 @@ import lombok.NoArgsConstructor;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class FavoriteInfo {
-
-	// @Getter
-	// @Builder
-	// @AllArgsConstructor
-	// public static class FindPageResponse {
-	// 	private CustomPageResponse<FindResponse> findPage;
-	// }
-	//
+	
 	@Getter
 	@AllArgsConstructor
 	public static class FindResponse {

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/favorite/core/FavoriteInfo.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/favorite/core/FavoriteInfo.java
@@ -13,18 +13,6 @@ import lombok.NoArgsConstructor;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class FavoriteInfo {
-	
-	@Getter
-	@AllArgsConstructor
-	public static class FindResponse {
-		private Long lectureId;
-		private String title;
-		private String lectureUrl;
-		private String imageUrl;
-		private String instructor;
-		private Long studentCount;
-		private Integer price;
-	}
 
 	@Getter
 	@AllArgsConstructor

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/favorite/core/FavoriteInfo.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/favorite/core/FavoriteInfo.java
@@ -17,13 +17,13 @@ public class FavoriteInfo {
 	@Getter
 	@AllArgsConstructor
 	public static class FindFavoriteListResponse {
-		private List<FindFavoriteInfo> content;
+		private List<FindFavorite> content;
 		private CustomPageInfo pageInfo;
 	}
 
 	@Getter
 	@AllArgsConstructor
-	public static class FindFavoriteInfo {
+	public static class FindFavorite {
 		private Long lectureId;
 		private String title;
 		private String lectureUrl;
@@ -32,8 +32,8 @@ public class FavoriteInfo {
 		private Long studentCount;
 		private Integer price;
 
-		public static FindFavoriteInfo of(FavoriteReaderInfo.FindFavoriteListResponse favorite) {
-			return new FindFavoriteInfo(
+		public static FindFavorite of(FavoriteReaderInfo.FindFavoriteListResponse favorite) {
+			return new FindFavorite(
 				favorite.getLectureId(),
 				favorite.getTitle(),
 				favorite.getLectureUrl(),

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/favorite/core/FavoriteInfoMapper.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/favorite/core/FavoriteInfoMapper.java
@@ -6,6 +6,7 @@ import org.mapstruct.Mapping;
 import org.mapstruct.Mappings;
 import org.mapstruct.ReportingPolicy;
 
+import kernel.jdon.moduleapi.domain.favorite.infrastructure.FavoriteReaderInfo;
 import kernel.jdon.moduledomain.favorite.domain.Favorite;
 
 @Mapper(
@@ -24,5 +25,5 @@ public interface FavoriteInfoMapper {
 		@Mapping(source = "inflearnCourse.studentCount", target = "studentCount"),
 		@Mapping(source = "inflearnCourse.price", target = "price")
 	})
-	FavoriteInfo.FindResponse of(Favorite favorite);
+	FavoriteReaderInfo.FindFavoriteListResponse of(Favorite favorite);
 }

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/favorite/core/FavoriteReader.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/favorite/core/FavoriteReader.java
@@ -6,7 +6,6 @@ import kernel.jdon.moduleapi.global.page.PageInfoRequest;
 import kernel.jdon.moduledomain.favorite.domain.Favorite;
 
 public interface FavoriteReader {
-	// Page<Favorite> findList(final Long memberId, Pageable pageable);
 	FavoriteInfo.FindFavoriteListResponse findList(Long memberId, PageInfoRequest pageInfoRequest);
 
 	Optional<Favorite> findFavoriteByMemberIdAndInflearnCourseId(Long memberId, Long lectureId);

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/favorite/core/FavoriteReader.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/favorite/core/FavoriteReader.java
@@ -2,13 +2,12 @@ package kernel.jdon.moduleapi.domain.favorite.core;
 
 import java.util.Optional;
 
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
-
+import kernel.jdon.moduleapi.global.page.PageInfoRequest;
 import kernel.jdon.moduledomain.favorite.domain.Favorite;
 
 public interface FavoriteReader {
-	Page<Favorite> findList(final Long memberId, Pageable pageable);
+	// Page<Favorite> findList(final Long memberId, Pageable pageable);
+	FavoriteInfo.FindFavoriteListResponse findList(Long memberId, PageInfoRequest pageInfoRequest);
 
 	Optional<Favorite> findFavoriteByMemberIdAndInflearnCourseId(Long memberId, Long lectureId);
 

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/favorite/core/FavoriteService.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/favorite/core/FavoriteService.java
@@ -6,8 +6,6 @@ public interface FavoriteService {
 	FavoriteInfo.UpdateResponse save(Long memberId, Long lectureId);
 
 	FavoriteInfo.UpdateResponse delete(Long memberId, Long lectureId);
-
-	// FavoriteInfo.FindPageResponse getList(final Long memberId, final Pageable pageable);
-
+	
 	FavoriteInfo.FindFavoriteListResponse getList(Long memberId, PageInfoRequest pageInfoRequest);
 }

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/favorite/core/FavoriteService.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/favorite/core/FavoriteService.java
@@ -1,11 +1,13 @@
 package kernel.jdon.moduleapi.domain.favorite.core;
 
-import org.springframework.data.domain.Pageable;
+import kernel.jdon.moduleapi.global.page.PageInfoRequest;
 
 public interface FavoriteService {
 	FavoriteInfo.UpdateResponse save(Long memberId, Long lectureId);
 
 	FavoriteInfo.UpdateResponse delete(Long memberId, Long lectureId);
 
-	FavoriteInfo.FindPageResponse getList(final Long memberId, final Pageable pageable);
+	// FavoriteInfo.FindPageResponse getList(final Long memberId, final Pageable pageable);
+
+	FavoriteInfo.FindFavoriteListResponse getList(Long memberId, PageInfoRequest pageInfoRequest);
 }

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/favorite/core/FavoriteServiceImpl.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/favorite/core/FavoriteServiceImpl.java
@@ -58,14 +58,6 @@ public class FavoriteServiceImpl implements FavoriteService {
 		return new FavoriteInfo.UpdateResponse(findFavorite.getId());
 	}
 
-	// @Override
-	// public FavoriteInfo.FindPageResponse getList(Long memberId, Pageable pageable) {
-	// 	Page<Favorite> favoritePage = favoriteReader.findList(memberId, pageable);
-	// 	Page<FavoriteInfo.FindResponse> infoPage = favoritePage.map(favoriteInfoMapper::of);
-	//
-	// 	return new FavoriteInfo.FindPageResponse(CustomPageResponse.of(infoPage));
-	// }
-
 	@Override
 	public FavoriteInfo.FindFavoriteListResponse getList(Long memberId, PageInfoRequest pageInfoRequest) {
 		FavoriteInfo.FindFavoriteListResponse favoriteList = favoriteReader.findList(memberId, pageInfoRequest);

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/favorite/core/FavoriteServiceImpl.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/favorite/core/FavoriteServiceImpl.java
@@ -3,6 +3,7 @@ package kernel.jdon.moduleapi.domain.favorite.core;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import kernel.jdon.inflearncourse.domain.InflearnCourse;
 import kernel.jdon.member.domain.Member;
@@ -16,6 +17,7 @@ import kernel.jdon.moduledomain.favorite.domain.Favorite;
 import lombok.RequiredArgsConstructor;
 
 @Service
+@Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class FavoriteServiceImpl implements FavoriteService {
 	private final FavoriteReader favoriteReader;
@@ -25,6 +27,7 @@ public class FavoriteServiceImpl implements FavoriteService {
 	private final FavoriteInfoMapper favoriteInfoMapper;
 
 	@Override
+	@Transactional
 	public FavoriteInfo.UpdateResponse save(Long memberId, Long lectureId) {
 		Member findMember = memberReader.findById(memberId);
 		InflearnCourse findInflearnCourse = inflearnReader.findById(lectureId);
@@ -43,6 +46,7 @@ public class FavoriteServiceImpl implements FavoriteService {
 	}
 
 	@Override
+	@Transactional
 	public FavoriteInfo.UpdateResponse delete(Long memberId, Long lectureId) {
 		boolean memberExists = memberReader.existsById(memberId);
 		if (!memberExists) {

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/favorite/core/FavoriteServiceImpl.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/favorite/core/FavoriteServiceImpl.java
@@ -1,7 +1,5 @@
 package kernel.jdon.moduleapi.domain.favorite.core;
 
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -12,7 +10,7 @@ import kernel.jdon.moduleapi.domain.inflearncourse.core.InflearnReader;
 import kernel.jdon.moduleapi.domain.member.core.MemberReader;
 import kernel.jdon.moduleapi.domain.member.error.MemberErrorCode;
 import kernel.jdon.moduleapi.global.exception.ApiException;
-import kernel.jdon.moduleapi.global.page.CustomPageResponse;
+import kernel.jdon.moduleapi.global.page.PageInfoRequest;
 import kernel.jdon.moduledomain.favorite.domain.Favorite;
 import lombok.RequiredArgsConstructor;
 
@@ -24,7 +22,6 @@ public class FavoriteServiceImpl implements FavoriteService {
 	private final FavoriteStore favoriteStore;
 	private final MemberReader memberReader;
 	private final InflearnReader inflearnReader;
-	private final FavoriteInfoMapper favoriteInfoMapper;
 
 	@Override
 	@Transactional
@@ -61,11 +58,19 @@ public class FavoriteServiceImpl implements FavoriteService {
 		return new FavoriteInfo.UpdateResponse(findFavorite.getId());
 	}
 
-	@Override
-	public FavoriteInfo.FindPageResponse getList(Long memberId, Pageable pageable) {
-		Page<Favorite> favoritePage = favoriteReader.findList(memberId, pageable);
-		Page<FavoriteInfo.FindResponse> infoPage = favoritePage.map(favoriteInfoMapper::of);
+	// @Override
+	// public FavoriteInfo.FindPageResponse getList(Long memberId, Pageable pageable) {
+	// 	Page<Favorite> favoritePage = favoriteReader.findList(memberId, pageable);
+	// 	Page<FavoriteInfo.FindResponse> infoPage = favoritePage.map(favoriteInfoMapper::of);
+	//
+	// 	return new FavoriteInfo.FindPageResponse(CustomPageResponse.of(infoPage));
+	// }
 
-		return new FavoriteInfo.FindPageResponse(CustomPageResponse.of(infoPage));
+	@Override
+	public FavoriteInfo.FindFavoriteListResponse getList(Long memberId, PageInfoRequest pageInfoRequest) {
+		FavoriteInfo.FindFavoriteListResponse favoriteList = favoriteReader.findList(memberId, pageInfoRequest);
+
+		return favoriteList;
 	}
+
 }

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/favorite/infrastructure/FavoriteReaderImpl.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/favorite/infrastructure/FavoriteReaderImpl.java
@@ -22,11 +22,6 @@ public class FavoriteReaderImpl implements FavoriteReader {
 	private final FavoriteRepository favoriteRepository;
 	private final FavoriteInfoMapper favoriteInfoMapper;
 
-	// @Override
-	// public Page<Favorite> findList(Long memberId, Pageable pageable) {
-	// 	return favoriteRepository.findFavoriteByMemberId(memberId, pageable);
-	// }
-
 	@Override
 	public FavoriteInfo.FindFavoriteListResponse findList(Long memberId, PageInfoRequest pageInfoRequest) {
 		Pageable pageable = PageRequest.of(pageInfoRequest.getPage(), pageInfoRequest.getSize());

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/favorite/infrastructure/FavoriteReaderImpl.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/favorite/infrastructure/FavoriteReaderImpl.java
@@ -1,12 +1,18 @@
 package kernel.jdon.moduleapi.domain.favorite.infrastructure;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Component;
 
+import kernel.jdon.moduleapi.domain.favorite.core.FavoriteInfo;
+import kernel.jdon.moduleapi.domain.favorite.core.FavoriteInfoMapper;
 import kernel.jdon.moduleapi.domain.favorite.core.FavoriteReader;
+import kernel.jdon.moduleapi.global.page.CustomPageInfo;
+import kernel.jdon.moduleapi.global.page.PageInfoRequest;
 import kernel.jdon.moduledomain.favorite.domain.Favorite;
 import lombok.RequiredArgsConstructor;
 
@@ -14,10 +20,34 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class FavoriteReaderImpl implements FavoriteReader {
 	private final FavoriteRepository favoriteRepository;
+	private final FavoriteInfoMapper favoriteInfoMapper;
+
+	// @Override
+	// public Page<Favorite> findList(Long memberId, Pageable pageable) {
+	// 	return favoriteRepository.findFavoriteByMemberId(memberId, pageable);
+	// }
 
 	@Override
-	public Page<Favorite> findList(Long memberId, Pageable pageable) {
-		return favoriteRepository.findFavoriteByMemberId(memberId, pageable);
+	public FavoriteInfo.FindFavoriteListResponse findList(Long memberId, PageInfoRequest pageInfoRequest) {
+		Pageable pageable = PageRequest.of(pageInfoRequest.getPage(), pageInfoRequest.getSize());
+
+		Page<Favorite> favoritePage = favoriteRepository.findFavoriteByMemberId(memberId, pageable);
+		Page<FavoriteReaderInfo.FindFavoriteListResponse> favoritesPage = favoritePage.map(favoriteInfoMapper::of);
+
+		List<FavoriteInfo.FindFavoriteInfo> list = favoritesPage.getContent().stream()
+			.map(FavoriteInfo.FindFavoriteInfo::of)
+			.toList();
+
+		CustomPageInfo customPageInfo = new CustomPageInfo(
+			favoritesPage.getNumber(),
+			favoritesPage.getTotalElements(),
+			favoritesPage.getSize(),
+			favoritesPage.isFirst(),
+			favoritesPage.isLast(),
+			favoritesPage.isEmpty()
+		);
+
+		return new FavoriteInfo.FindFavoriteListResponse(list, customPageInfo);
 	}
 
 	@Override

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/favorite/infrastructure/FavoriteReaderImpl.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/favorite/infrastructure/FavoriteReaderImpl.java
@@ -29,8 +29,8 @@ public class FavoriteReaderImpl implements FavoriteReader {
 		Page<Favorite> favoritePage = favoriteRepository.findFavoriteByMemberId(memberId, pageable);
 		Page<FavoriteReaderInfo.FindFavoriteListResponse> favoritesPage = favoritePage.map(favoriteInfoMapper::of);
 
-		List<FavoriteInfo.FindFavoriteInfo> list = favoritesPage.getContent().stream()
-			.map(FavoriteInfo.FindFavoriteInfo::of)
+		List<FavoriteInfo.FindFavorite> list = favoritesPage.getContent().stream()
+			.map(FavoriteInfo.FindFavorite::of)
 			.toList();
 
 		CustomPageInfo customPageInfo = new CustomPageInfo(

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/favorite/infrastructure/FavoriteReaderInfo.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/favorite/infrastructure/FavoriteReaderInfo.java
@@ -1,0 +1,22 @@
+package kernel.jdon.moduleapi.domain.favorite.infrastructure;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class FavoriteReaderInfo {
+
+	@Getter
+	@AllArgsConstructor
+	public static class FindFavoriteListResponse {
+		private Long lectureId;
+		private String title;
+		private String lectureUrl;
+		private String imageUrl;
+		private String instructor;
+		private Long studentCount;
+		private Integer price;
+	}
+}

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/favorite/infrastructure/FavoriteStoreImpl.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/favorite/infrastructure/FavoriteStoreImpl.java
@@ -1,26 +1,22 @@
 package kernel.jdon.moduleapi.domain.favorite.infrastructure;
 
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Transactional;
 
 import kernel.jdon.moduleapi.domain.favorite.core.FavoriteStore;
 import kernel.jdon.moduledomain.favorite.domain.Favorite;
 import lombok.RequiredArgsConstructor;
 
 @Component
-@Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class FavoriteStoreImpl implements FavoriteStore {
 	private final FavoriteRepository favoriteRepository;
 
 	@Override
-	@Transactional
 	public Favorite save(Favorite favorite) {
 		return favoriteRepository.save(favorite);
 	}
 
 	@Override
-	@Transactional
 	public void delete(Favorite favorite) {
 		favoriteRepository.delete(favorite);
 	}

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/favorite/presentation/FavoriteController.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/favorite/presentation/FavoriteController.java
@@ -24,15 +24,7 @@ import lombok.RequiredArgsConstructor;
 public class FavoriteController {
 	private final FavoriteFacade favoriteFacade;
 	private final FavoriteDtoMapper favoriteDtoMapper;
-
-	// @GetMapping("/api/v1/favorites")
-	// public ResponseEntity<CommonResponse<FavoriteDto.FindPageResponse>> getList(@LoginUser SessionUserInfo member,
-	// 	@PageableDefault(size = 12) Pageable pageable) {
-	// 	final FavoriteInfo.FindPageResponse info = favoriteFacade.getList(member.getId(), pageable);
-	// 	final FavoriteDto.FindPageResponse response = favoriteDtoMapper.of(info);
-	//
-	// 	return ResponseEntity.ok(CommonResponse.of(response.getFindPage()));
-	// }
+	
 	@GetMapping("/api/v1/favorites")
 	public ResponseEntity<CommonResponse<FavoriteDto.FindFavoriteListResponse>> getList(
 		@LoginUser SessionUserInfo member,

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/favorite/presentation/FavoriteController.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/favorite/presentation/FavoriteController.java
@@ -2,12 +2,11 @@ package kernel.jdon.moduleapi.domain.favorite.presentation;
 
 import java.net.URI;
 
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import jakarta.validation.Valid;
@@ -16,6 +15,7 @@ import kernel.jdon.moduleapi.domain.favorite.application.FavoriteFacade;
 import kernel.jdon.moduleapi.domain.favorite.core.FavoriteCommand;
 import kernel.jdon.moduleapi.domain.favorite.core.FavoriteInfo;
 import kernel.jdon.moduleapi.global.annotation.LoginUser;
+import kernel.jdon.moduleapi.global.page.PageInfoRequest;
 import kernel.jdon.modulecommon.dto.response.CommonResponse;
 import lombok.RequiredArgsConstructor;
 
@@ -25,13 +25,24 @@ public class FavoriteController {
 	private final FavoriteFacade favoriteFacade;
 	private final FavoriteDtoMapper favoriteDtoMapper;
 
+	// @GetMapping("/api/v1/favorites")
+	// public ResponseEntity<CommonResponse<FavoriteDto.FindPageResponse>> getList(@LoginUser SessionUserInfo member,
+	// 	@PageableDefault(size = 12) Pageable pageable) {
+	// 	final FavoriteInfo.FindPageResponse info = favoriteFacade.getList(member.getId(), pageable);
+	// 	final FavoriteDto.FindPageResponse response = favoriteDtoMapper.of(info);
+	//
+	// 	return ResponseEntity.ok(CommonResponse.of(response.getFindPage()));
+	// }
 	@GetMapping("/api/v1/favorites")
-	public ResponseEntity<CommonResponse<FavoriteDto.FindPageResponse>> getList(@LoginUser SessionUserInfo member,
-		@PageableDefault(size = 12) Pageable pageable) {
-		final FavoriteInfo.FindPageResponse info = favoriteFacade.getList(member.getId(), pageable);
-		final FavoriteDto.FindPageResponse response = favoriteDtoMapper.of(info);
+	public ResponseEntity<CommonResponse<FavoriteDto.FindFavoriteListResponse>> getList(
+		@LoginUser SessionUserInfo member,
+		@RequestParam(value = "page", defaultValue = "0") int page,
+		@RequestParam(value = "size", defaultValue = "12") int size) {
+		final FavoriteInfo.FindFavoriteListResponse info = favoriteFacade.getList(member.getId(),
+			new PageInfoRequest(page, size));
+		final FavoriteDto.FindFavoriteListResponse response = favoriteDtoMapper.of(info);
 
-		return ResponseEntity.ok(CommonResponse.of(response.getFindPage()));
+		return ResponseEntity.ok(CommonResponse.of(response));
 	}
 
 	@PostMapping("/api/v1/favorites")

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/favorite/presentation/FavoriteDto.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/favorite/presentation/FavoriteDto.java
@@ -12,12 +12,6 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class FavoriteDto {
 
-	// @Getter
-	// @AllArgsConstructor
-	// public static class FindPageResponse {
-	// 	private CustomPageResponse<FavoriteInfo.FindResponse> findPage;
-	// }
-
 	@Getter
 	@AllArgsConstructor
 	public static class FindResponse {

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/favorite/presentation/FavoriteDto.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/favorite/presentation/FavoriteDto.java
@@ -14,18 +14,6 @@ public class FavoriteDto {
 
 	@Getter
 	@AllArgsConstructor
-	public static class FindResponse {
-		private Long lectureId;
-		private String title;
-		private String lectureUrl;
-		private String imageUrl;
-		private String instructor;
-		private Long studentCount;
-		private Integer price;
-	}
-
-	@Getter
-	@AllArgsConstructor
 	public static class FindFavoriteListResponse {
 		private List<FavoriteDto.FindFavoriteDto> content;
 		private CustomPageInfo pageInfo;

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/favorite/presentation/FavoriteDto.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/favorite/presentation/FavoriteDto.java
@@ -1,8 +1,9 @@
 package kernel.jdon.moduleapi.domain.favorite.presentation;
 
+import java.util.List;
+
 import jakarta.validation.constraints.NotNull;
-import kernel.jdon.moduleapi.domain.favorite.core.FavoriteInfo;
-import kernel.jdon.moduleapi.global.page.CustomPageResponse;
+import kernel.jdon.moduleapi.global.page.CustomPageInfo;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -11,15 +12,34 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class FavoriteDto {
 
-	@Getter
-	@AllArgsConstructor
-	public static class FindPageResponse {
-		private CustomPageResponse<FavoriteInfo.FindResponse> findPage;
-	}
+	// @Getter
+	// @AllArgsConstructor
+	// public static class FindPageResponse {
+	// 	private CustomPageResponse<FavoriteInfo.FindResponse> findPage;
+	// }
 
 	@Getter
 	@AllArgsConstructor
 	public static class FindResponse {
+		private Long lectureId;
+		private String title;
+		private String lectureUrl;
+		private String imageUrl;
+		private String instructor;
+		private Long studentCount;
+		private Integer price;
+	}
+
+	@Getter
+	@AllArgsConstructor
+	public static class FindFavoriteListResponse {
+		private List<FavoriteDto.FindFavoriteDto> content;
+		private CustomPageInfo pageInfo;
+	}
+
+	@Getter
+	@AllArgsConstructor
+	public static class FindFavoriteDto {
 		private Long lectureId;
 		private String title;
 		private String lectureUrl;

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/favorite/presentation/FavoriteDto.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/favorite/presentation/FavoriteDto.java
@@ -15,13 +15,13 @@ public class FavoriteDto {
 	@Getter
 	@AllArgsConstructor
 	public static class FindFavoriteListResponse {
-		private List<FavoriteDto.FindFavoriteDto> content;
+		private List<FindFavorite> content;
 		private CustomPageInfo pageInfo;
 	}
 
 	@Getter
 	@AllArgsConstructor
-	public static class FindFavoriteDto {
+	public static class FindFavorite {
 		private Long lectureId;
 		private String title;
 		private String lectureUrl;

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/favorite/presentation/FavoriteDtoMapper.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/favorite/presentation/FavoriteDtoMapper.java
@@ -13,7 +13,6 @@ import kernel.jdon.moduleapi.domain.favorite.core.FavoriteInfo;
 	unmappedTargetPolicy = ReportingPolicy.ERROR
 )
 public interface FavoriteDtoMapper {
-	// FavoriteDto.FindPageResponse of(FavoriteInfo.FindPageResponse info);
 	FavoriteDto.FindFavoriteListResponse of(FavoriteInfo.FindFavoriteListResponse info);
 
 	FavoriteCommand.UpdateRequest of(FavoriteDto.UpdateRequest request);

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/favorite/presentation/FavoriteDtoMapper.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/favorite/presentation/FavoriteDtoMapper.java
@@ -13,10 +13,11 @@ import kernel.jdon.moduleapi.domain.favorite.core.FavoriteInfo;
 	unmappedTargetPolicy = ReportingPolicy.ERROR
 )
 public interface FavoriteDtoMapper {
-	FavoriteDto.FindPageResponse of(FavoriteInfo.FindPageResponse info);
+	// FavoriteDto.FindPageResponse of(FavoriteInfo.FindPageResponse info);
+	FavoriteDto.FindFavoriteListResponse of(FavoriteInfo.FindFavoriteListResponse info);
 
 	FavoriteCommand.UpdateRequest of(FavoriteDto.UpdateRequest request);
 
 	FavoriteDto.UpdateResponse of(FavoriteInfo.UpdateResponse info);
-	
+
 }

--- a/module-api/src/test/java/kernel/jdon/moduleapi/domain/favorite/application/FavoriteFacadeTest.java
+++ b/module-api/src/test/java/kernel/jdon/moduleapi/domain/favorite/application/FavoriteFacadeTest.java
@@ -25,7 +25,7 @@ class FavoriteFacadeTest {
 	@InjectMocks
 	private FavoriteFacade favoriteFacade;
 
-	@DisplayName("유효한 요청이 주어졌을 때, 찜하기를 하면 favorite id를 응답한다.")
+	@DisplayName("1: 유효한 요청이 주어졌을 때, 찜하기를 하면 favorite id를 응답한다.")
 	@Test
 	void givenValidRequest_whenCreateFavorite_thenReturnCreatedFavorite() {
 		// given
@@ -42,7 +42,7 @@ class FavoriteFacadeTest {
 		verify(favoriteService, times(1)).save(memberId, request.getLectureId());
 	}
 
-	@DisplayName("유효한 요청으로 즐겨찾기 삭제하면, 삭제된 favorite id를 응답한다.")
+	@DisplayName("2: 유효한 요청으로 즐겨찾기 삭제하면, 삭제된 favorite id를 응답한다.")
 	@Test
 	void givenValidRequest_whenDeleteFavorite_thenReturnDeletedFavorite() {
 		// given
@@ -60,7 +60,7 @@ class FavoriteFacadeTest {
 		verify(favoriteService, times(1)).delete(memberId, lectureId);
 	}
 
-	@DisplayName("내가 찜한 목록을 요청하면, 찜한 목록을 응답한다.")
+	@DisplayName("3: 내가 찜한 목록을 요청하면, 찜한 목록을 응답한다.")
 	@Test
 	void whenGetList_thenReturnList() {
 		// given

--- a/module-api/src/test/java/kernel/jdon/moduleapi/domain/favorite/application/FavoriteFacadeTest.java
+++ b/module-api/src/test/java/kernel/jdon/moduleapi/domain/favorite/application/FavoriteFacadeTest.java
@@ -9,11 +9,11 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.data.domain.Pageable;
 
 import kernel.jdon.moduleapi.domain.favorite.core.FavoriteCommand;
 import kernel.jdon.moduleapi.domain.favorite.core.FavoriteInfo;
 import kernel.jdon.moduleapi.domain.favorite.core.FavoriteService;
+import kernel.jdon.moduleapi.global.page.PageInfoRequest;
 
 @DisplayName("Favorite Facade 테스트")
 @ExtendWith(MockitoExtension.class)
@@ -34,12 +34,12 @@ class FavoriteFacadeTest {
 		FavoriteInfo.UpdateResponse expectedResponse = new FavoriteInfo.UpdateResponse(2L);
 
 		// when
-		when(favoriteService.save(memberId, request)).thenReturn(expectedResponse);
+		when(favoriteService.save(memberId, request.getLectureId())).thenReturn(expectedResponse);
 		FavoriteInfo.UpdateResponse actualResponse = favoriteFacade.update(memberId, request);
 
 		// then
 		assertThat(expectedResponse.getLectureId()).isEqualTo(actualResponse.getLectureId());
-		verify(favoriteService, times(1)).save(memberId, request);
+		verify(favoriteService, times(1)).save(memberId, request.getLectureId());
 	}
 
 	@DisplayName("유효한 요청으로 즐겨찾기 삭제하면, 삭제된 favorite id를 응답한다.")
@@ -48,13 +48,15 @@ class FavoriteFacadeTest {
 		// given
 		Long memberId = 1L;
 		Long lectureId = 2L;
+		FavoriteCommand.UpdateRequest request = new FavoriteCommand.UpdateRequest(2L, false);
+		FavoriteInfo.UpdateResponse expectedResponse = new FavoriteInfo.UpdateResponse(lectureId);
 
 		// when
-		FavoriteCommand.UpdateRequest request = new FavoriteCommand.UpdateRequest(2L, false);
-		doNothing().when(favoriteService).delete(memberId, lectureId);
-		favoriteFacade.update(memberId, request);
+		when(favoriteService.delete(memberId, lectureId)).thenReturn(expectedResponse);
+		FavoriteInfo.UpdateResponse actualResponse = favoriteFacade.update(memberId, request);
 
 		// then
+		assertThat(actualResponse).isEqualTo(expectedResponse);
 		verify(favoriteService, times(1)).delete(memberId, lectureId);
 	}
 
@@ -63,16 +65,16 @@ class FavoriteFacadeTest {
 	void whenGetList_thenReturnList() {
 		// given
 		Long memberId = 1L;
-		Pageable pageable = Pageable.unpaged();
-		FavoriteInfo.FindPageResponse expectedResponse = mock(FavoriteInfo.FindPageResponse.class);
+		PageInfoRequest pageInfoRequest = new PageInfoRequest(0, 10);
+		FavoriteInfo.FindFavoriteListResponse expectedResponse = mock(FavoriteInfo.FindFavoriteListResponse.class);
 
 		// when
-		when(favoriteService.getList(memberId, pageable)).thenReturn(expectedResponse);
-		FavoriteInfo.FindPageResponse actualResponse = favoriteFacade.getList(memberId, pageable);
+		when(favoriteService.getList(memberId, pageInfoRequest)).thenReturn(expectedResponse);
+		FavoriteInfo.FindFavoriteListResponse actualResponse = favoriteFacade.getList(memberId, pageInfoRequest);
 
 		// then
 		assertThat(expectedResponse).isEqualTo(actualResponse);
-		verify(favoriteService, times(1)).getList(memberId, pageable);
+		verify(favoriteService, times(1)).getList(memberId, pageInfoRequest);
 	}
 
 }


### PR DESCRIPTION
## 개요

### 요약
- 페이징 방식 컨벤션에 맞게 변경
- 변경된 부분에 대하여 테스트 통과하도록 수정

### 변경한 부분
- CustomPageResponse 방식에서 content와 pageInfo를 별도로 들고 다니는 방식으로 변경

### 변경한 결과
- 찜하기/취소하기 API 
![image](https://github.com/Kernel360/f1-JDON-Backend/assets/86637372/cf5468e1-5c8b-407d-b126-61ade147596a)
- 찜 조회하기 API
![image](https://github.com/Kernel360/f1-JDON-Backend/assets/86637372/5bc4b01b-5e91-4d66-bb6b-8c6b01382641)
![image](https://github.com/Kernel360/f1-JDON-Backend/assets/86637372/b612503b-147f-43b4-a364-1066b5ce8015)

### 이슈

- closes: # 331

---

## PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경, 주석 변경)
- [x] 코드 리팩토링
- [ ] 문서 수정
- [x] 테스트 추가, 테스트 리팩토링
- [ ] 파일 혹은 폴더명 수정, 삭제
- [ ] 배포 관련