### PR TITLE
Feature: JD 목록 조회 API 구현

### DIFF
--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/coffeechat/infrastructure/CoffeeChatReaderImpl.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/coffeechat/infrastructure/CoffeeChatReaderImpl.java
@@ -12,7 +12,7 @@ import kernel.jdon.moduleapi.domain.coffeechat.core.CoffeeChatCommand;
 import kernel.jdon.moduleapi.domain.coffeechat.core.CoffeeChatInfo;
 import kernel.jdon.moduleapi.domain.coffeechat.core.CoffeeChatReader;
 import kernel.jdon.moduleapi.domain.coffeechat.error.CoffeeChatErrorCode;
-import kernel.jdon.moduleapi.global.page.CustomPageInfo;
+import kernel.jdon.moduleapi.global.page.CustomJpaPageInfo;
 import kernel.jdon.moduleapi.global.page.PageInfoRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -36,11 +36,7 @@ public class CoffeeChatReaderImpl implements CoffeeChatReader {
 			.map(coffeeChat -> CoffeeChatInfo.FindCoffeeChatInfo.of(coffeeChat))
 			.toList();
 
-		final CustomPageInfo customPageInfo = new CustomPageInfo(readerInfo.getPageable().getPageNumber(),
-			readerInfo.getTotalElements(), readerInfo.getPageable().getPageSize(), readerInfo.isFirst(),
-			readerInfo.isLast(), readerInfo.isEmpty());
-
-		return new CoffeeChatInfo.FindCoffeeChatListResponse(list, customPageInfo);
+		return new CoffeeChatInfo.FindCoffeeChatListResponse(list, new CustomJpaPageInfo(readerInfo));
 	}
 
 	@Override

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/favorite/core/FavoriteInfo.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/favorite/core/FavoriteInfo.java
@@ -46,16 +46,16 @@ public class FavoriteInfo {
 	}
 
 	@Getter
-	public class UpdateRequest {
-		private Long lectureId;
-		@NotNull(message = "isFavorite은 null이 될 수 없습니다.")
-		private Boolean isFavorite;
-	}
-
-	@Getter
 	@AllArgsConstructor
 	@Builder
 	public static class UpdateResponse {
 		private Long lectureId;
+	}
+
+	@Getter
+	public class UpdateRequest {
+		private Long lectureId;
+		@NotNull(message = "isFavorite은 null이 될 수 없습니다.")
+		private Boolean isFavorite;
 	}
 }

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/favorite/infrastructure/FavoriteReaderImpl.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/favorite/infrastructure/FavoriteReaderImpl.java
@@ -11,7 +11,7 @@ import org.springframework.stereotype.Component;
 import kernel.jdon.moduleapi.domain.favorite.core.FavoriteInfo;
 import kernel.jdon.moduleapi.domain.favorite.core.FavoriteInfoMapper;
 import kernel.jdon.moduleapi.domain.favorite.core.FavoriteReader;
-import kernel.jdon.moduleapi.global.page.CustomPageInfo;
+import kernel.jdon.moduleapi.global.page.CustomJpaPageInfo;
 import kernel.jdon.moduleapi.global.page.PageInfoRequest;
 import kernel.jdon.moduledomain.favorite.domain.Favorite;
 import lombok.RequiredArgsConstructor;
@@ -33,16 +33,7 @@ public class FavoriteReaderImpl implements FavoriteReader {
 			.map(FavoriteInfo.FindFavorite::of)
 			.toList();
 
-		CustomPageInfo customPageInfo = new CustomPageInfo(
-			favoritesPage.getNumber(),
-			favoritesPage.getTotalElements(),
-			favoritesPage.getSize(),
-			favoritesPage.isFirst(),
-			favoritesPage.isLast(),
-			favoritesPage.isEmpty()
-		);
-
-		return new FavoriteInfo.FindFavoriteListResponse(list, customPageInfo);
+		return new FavoriteInfo.FindFavoriteListResponse(list, new CustomJpaPageInfo(favoritesPage));
 	}
 
 	@Override

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/jd/application/JdFacade.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/jd/application/JdFacade.java
@@ -4,6 +4,7 @@ import org.springframework.stereotype.Service;
 
 import kernel.jdon.moduleapi.domain.jd.core.JdInfo;
 import kernel.jdon.moduleapi.domain.jd.core.JdService;
