### PR TITLE
Refactor: 닉네임 중복 확인 API를 레이어드 아키텍처에 맞게 refactor

### DIFF
--- a/module-api/src/main/java/kernel/jdon/member/controller/MemberController.java
+++ b/module-api/src/main/java/kernel/jdon/member/controller/MemberController.java
@@ -1,7 +1,6 @@
 package kernel.jdon.member.controller;
 
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 
 import kernel.jdon.member.dto.request.NicknameDuplicateRequest;
@@ -16,7 +15,7 @@ public class MemberController {
 
 	private final MemberService memberService;
 
-	@PostMapping("/api/v1/nickname/duplicate")
+	// @PostMapping("/api/v1/nickname/duplicate")
 	public ResponseEntity<Void> checkNicknameDuplicate(@RequestBody NicknameDuplicateRequest nicknameDuplicateRequest) {
 		memberService.checkNicknameDuplicate(nicknameDuplicateRequest.getNickname());
 

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/member/application/MemberFacade.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/member/application/MemberFacade.java
@@ -22,7 +22,7 @@ public class MemberFacade {
 		return memberService.modifyMember(memberId, command);
 	}
 
-	public void checkNicknameDuplicate(MemberCommand.NicknameDuplicateRequest command) {
+	public void checkNicknameDuplicate(final MemberCommand.NicknameDuplicateRequest command) {
 		memberService.checkNicknameDuplicate(command);
 	}
 }

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/member/application/MemberFacade.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/member/application/MemberFacade.java
@@ -21,4 +21,8 @@ public class MemberFacade {
 
 		return memberService.modifyMember(memberId, command);
 	}
+
+	public void checkNicknameDuplicate(MemberCommand.NicknameDuplicateRequest command) {
+		memberService.checkNicknameDuplicate(command);
+	}
 }

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/member/core/MemberCommand.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/member/core/MemberCommand.java
@@ -23,6 +23,6 @@ public class MemberCommand {
 	@Getter
 	@Builder
 	public static class NicknameDuplicateRequest {
-		private String nickname;
+		private final String nickname;
 	}
 }

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/member/core/MemberCommand.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/member/core/MemberCommand.java
@@ -20,4 +20,9 @@ public class MemberCommand {
 		private final List<Long> skillList;
 	}
 
+	@Getter
+	@Builder
+	public static class NicknameDuplicateRequest {
+		private String nickname;
+	}
 }

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/member/core/MemberReader.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/member/core/MemberReader.java
@@ -10,4 +10,6 @@ public interface MemberReader {
 	boolean existsById(Long memberId);
 
 	List<Long> findSkillIdListByMember(Member findMember);
+
+	boolean existsByNickname(String nickname);
 }

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/member/core/MemberService.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/member/core/MemberService.java
@@ -4,4 +4,6 @@ public interface MemberService {
 	MemberInfo.FindMemberResponse getMember(Long memberId);
 
 	MemberInfo.UpdateMemberResponse modifyMember(Long memberId, MemberCommand.UpdateMemberRequest command);
+
+	void checkNicknameDuplicate(MemberCommand.NicknameDuplicateRequest command);
 }

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/member/core/MemberServiceImpl.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/member/core/MemberServiceImpl.java
@@ -39,7 +39,7 @@ public class MemberServiceImpl implements MemberService {
 	}
 
 	@Override