+import kernel.jdon.moduleapi.global.page.PageInfoRequest;
 import lombok.RequiredArgsConstructor;
 
 @Service
@@ -13,5 +14,9 @@ public class JdFacade {
 
 	public JdInfo.FindWantedJdResponse getJd(final Long jdId) {
 		return jdService.getJd(jdId);
+	}
+
+	public JdInfo.FindWantedJdListResponse getJdList(final PageInfoRequest pageInfoRequest, final String keyword) {
+		return jdService.getJdList(pageInfoRequest, keyword);
 	}
 }

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/jd/core/JdInfo.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/jd/core/JdInfo.java
@@ -2,8 +2,10 @@ package kernel.jdon.moduleapi.domain.jd.core;
 
 import java.util.List;
 
+import kernel.jdon.moduleapi.global.page.CustomPageInfo;
 import kernel.jdon.skill.domain.Skill;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -37,5 +39,23 @@ public class JdInfo {
 			this.id = skill.getId();
 			this.keyword = skill.getKeyword();
 		}
+	}
+
+	@Getter
+	@Builder
+	@AllArgsConstructor
+	public static class FindWantedJdListResponse {
+		private List<FindWantedJd> content;
+		private CustomPageInfo pageInfo;
+	}
+
+	@Getter
+	@Builder
+	public static class FindWantedJd {
+		private Long id;
+		private String title;
+		private String company;
+		private String imageUrl;
+		private String jobCategoryName;
 	}
 }

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/jd/core/JdReader.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/jd/core/JdReader.java
@@ -2,10 +2,13 @@ package kernel.jdon.moduleapi.domain.jd.core;
 
 import java.util.List;
 
+import kernel.jdon.moduleapi.global.page.PageInfoRequest;
 import kernel.jdon.wantedjd.domain.WantedJd;
 
 public interface JdReader {
-	WantedJd findWantedJd(final Long jdId);
+	WantedJd findWantedJd(Long jdId);
 
-	List<JdInfo.FindSkill> findSkillListByWantedJd(final WantedJd wantedJd);
+	List<JdInfo.FindSkill> findSkillListByWantedJd(WantedJd wantedJd);
+
+	JdInfo.FindWantedJdListResponse findWantedJdList(PageInfoRequest pageInfoRequest, String keyword);
 }

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/jd/core/JdService.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/jd/core/JdService.java
@@ -1,5 +1,9 @@
 package kernel.jdon.moduleapi.domain.jd.core;
 
+import kernel.jdon.moduleapi.global.page.PageInfoRequest;
+
 public interface JdService {
-	JdInfo.FindWantedJdResponse getJd(final Long jdId);
+	JdInfo.FindWantedJdResponse getJd(Long jdId);
+
+	JdInfo.FindWantedJdListResponse getJdList(PageInfoRequest pageInfoRequest, String keyword);
 }

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/jd/core/JdServiceImpl.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/jd/core/JdServiceImpl.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import org.springframework.stereotype.Service;
 
+import kernel.jdon.moduleapi.global.page.PageInfoRequest;
 import kernel.jdon.wantedjd.domain.WantedJd;
 import lombok.RequiredArgsConstructor;
 
@@ -20,4 +21,10 @@ public class JdServiceImpl implements JdService {
 
 		return jdInfoMapper.of(findWantedJd, findSkillList);
 	}
+
+	@Override
+	public JdInfo.FindWantedJdListResponse getJdList(final PageInfoRequest pageInfoRequest, final String keyword) {
+		return jdReader.findWantedJdList(pageInfoRequest, keyword);
+	}
+
 }

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/jd/infrastructure/CustomWantedJdRepository.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/jd/infrastructure/CustomWantedJdRepository.java
@@ -1,0 +1,8 @@
+package kernel.jdon.moduleapi.domain.jd.infrastructure;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface CustomWantedJdRepository {
+	Page<JdReaderInfo.FindWantedJd> findWantedJdList(Pageable pageable, String keyword);
+}

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/jd/infrastructure/JdReaderImpl.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/jd/infrastructure/JdReaderImpl.java
@@ -2,11 +2,16 @@ package kernel.jdon.moduleapi.domain.jd.infrastructure;
 
 import java.util.List;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Component;
 
 import kernel.jdon.moduleapi.domain.jd.core.JdInfo;
 import kernel.jdon.moduleapi.domain.jd.core.JdReader;
 import kernel.jdon.moduleapi.domain.jd.error.JdErrorCode;
+import kernel.jdon.moduleapi.global.page.CustomPageInfo;
+import kernel.jdon.moduleapi.global.page.PageInfoRequest;
 import kernel.jdon.wantedjd.domain.WantedJd;
 import lombok.RequiredArgsConstructor;
 
@@ -14,6 +19,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class JdReaderImpl implements JdReader {
 	private final WantedJdRepository wantedJdRepository;
+	private final JdReaderImplMapper jdReaderImplMapper;
 
 	@Override
 	public WantedJd findWantedJd(final Long jdId) {
@@ -27,5 +33,23 @@ public class JdReaderImpl implements JdReader {
 			.map(wantedJdSkill -> new JdInfo.FindSkill(
 				wantedJdSkill.getSkill()))
 			.toList();
+	}
+
+	@Override
+	public JdInfo.FindWantedJdListResponse findWantedJdList(final PageInfoRequest pageInfoRequest,
+		final String keyword) {
+		final Pageable pageable = PageRequest.of(pageInfoRequest.getPage(), pageInfoRequest.getSize());
+
+		final Page<JdReaderInfo.FindWantedJd> readerInfo = wantedJdRepository.findWantedJdList(pageable, keyword);
+
+		final List<JdInfo.FindWantedJd> content = readerInfo.stream()
+			.map(jdReaderImplMapper::of)
+			.toList();
+
+		final CustomPageInfo customPageInfo = new CustomPageInfo(readerInfo.getPageable().getPageNumber(),
+			readerInfo.getTotalElements(), readerInfo.getPageable().getPageSize(), readerInfo.isFirst(),
+			readerInfo.isLast(), readerInfo.isEmpty());
+
+		return new JdInfo.FindWantedJdListResponse(content, customPageInfo);
 	}
 }

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/jd/infrastructure/JdReaderImpl.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/jd/infrastructure/JdReaderImpl.java
@@ -10,7 +10,7 @@ import org.springframework.stereotype.Component;
 import kernel.jdon.moduleapi.domain.jd.core.JdInfo;
 import kernel.jdon.moduleapi.domain.jd.core.JdReader;
 import kernel.jdon.moduleapi.domain.jd.error.JdErrorCode;
-import kernel.jdon.moduleapi.global.page.CustomPageInfo;
+import kernel.jdon.moduleapi.global.page.CustomJpaPageInfo;
 import kernel.jdon.moduleapi.global.page.PageInfoRequest;
 import kernel.jdon.wantedjd.domain.WantedJd;
 import lombok.RequiredArgsConstructor;
@@ -46,10 +46,6 @@ public class JdReaderImpl implements JdReader {
 			.map(jdReaderImplMapper::of)
 			.toList();
 
-		final CustomPageInfo customPageInfo = new CustomPageInfo(readerInfo.getPageable().getPageNumber(),
-			readerInfo.getTotalElements(), readerInfo.getPageable().getPageSize(), readerInfo.isFirst(),
-			readerInfo.isLast(), readerInfo.isEmpty());
-
-		return new JdInfo.FindWantedJdListResponse(content, customPageInfo);
+		return new JdInfo.FindWantedJdListResponse(content, new CustomJpaPageInfo(readerInfo));
 	}
 }

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/jd/infrastructure/JdReaderImplMapper.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/jd/infrastructure/JdReaderImplMapper.java
@@ -1,4 +1,4 @@
-package kernel.jdon.moduleapi.domain.jd.presentation;
+package kernel.jdon.moduleapi.domain.jd.infrastructure;
 
 import org.mapstruct.InjectionStrategy;
 import org.mapstruct.Mapper;
@@ -11,8 +11,6 @@ import kernel.jdon.moduleapi.domain.jd.core.JdInfo;
 	injectionStrategy = InjectionStrategy.CONSTRUCTOR,
 	unmappedTargetPolicy = ReportingPolicy.ERROR
 )