-	public void checkNicknameDuplicate(MemberCommand.NicknameDuplicateRequest command) {
+	public void checkNicknameDuplicate(final MemberCommand.NicknameDuplicateRequest command) {
 		final boolean isExistNickname = memberReader.existsByNickname(command.getNickname());
 		if (isExistNickname) {
 			throw new ApiException(MemberErrorCode.CONFLICT_DUPLICATE_NICKNAME);

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/member/core/MemberServiceImpl.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/member/core/MemberServiceImpl.java
@@ -6,6 +6,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import kernel.jdon.member.domain.Member;
+import kernel.jdon.moduleapi.domain.member.error.MemberErrorCode;
+import kernel.jdon.moduleapi.global.exception.ApiException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -34,5 +36,13 @@ public class MemberServiceImpl implements MemberService {
 		memberFactory.update(findMember, command);
 
 		return MemberInfo.UpdateMemberResponse.of(findMember.getId());
+	}
+
+	@Override
+	public void checkNicknameDuplicate(MemberCommand.NicknameDuplicateRequest command) {
+		final boolean isExistNickname = memberReader.existsByNickname(command.getNickname());
+		if (isExistNickname) {
+			throw new ApiException(MemberErrorCode.CONFLICT_DUPLICATE_NICKNAME);
+		}
 	}
 }

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/member/core/MemberServiceImpl.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/member/core/MemberServiceImpl.java
@@ -15,7 +15,6 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 public class MemberServiceImpl implements MemberService {
 	private final MemberReader memberReader;
-	private final MemberStore memberStore;
 	private final MemberInfoMapper memberInfoMapper;
 	private final MemberFactory memberFactory;
 

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/member/infrastructure/MemberReaderImpl.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/member/infrastructure/MemberReaderImpl.java
@@ -32,4 +32,9 @@ public class MemberReaderImpl implements MemberReader {
 			.map(memberSkill -> memberSkill.getSkill().getId())
 			.toList();
 	}
+
+	@Override
+	public boolean existsByNickname(String nickname) {
+		return memberRepository.existsByNickname(nickname);
+	}
 }

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/member/infrastructure/MemberReaderImpl.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/member/infrastructure/MemberReaderImpl.java
@@ -34,7 +34,7 @@ public class MemberReaderImpl implements MemberReader {
 	}
 
 	@Override
-	public boolean existsByNickname(String nickname) {
+	public boolean existsByNickname(final String nickname) {
 		return memberRepository.existsByNickname(nickname);
 	}
 }

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/member/infrastructure/MemberStoreImpl.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/member/infrastructure/MemberStoreImpl.java
@@ -9,7 +9,6 @@ import lombok.RequiredArgsConstructor;
 @Component
 @RequiredArgsConstructor
 public class MemberStoreImpl implements MemberStore {
-	private final MemberRepository memberRepository;
 
 	@Override
 	public void update(final Member target, final Member updateMember) {

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/member/presentation/MemberController.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/member/presentation/MemberController.java
@@ -2,6 +2,7 @@ package kernel.jdon.moduleapi.domain.member.presentation;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
@@ -41,5 +42,13 @@ public class MemberController {
 		final MemberDto.UpdateMemberResponse response = memberDtoMapper.of(info);
 
 		return ResponseEntity.ok().body(CommonResponse.of(response));
+	}
+
+	@PostMapping("/api/v1/nickname/duplicate")
+	public ResponseEntity<Void> checkNicknameDuplicate(@RequestBody MemberDto.NicknameDuplicateRequest request) {
+		final MemberCommand.NicknameDuplicateRequest command = memberDtoMapper.of(request);
+		memberFacade.checkNicknameDuplicate(command);
+
+		return ResponseEntity.noContent().build();
 	}
 }

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/member/presentation/MemberController.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/member/presentation/MemberController.java
@@ -45,7 +45,8 @@ public class MemberController {
 	}
 
 	@PostMapping("/api/v1/nickname/duplicate")
-	public ResponseEntity<Void> checkNicknameDuplicate(@RequestBody MemberDto.NicknameDuplicateRequest request) {
+	public ResponseEntity<Void> checkNicknameDuplicate(
+		@RequestBody @Valid final MemberDto.NicknameDuplicateRequest request) {
 		final MemberCommand.NicknameDuplicateRequest command = memberDtoMapper.of(request);
 		memberFacade.checkNicknameDuplicate(command);
 

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/member/presentation/MemberDto.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/member/presentation/MemberDto.java
@@ -43,5 +43,4 @@ public class MemberDto {
 	public static class UpdateMemberResponse {
 		private Long memberId;
 	}
-
 }

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/member/presentation/MemberDto.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/member/presentation/MemberDto.java
@@ -8,6 +8,7 @@ import kernel.jdon.moduleapi.global.annotation.validate.Gender;
 import kernel.jdon.moduleapi.global.annotation.validate.isPastDate;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.Setter;
 
 @Getter
 public class MemberDto {
@@ -45,7 +46,9 @@ public class MemberDto {
 	}
 
 	@Getter
+	@Setter
 	public static class NicknameDuplicateRequest {
+		@NotBlank(message = "증복 확인하려는 닉네임을 작성해주세요.")
 		private String nickname;
 	}
 

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/member/presentation/MemberDto.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/member/presentation/MemberDto.java
@@ -43,4 +43,10 @@ public class MemberDto {
 	public static class UpdateMemberResponse {
 		private Long memberId;
 	}
+
+	@Getter
+	public static class NicknameDuplicateRequest {
+		private String nickname;
+	}
+
 }

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/member/presentation/MemberDtoMapper.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/member/presentation/MemberDtoMapper.java
@@ -20,4 +20,6 @@ public interface MemberDtoMapper {
 
 	MemberDto.UpdateMemberResponse of(MemberInfo.UpdateMemberResponse response);
 
+	MemberCommand.NicknameDuplicateRequest of(MemberDto.NicknameDuplicateRequest request);
+
 }

--- a/module-domain/src/main/java/kernel/jdon/member/domain/Member.java
+++ b/module-domain/src/main/java/kernel/jdon/member/domain/Member.java
@@ -106,6 +106,7 @@ public class Member {
 		this.withdrawDate = withdrawDate;
 		this.socialProvider = socialProvider;
 		this.jobCategory = jobCategory;
+		this.memberSkillList = memberSkillList;
 	}
 
 	public boolean isActiveMember() {

--- a/module-domain/src/main/java/kernel/jdon/member/domain/Member.java
+++ b/module-domain/src/main/java/kernel/jdon/member/domain/Member.java
@@ -106,7 +106,6 @@ public class Member {
 		this.withdrawDate = withdrawDate;
 		this.socialProvider = socialProvider;
 		this.jobCategory = jobCategory;
-		this.memberSkillList = memberSkillList;
 	}
 
 	public boolean isActiveMember() {


### PR DESCRIPTION
## 개요

### 요약

### 변경한 부분
- `POST /api/v1/nickname/duplicate`
닉네임 중복확인하는 API를 레이어드 아키텍처에 맞게 리팩토링했습니다. 
  -  existsByNickname을 사용하여 이미 사용되고 있는 닉네임인지 확인하고 사용 중이 아니라면 204를, 사용 중이라면 409 에러를 반환합니다. 

### 변경한 결과
### 성공시
![image](https://github.com/Kernel360/f1-JDON-Backend/assets/68376744/c1e69c8a-0632-401d-8f6b-e3caf8abc7ad)

### 실패시
![image](https://github.com/Kernel360/f1-JDON-Backend/assets/68376744/23ea0432-8737-46ed-81d5-6c9ada6d5969)


### 이슈

- closes: #

---

## PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경, 주석 변경)
- [ ] 코드 리팩토링
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 파일 혹은 폴더명 수정, 삭제
- [ ] 배포 관련