-public interface JdDtoMapper {
-	JdDto.FindWantedJdResponse of(JdInfo.FindWantedJdResponse info);
-
-	JdDto.FindWantedJdListResponse of(JdInfo.FindWantedJdListResponse info);
+public interface JdReaderImplMapper {
+	JdInfo.FindWantedJd of(JdReaderInfo.FindWantedJd readerInfo);
 }

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/jd/infrastructure/JdReaderInfo.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/jd/infrastructure/JdReaderInfo.java
@@ -1,0 +1,29 @@
+package kernel.jdon.moduleapi.domain.jd.infrastructure;
+
+import com.querydsl.core.annotations.QueryProjection;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class JdReaderInfo {
+
+	@Getter
+	public static class FindWantedJd {
+		private Long id;
+		private String title;
+		private String company;
+		private String imageUrl;
+		private String jobCategoryName;
+
+		@QueryProjection
+		public FindWantedJd(Long id, String title, String company, String imageUrl, String jobCategoryName) {
+			this.id = id;
+			this.title = title;
+			this.company = company;
+			this.imageUrl = imageUrl;
+			this.jobCategoryName = jobCategoryName;
+		}
+	}
+}

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/jd/infrastructure/WantedJdRepository.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/jd/infrastructure/WantedJdRepository.java
@@ -2,5 +2,5 @@ package kernel.jdon.moduleapi.domain.jd.infrastructure;
 
 import kernel.jdon.wantedjd.repository.WantedJdDomainRepository;
 
-public interface WantedJdRepository extends WantedJdDomainRepository {
+public interface WantedJdRepository extends WantedJdDomainRepository, CustomWantedJdRepository {
 }

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/jd/infrastructure/WantedJdRepositoryImpl.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/jd/infrastructure/WantedJdRepositoryImpl.java
@@ -30,7 +30,7 @@ public class WantedJdRepositoryImpl implements CustomWantedJdRepository {
 				wantedJd.imageUrl,
 				jobCategory.name))
 			.from(wantedJd)
-			.join(wantedJd)
+			.join(jobCategory)
 			.on(wantedJd.jobCategory.eq(jobCategory))
 			.where(wantedJdTitleContains(keyword))
 			.orderBy(wantedJd.scrapingDate.desc())

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/jd/infrastructure/WantedJdRepositoryImpl.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/jd/infrastructure/WantedJdRepositoryImpl.java
@@ -1,0 +1,53 @@
+package kernel.jdon.moduleapi.domain.jd.infrastructure;
+
+import static kernel.jdon.jobcategory.domain.QJobCategory.*;
+import static kernel.jdon.wantedjd.domain.QWantedJd.*;
+import static org.springframework.util.StringUtils.*;
+
+import java.util.List;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class WantedJdRepositoryImpl implements CustomWantedJdRepository {
+	private final JPAQueryFactory jpaQueryFactory;
+
+	@Override
+	public Page<JdReaderInfo.FindWantedJd> findWantedJdList(final Pageable pageable, final String keyword) {
+
+		List<JdReaderInfo.FindWantedJd> content = jpaQueryFactory
+			.select(new QJdReaderInfo_FindWantedJd(
+				wantedJd.id,
+				wantedJd.title,
+				wantedJd.companyName,
+				wantedJd.imageUrl,
+				jobCategory.name))
+			.from(wantedJd)
+			.join(wantedJd)
+			.on(wantedJd.jobCategory.eq(jobCategory))
+			.where(wantedJdTitleContains(keyword))
+			.orderBy(wantedJd.scrapingDate.desc())
+			.offset(pageable.getOffset())
+			.limit(pageable.getPageSize())
+			.fetch();
+
+		Long totalCount = jpaQueryFactory
+			.select(wantedJd.count())
+			.from(wantedJd)
+			.where(wantedJdTitleContains(keyword))
+			.fetchOne();
+
+		return new PageImpl<>(content, pageable, totalCount);
+	}
+
+	private BooleanExpression wantedJdTitleContains(String keyword) {
+		return hasText(keyword) ? wantedJd.title.contains(keyword) : null;
+	}
+}

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/jd/presentation/JdController.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/jd/presentation/JdController.java
@@ -3,10 +3,12 @@ package kernel.jdon.moduleapi.domain.jd.presentation;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import kernel.jdon.moduleapi.domain.jd.application.JdFacade;
 import kernel.jdon.moduleapi.domain.jd.core.JdInfo;
+import kernel.jdon.moduleapi.global.page.PageInfoRequest;
 import kernel.jdon.modulecommon.dto.response.CommonResponse;
 import lombok.RequiredArgsConstructor;
 
@@ -25,4 +27,14 @@ public class JdController {
 		return ResponseEntity.ok().body(CommonResponse.of(response));
 	}
 
+	@GetMapping("/api/v1/jds")
+	public ResponseEntity<CommonResponse<JdDto.FindWantedJdListResponse>> getJdList(
+		@RequestParam(value = "page", defaultValue = "0") final int page,
+		@RequestParam(value = "size", defaultValue = "12") final int size,
+		@RequestParam(value = "keyword", defaultValue = "") final String keyword) {
+		final JdInfo.FindWantedJdListResponse info = jdFacade.getJdList(new PageInfoRequest(page, size), keyword);
+		final JdDto.FindWantedJdListResponse response = jdDtoMapper.of(info);
+
+		return ResponseEntity.ok().body(CommonResponse.of(response));
+	}
 }

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/jd/presentation/JdController.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/jd/presentation/JdController.java
@@ -14,13 +14,13 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class JdController {
 	private final JdFacade jdFacade;
-	private final JdMapper jdMapper;
+	private final JdDtoMapper jdDtoMapper;
 
 	@GetMapping("/api/v1/jds/{id}")
 	public ResponseEntity<CommonResponse<JdDto.FindWantedJdResponse>> getJd(
 		@PathVariable(name = "id") Long jdId) {
 		JdInfo.FindWantedJdResponse info = jdFacade.getJd(jdId);
-		JdDto.FindWantedJdResponse response = jdMapper.of(info);
+		JdDto.FindWantedJdResponse response = jdDtoMapper.of(info);
 
 		return ResponseEntity.ok().body(CommonResponse.of(response));
 	}

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/jd/presentation/JdDto.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/jd/presentation/JdDto.java
@@ -2,7 +2,6 @@ package kernel.jdon.moduleapi.domain.jd.presentation;
 
 import java.util.List;
 
-import kernel.jdon.moduleapi.domain.jd.core.JdInfo;
 import kernel.jdon.moduleapi.global.page.CustomPageInfo;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -38,7 +37,7 @@ public class JdDto {
 	@Getter
 	@Builder
 	public static class FindWantedJdListResponse {
-		private List<JdInfo.FindWantedJd> content;
+		private List<FindWantedJd> content;
 		private CustomPageInfo pageInfo;
 	}
 

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/jd/presentation/JdDto.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/jd/presentation/JdDto.java
@@ -2,6 +2,8 @@ package kernel.jdon.moduleapi.domain.jd.presentation;
 
 import java.util.List;
 
+import kernel.jdon.moduleapi.domain.jd.core.JdInfo;
+import kernel.jdon.moduleapi.global.page.CustomPageInfo;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -31,5 +33,22 @@ public class JdDto {
 	public static class FindSkill {
 		private Long id;
 		private String keyword;
+	}
+
+	@Getter
+	@Builder
+	public static class FindWantedJdListResponse {
+		private List<JdInfo.FindWantedJd> content;
+		private CustomPageInfo pageInfo;
+	}
+
+	@Getter
+	@Builder
+	public static class FindWantedJd {
+		private Long id;
+		private String title;
+		private String company;
+		private String imageUrl;
+		private String jobCategoryName;
 	}
 }

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/jd/presentation/JdDtoMapper.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/jd/presentation/JdDtoMapper.java
@@ -11,6 +11,6 @@ import kernel.jdon.moduleapi.domain.jd.core.JdInfo;
 	injectionStrategy = InjectionStrategy.CONSTRUCTOR,
 	unmappedTargetPolicy = ReportingPolicy.ERROR
 )
-public interface JdMapper {
+public interface JdDtoMapper {
 	JdDto.FindWantedJdResponse of(JdInfo.FindWantedJdResponse info);
 }

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/jobcategory/core/JobCategoryReader.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/jobcategory/core/JobCategoryReader.java
@@ -5,9 +5,9 @@ import java.util.List;
 import kernel.jdon.jobcategory.domain.JobCategory;
 
 public interface JobCategoryReader {
-	JobCategory findById(final Long jobCategoryId);
+	JobCategory findById(Long jobCategoryId);
 
 	List<JobCategory> findByParentIdIsNull();
 
-	List<JobCategory> findByParentId(final Long parentId);
+	List<JobCategory> findByParentId(Long parentId);
 }

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/skill/core/SkillReader.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/skill/core/SkillReader.java
@@ -7,7 +7,7 @@ import kernel.jdon.skill.domain.Skill;
 public interface SkillReader {
 	List<SkillInfo.FindHotSkill> findHotSkillList();
 
-	List<SkillInfo.FindMemberSkill> findMemberSkillList(final Long memberId);
+	List<SkillInfo.FindMemberSkill> findMemberSkillList(Long memberId);
 
-	Skill findById(final Long jobCategoryId);
+	Skill findById(Long jobCategoryId);
 }

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/skill/core/SkillService.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/skill/core/SkillService.java
@@ -3,9 +3,9 @@ package kernel.jdon.moduleapi.domain.skill.core;
 public interface SkillService {
 	SkillInfo.FindHotSkillListResponse getHotSkillList();
 
-	SkillInfo.FindMemberSkillListResponse getMemberSkillList(final Long memberId);
+	SkillInfo.FindMemberSkillListResponse getMemberSkillList(Long memberId);
 
-	SkillInfo.FindJobCategorySkillListResponse getJobCategorySkillList(final Long jobCategoryId);
+	SkillInfo.FindJobCategorySkillListResponse getJobCategorySkillList(Long jobCategoryId);
 
-	SkillInfo.FindDataListBySkillResponse getDataListBySkill(final String keyword, final Long userId);
+	SkillInfo.FindDataListBySkillResponse getDataListBySkill(String keyword, Long userId);
 }

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/skill/core/inflearnjd/InflearnJdSkillReader.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/skill/core/inflearnjd/InflearnJdSkillReader.java
@@ -5,6 +5,5 @@ import java.util.List;
 import kernel.jdon.moduleapi.domain.skill.core.SkillInfo;
 
 public interface InflearnJdSkillReader {
-	List<SkillInfo.FindLecture> findInflearnLectureListBySkill(final String keyword,
-		final Long memberId);
+	List<SkillInfo.FindLecture> findInflearnLectureListBySkill(String keyword, Long memberId);
 }

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/skill/infrastructure/CustomSkillRepository.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/skill/infrastructure/CustomSkillRepository.java
@@ -2,7 +2,7 @@ package kernel.jdon.moduleapi.domain.skill.infrastructure;
 
 import java.util.List;
 
-public interface SkillRepositoryCustom {
+public interface CustomSkillRepository {
 	List<SkillReaderInfo.FindHotSkill> findHotSkillList();
 
 	List<SkillReaderInfo.FindMemberSkill> findMemberSkillList(final Long memberId);

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/skill/infrastructure/CustomSkillRepository.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/skill/infrastructure/CustomSkillRepository.java
@@ -5,9 +5,9 @@ import java.util.List;
 public interface CustomSkillRepository {
 	List<SkillReaderInfo.FindHotSkill> findHotSkillList();
 
-	List<SkillReaderInfo.FindMemberSkill> findMemberSkillList(final Long memberId);
+	List<SkillReaderInfo.FindMemberSkill> findMemberSkillList(Long memberId);
 
-	List<SkillReaderInfo.FindWantedJd> findWantedJdListBySkill(final String keyword);
+	List<SkillReaderInfo.FindWantedJd> findWantedJdListBySkill(String keyword);
 
-	List<SkillReaderInfo.FindInflearnLecture> findInflearnLectureListBySkill(final String keyword, final Long memberId);
+	List<SkillReaderInfo.FindInflearnLecture> findInflearnLectureListBySkill(String keyword, Long memberId);
 }

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/skill/infrastructure/ImplSkillRepository.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/skill/infrastructure/ImplSkillRepository.java
@@ -19,7 +19,7 @@ import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
-public class SkillRepositoryImpl implements SkillRepositoryCustom {
+public class ImplSkillRepository implements CustomSkillRepository {
 
 	private final JPAQueryFactory jpaQueryFactory;
 

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/skill/infrastructure/SkillRepository.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/skill/infrastructure/SkillRepository.java
@@ -2,5 +2,5 @@ package kernel.jdon.moduleapi.domain.skill.infrastructure;
 
 import kernel.jdon.skill.repository.SkillDomainRepository;
 
-public interface SkillRepository extends SkillDomainRepository, SkillRepositoryCustom {
+public interface SkillRepository extends SkillDomainRepository, CustomSkillRepository {
 }

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/skill/infrastructure/SkillRepositoryImpl.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/skill/infrastructure/SkillRepositoryImpl.java
@@ -19,7 +19,7 @@ import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
-public class ImplSkillRepository implements CustomSkillRepository {
+public class SkillRepositoryImpl implements CustomSkillRepository {
 
 	private final JPAQueryFactory jpaQueryFactory;
 

--- a/module-api/src/main/java/kernel/jdon/moduleapi/global/page/CustomJpaPageInfo.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/global/page/CustomJpaPageInfo.java
@@ -1,0 +1,17 @@
+package kernel.jdon.moduleapi.global.page;
+
+import org.springframework.data.domain.Page;
+
+import lombok.Getter;
+
+@Getter
+public class CustomJpaPageInfo extends CustomPageInfo {
+	public CustomJpaPageInfo(Page<?> page) {
+		super(page.getPageable().getPageNumber(),
+			page.getPageable().getPageSize(),
+			page.getTotalPages(),
+			page.isFirst(),
+			page.isLast(),
+			page.isEmpty());
+	}
+}

--- a/module-api/src/main/java/kernel/jdon/moduleapi/global/page/CustomPageInfo.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/global/page/CustomPageInfo.java
@@ -1,13 +1,11 @@
 package kernel.jdon.moduleapi.global.page;
 
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Getter;
 
 @Getter
-@Builder
 @AllArgsConstructor
-public class CustomPageInfo {
+public abstract class CustomPageInfo {
 	private long pageNumber;
 	private long pageSize;
 	private long totalPages;


### PR DESCRIPTION
## 개요

### 요약

[JD 목록 조회](https://www.notion.so/JD-bd92f83c1f284c40849e6f611896ee61?pvs=4) API 구현

### 변경한 부분

- [JD 목록 조회](https://www.notion.so/JD-bd92f83c1f284c40849e6f611896ee61?pvs=4) API를 구현했습니다.
- 검색어 유무에 따른 동적쿼리를 Querydsl을 사용하여 구현했습니다.
- 인터페이스에서 매개변수에 있는 의미없는 final 키워드를 삭제했습니다.
- [domain명]RepositoryCustom 클래스 명을 Custom[domain명]Repository 형식으로 변경했습니다.
- JdMapper 인터페이스명에서 Dto가 누락되어 코드컨벤션에 맞는 JdDtoMapper로 변경하였습니다.
- CustomPageInfo 클래스를 추상화
  - 기존의 CustomPageInfo 클래스를 추상화하고, `org.springframework.data.domain.Page` 라이브러리에 의존하는 Page 객체를 인자로 받는 CustomJpaPageInfo 클래스를 생성했습니다. 이에 따라 infrastructor 계층에서 CustomPageInfo를 생성자를 통해 생성하던 부분을 CustomJpaPageInfo 객체를 생성하도록 변경하였고, DTO에서는 반환타입을 추상클래스로 변경한 CustomPageInfo로 지정하였습니다. 이로써 확장성을 고려하여 다른 라이브러리를 사용하여 페이징을 구현할 때, 추상클래스를 상속받아 상세 내용을 구현할 수 있도록 수정하였습니다.(팀원들과 페어프로그래밍 진행)

### 변경한 결과
- keyword 검색
<img width="882" alt="image" src="https://github.com/Kernel360/f1-JDON-Backend/assets/59242594/a1bd3235-20d2-41f3-8af5-f4918a5a8457">

- 2페이지 검색
<img width="883" alt="image" src="https://github.com/Kernel360/f1-JDON-Backend/assets/59242594/54e168cc-cdb5-47a4-a653-e0367f4048a5">

- 존재하지 않는 페이지 검색
<img width="865" alt="image" src="https://github.com/Kernel360/f1-JDON-Backend/assets/59242594/663721aa-35d6-4dac-9f2f-526b129e4969">


### 이슈

- closes: #335 

---

## PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경, 주석 변경)
- [x] 코드 리팩토링
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 파일 혹은 폴더명 수정, 삭제
- [ ] 배포 관련