### PR TITLE
Feature: 리뷰 목록조회, 생성 API 구현

### DIFF
--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/jd/infrastructure/JdReaderImpl.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/jd/infrastructure/JdReaderImpl.java
@@ -19,7 +19,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class JdReaderImpl implements JdReader {
 	private final WantedJdRepository wantedJdRepository;
-	private final JdReaderImplMapper jdReaderImplMapper;
+	private final JdReaderInfoMapper jdReaderInfoMapper;
 
 	@Override
 	public WantedJd findWantedJd(final Long jdId) {
@@ -43,7 +43,7 @@ public class JdReaderImpl implements JdReader {
 		final Page<JdReaderInfo.FindWantedJd> readerInfo = wantedJdRepository.findWantedJdList(pageable, keyword);
 
 		final List<JdInfo.FindWantedJd> content = readerInfo.stream()
-			.map(jdReaderImplMapper::of)
+			.map(jdReaderInfoMapper::of)
 			.toList();
 
 		return new JdInfo.FindWantedJdListResponse(content, new CustomJpaPageInfo(readerInfo));

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/jd/infrastructure/JdReaderInfoMapper.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/jd/infrastructure/JdReaderInfoMapper.java
@@ -1,0 +1,16 @@
+package kernel.jdon.moduleapi.domain.jd.infrastructure;
+
+import org.mapstruct.InjectionStrategy;
+import org.mapstruct.Mapper;
+import org.mapstruct.ReportingPolicy;
+
+import kernel.jdon.moduleapi.domain.jd.core.JdInfo;
+
+@Mapper(
+	componentModel = "spring",
+	injectionStrategy = InjectionStrategy.CONSTRUCTOR,
+	unmappedTargetPolicy = ReportingPolicy.ERROR
+)
+public interface JdReaderInfoMapper {
+	JdInfo.FindWantedJd of(JdReaderInfo.FindWantedJd readerInfo);
+}

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/review/application/ReviewFacade.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/review/application/ReviewFacade.java
@@ -1,0 +1,18 @@
+package kernel.jdon.moduleapi.domain.review.application;
+
+import org.springframework.stereotype.Service;
+
+import kernel.jdon.moduleapi.domain.review.core.ReviewCommand;
+import kernel.jdon.moduleapi.domain.review.core.ReviewInfo;
+import kernel.jdon.moduleapi.domain.review.core.ReviewService;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class ReviewFacade {
+	private final ReviewService reviewService;
+
+	public ReviewInfo.CreateReviewResponse createReview(final ReviewCommand.CreateReviewRequest command) {
+		return reviewService.createReview(command);
+	}
+}

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/review/application/ReviewFacade.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/review/application/ReviewFacade.java
@@ -17,7 +17,7 @@ public class ReviewFacade {
 		return reviewService.createReview(command);
 	}
 
-	public ReviewInfo.FindReviewListResponse findReviewList(final Long jdId, final PageInfoRequest pageInfoRequest) {
+	public ReviewInfo.FindReviewListResponse getReviewList(final Long jdId, final PageInfoRequest pageInfoRequest) {
 		return reviewService.getReviewList(jdId, pageInfoRequest);
 	}
 }

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/review/application/ReviewFacade.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/review/application/ReviewFacade.java
@@ -5,6 +5,7 @@ import org.springframework.stereotype.Service;
 import kernel.jdon.moduleapi.domain.review.core.ReviewCommand;
 import kernel.jdon.moduleapi.domain.review.core.ReviewInfo;
 import kernel.jdon.moduleapi.domain.review.core.ReviewService;
+import kernel.jdon.moduleapi.global.page.PageInfoRequest;
 import lombok.RequiredArgsConstructor;
 
 @Service
@@ -14,5 +15,9 @@ public class ReviewFacade {
 
 	public ReviewInfo.CreateReviewResponse createReview(final ReviewCommand.CreateReviewRequest command) {
 		return reviewService.createReview(command);
+	}
+
+	public ReviewInfo.FindReviewListResponse findReviewList(final Long jdId, final PageInfoRequest pageInfoRequest) {
+		return reviewService.getReviewList(jdId, pageInfoRequest);
 	}
 }

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/review/core/ReviewCommand.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/review/core/ReviewCommand.java
@@ -1,0 +1,29 @@
+package kernel.jdon.moduleapi.domain.review.core;
+
+import kernel.jdon.member.domain.Member;
+import kernel.jdon.moduledomain.review.domain.Review;
+import kernel.jdon.wantedjd.domain.WantedJd;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class ReviewCommand {
+
+	@Getter
+	@Builder
+	public static class CreateReviewRequest {
+		private final Long jdId;
+		private final String content;
+		private final Long memberId;
+
+		public Review toEntity(Member member, WantedJd wantedJd) {
+			return Review.builder()
+				.content(this.content)
+				.member(member)
+				.wantedJd(wantedJd)
+				.build();
+		}
+	}
+}

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/review/core/ReviewInfo.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/review/core/ReviewInfo.java
@@ -16,7 +16,7 @@ public class ReviewInfo {
 	@Getter
 	@AllArgsConstructor
 	public static class CreateReviewResponse {
-		private final Long commandId;
+		private final Long reviewId;
 	}
 
 	@Getter

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/review/core/ReviewInfo.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/review/core/ReviewInfo.java
@@ -1,0 +1,16 @@
+package kernel.jdon.moduleapi.domain.review.core;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class ReviewInfo {
+
+	@Getter
+	@AllArgsConstructor
+	public static class CreateReviewResponse {
+		private final Long commandId;
+	}
+}

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/review/core/ReviewInfo.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/review/core/ReviewInfo.java
@@ -1,7 +1,12 @@
 package kernel.jdon.moduleapi.domain.review.core;
 
+import java.time.LocalDateTime;
+import java.util.List;
+
+import kernel.jdon.moduleapi.global.page.CustomPageInfo;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -12,5 +17,22 @@ public class ReviewInfo {
 	@AllArgsConstructor
 	public static class CreateReviewResponse {
 		private final Long commandId;
+	}
+
+	@Getter
+	@AllArgsConstructor
+	public static class FindReviewListResponse {
+		private final List<FindReview> content;
+		private final CustomPageInfo pageInfo;
+	}
+
+	@Getter
+	@Builder
+	public static class FindReview {
+		private final Long id;
+		private final String content;
+		private final String nickname;
+		private final LocalDateTime createdDate;
+		private final Long userId;
 	}
 }

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/review/core/ReviewInfo.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/review/core/ReviewInfo.java
@@ -33,6 +33,6 @@ public class ReviewInfo {
 		private final String content;
 		private final String nickname;
 		private final LocalDateTime createdDate;
-		private final Long userId;
+		private final Long memberId;
 	}
 }

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/review/core/ReviewReader.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/review/core/ReviewReader.java
@@ -1,0 +1,7 @@
+package kernel.jdon.moduleapi.domain.review.core;
+
+import kernel.jdon.moduleapi.global.page.PageInfoRequest;
+
+public interface ReviewReader {
+	ReviewInfo.FindReviewListResponse findReviewList(Long jdId, PageInfoRequest pageInfoRequest);
+}

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/review/core/ReviewService.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/review/core/ReviewService.java
@@ -1,0 +1,5 @@
+package kernel.jdon.moduleapi.domain.review.core;
+
+public interface ReviewService {
+	ReviewInfo.CreateReviewResponse createReview(ReviewCommand.CreateReviewRequest command);
+}

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/review/core/ReviewService.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/review/core/ReviewService.java
@@ -1,5 +1,9 @@
 package kernel.jdon.moduleapi.domain.review.core;
 
+import kernel.jdon.moduleapi.global.page.PageInfoRequest;
+
 public interface ReviewService {
 	ReviewInfo.CreateReviewResponse createReview(ReviewCommand.CreateReviewRequest command);
+
+	ReviewInfo.FindReviewListResponse getReviewList(Long jdId, PageInfoRequest pageInfoRequest);
 }

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/review/core/ReviewServiceImpl.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/review/core/ReviewServiceImpl.java
@@ -5,6 +5,7 @@ import org.springframework.stereotype.Service;
 import kernel.jdon.member.domain.Member;
 import kernel.jdon.moduleapi.domain.jd.core.JdReader;
 import kernel.jdon.moduleapi.domain.member.core.MemberReader;
+import kernel.jdon.moduleapi.global.page.PageInfoRequest;
 import kernel.jdon.moduledomain.review.domain.Review;
 import kernel.jdon.wantedjd.domain.WantedJd;
 import lombok.RequiredArgsConstructor;
@@ -13,15 +14,21 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class ReviewServiceImpl implements ReviewService {
 	private final ReviewStore reviewStore;
+	private final ReviewReader reviewReader;
 	private final JdReader jdReader;
 	private final MemberReader memberReader;
 
 	@Override
-	public ReviewInfo.CreateReviewResponse createReview(ReviewCommand.CreateReviewRequest command) {
+	public ReviewInfo.CreateReviewResponse createReview(final ReviewCommand.CreateReviewRequest command) {
 		final Member findMember = memberReader.findById(command.getMemberId());
 		final WantedJd findWantedJd = jdReader.findWantedJd(command.getJdId());
 		final Review savedReview = reviewStore.save(command.toEntity(findMember, findWantedJd));
 
 		return new ReviewInfo.CreateReviewResponse(savedReview.getId());
+	}
+
+	@Override
+	public ReviewInfo.FindReviewListResponse getReviewList(final Long jdId, final PageInfoRequest pageInfoRequest) {
+		return reviewReader.findReviewList(jdId, pageInfoRequest);
 	}
 }

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/review/core/ReviewServiceImpl.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/review/core/ReviewServiceImpl.java
@@ -1,0 +1,27 @@
+package kernel.jdon.moduleapi.domain.review.core;
+
+import org.springframework.stereotype.Service;
+
+import kernel.jdon.member.domain.Member;
+import kernel.jdon.moduleapi.domain.jd.core.JdReader;
+import kernel.jdon.moduleapi.domain.member.core.MemberReader;
+import kernel.jdon.moduledomain.review.domain.Review;
+import kernel.jdon.wantedjd.domain.WantedJd;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class ReviewServiceImpl implements ReviewService {
+	private final ReviewStore reviewStore;
+	private final JdReader jdReader;
+	private final MemberReader memberReader;
+
+	@Override
+	public ReviewInfo.CreateReviewResponse createReview(ReviewCommand.CreateReviewRequest command) {
+		final Member findMember = memberReader.findById(command.getMemberId());
+		final WantedJd findWantedJd = jdReader.findWantedJd(command.getJdId());
+		final Review savedReview = reviewStore.save(command.toEntity(findMember, findWantedJd));
+
+		return new ReviewInfo.CreateReviewResponse(savedReview.getId());
+	}
+}

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/review/core/ReviewStore.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/review/core/ReviewStore.java
@@ -1,0 +1,7 @@
+package kernel.jdon.moduleapi.domain.review.core;
+
+import kernel.jdon.moduledomain.review.domain.Review;
+
+public interface ReviewStore {
+	Review save(Review initReview);
+}

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/review/error/ReviewErrorCode.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/review/error/ReviewErrorCode.java
@@ -1,0 +1,38 @@
+package kernel.jdon.moduleapi.domain.review.error;
+
+import org.springframework.http.HttpStatus;
+
+import kernel.jdon.moduleapi.global.exception.ApiException;
+import kernel.jdon.moduleapi.global.exception.BaseThrowException;
+import kernel.jdon.modulecommon.error.ErrorCode;
+import lombok.AllArgsConstructor;
+
+@AllArgsConstructor
+public enum ReviewErrorCode implements ErrorCode, BaseThrowException<ReviewErrorCode.ReviewBaseException> {
+	NOT_FOUND_REVIEW(HttpStatus.NOT_FOUND, "존재하지 않는 리뷰 입니다.");
+
+	private final HttpStatus httpStatus;
+	private final String message;
+
+	@Override
+	public HttpStatus getHttpStatus() {
+		return httpStatus;
+	}
+
+	@Override
+	public String getMessage() {
+		return message;
+	}
+
+	@Override
+	public ReviewBaseException throwException() {
+		return new ReviewBaseException(this);
+	}
+
+	public class ReviewBaseException extends ApiException {
+		public ReviewBaseException(ReviewErrorCode reviewErrorCode) {
+			super(reviewErrorCode);
+		}
+	}
+
+}

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/review/infrastructure/CustomReviewRepository.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/review/infrastructure/CustomReviewRepository.java
@@ -1,0 +1,8 @@
+package kernel.jdon.moduleapi.domain.review.infrastructure;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface CustomReviewRepository {
+	Page<ReviewReaderInfo.FindReview> findReviewList(Long jdId, Pageable pageable);
+}

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/review/infrastructure/ReviewReaderImpl.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/review/infrastructure/ReviewReaderImpl.java
@@ -1,0 +1,34 @@
+package kernel.jdon.moduleapi.domain.review.infrastructure;
+
+import java.util.List;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Component;
+
+import kernel.jdon.moduleapi.domain.review.core.ReviewInfo;
+import kernel.jdon.moduleapi.domain.review.core.ReviewReader;
+import kernel.jdon.moduleapi.global.page.CustomJpaPageInfo;
+import kernel.jdon.moduleapi.global.page.PageInfoRequest;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class ReviewReaderImpl implements ReviewReader {
+	private final ReviewRepository reviewRepository;
+	private final ReviewReaderInfoMapper reviewReaderInfoMapper;
+
+	@Override
+	public ReviewInfo.FindReviewListResponse findReviewList(final Long jdId, final PageInfoRequest pageInfoRequest) {
+		final Pageable pageable = PageRequest.of(pageInfoRequest.getPage(), pageInfoRequest.getSize());
+
+		final Page<ReviewReaderInfo.FindReview> findReviewList = reviewRepository.findReviewList(jdId, pageable);
+
+		final List<ReviewInfo.FindReview> content = findReviewList.stream()
+			.map(reviewReaderInfoMapper::of)
+			.toList();
+
+		return new ReviewInfo.FindReviewListResponse(content, new CustomJpaPageInfo(findReviewList));
+	}
+}

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/review/infrastructure/ReviewReaderInfo.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/review/infrastructure/ReviewReaderInfo.java
@@ -1,0 +1,33 @@
+package kernel.jdon.moduleapi.domain.review.infrastructure;
+
+import java.time.LocalDateTime;
+
+import com.querydsl.core.annotations.QueryProjection;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class ReviewReaderInfo {
+
+	@Getter
+	public static class FindReview {
+		private final Long id;
+		private final String content;
+		private final String nickname;
+		private final LocalDateTime createdDate;
+		private final Long userId;
+
+		@QueryProjection
+		public FindReview(Long id, String content, String nickname, LocalDateTime createdDate,
+			Long userId) {
+			this.id = id;
+			this.content = content;
+			this.nickname = nickname;
+			this.createdDate = createdDate;
+			this.userId = userId;
+		}
+	}
+
+}

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/review/infrastructure/ReviewReaderInfo.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/review/infrastructure/ReviewReaderInfo.java
@@ -17,16 +17,16 @@ public class ReviewReaderInfo {
 		private final String content;
 		private final String nickname;
 		private final LocalDateTime createdDate;
-		private final Long userId;
+		private final Long memberId;
 
 		@QueryProjection
 		public FindReview(Long id, String content, String nickname, LocalDateTime createdDate,
-			Long userId) {
+			Long memberId) {
 			this.id = id;
 			this.content = content;
 			this.nickname = nickname;
 			this.createdDate = createdDate;
-			this.userId = userId;
+			this.memberId = memberId;
 		}
 	}
 

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/review/infrastructure/ReviewReaderInfoMapper.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/review/infrastructure/ReviewReaderInfoMapper.java
@@ -1,16 +1,16 @@
-package kernel.jdon.moduleapi.domain.jd.infrastructure;
+package kernel.jdon.moduleapi.domain.review.infrastructure;
 
 import org.mapstruct.InjectionStrategy;
 import org.mapstruct.Mapper;
 import org.mapstruct.ReportingPolicy;
 
-import kernel.jdon.moduleapi.domain.jd.core.JdInfo;
+import kernel.jdon.moduleapi.domain.review.core.ReviewInfo;
 
 @Mapper(
 	componentModel = "spring",
 	injectionStrategy = InjectionStrategy.CONSTRUCTOR,
 	unmappedTargetPolicy = ReportingPolicy.ERROR
 )
-public interface JdReaderImplMapper {
-	JdInfo.FindWantedJd of(JdReaderInfo.FindWantedJd readerInfo);
+public interface ReviewReaderInfoMapper {
+	ReviewInfo.FindReview of(ReviewReaderInfo.FindReview readerInfo);
 }

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/review/infrastructure/ReviewRepository.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/review/infrastructure/ReviewRepository.java
@@ -2,5 +2,5 @@ package kernel.jdon.moduleapi.domain.review.infrastructure;
 
 import kernel.jdon.moduledomain.review.repository.ReviewDomainRepository;
 
-public interface ReviewRepository extends ReviewDomainRepository {
+public interface ReviewRepository extends ReviewDomainRepository, CustomReviewRepository {
 }

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/review/infrastructure/ReviewRepository.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/review/infrastructure/ReviewRepository.java
@@ -1,0 +1,6 @@
+package kernel.jdon.moduleapi.domain.review.infrastructure;
+
+import kernel.jdon.moduledomain.review.repository.ReviewDomainRepository;
+
+public interface ReviewRepository extends ReviewDomainRepository {
+}

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/review/infrastructure/ReviewRepositoryImpl.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/review/infrastructure/ReviewRepositoryImpl.java
@@ -1,0 +1,46 @@
+package kernel.jdon.moduleapi.domain.review.infrastructure;
+
+import static kernel.jdon.member.domain.QMember.*;
+import static kernel.jdon.moduledomain.review.domain.QReview.*;
+
+import java.util.List;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class ReviewRepositoryImpl implements CustomReviewRepository {
+	private final JPAQueryFactory jpaQueryFactory;
+
+	@Override
+	public Page<ReviewReaderInfo.FindReview> findReviewList(final Long jdId, final Pageable pageable) {
+		final List<ReviewReaderInfo.FindReview> content = jpaQueryFactory
+			.select(new QReviewReaderInfo_FindReview(
+				review.id,
+				review.content,
+				member.nickname,
+				review.createdDate,
+				member.id
+			))
+			.from(review)
+			.join(member)
+			.on(review.member.eq(member))
+			.where(review.wantedJd.id.eq(jdId))
+			.offset(pageable.getOffset())
+			.limit(pageable.getPageSize())
+			.fetch();
+
+		final Long totalCount = jpaQueryFactory
+			.select(review.count())
+			.from(review)
+			.where(review.wantedJd.id.eq(jdId))
+			.fetchOne();
+
+		return new PageImpl<>(content, pageable, totalCount);
+	}
+}

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/review/infrastructure/ReviewStoreImpl.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/review/infrastructure/ReviewStoreImpl.java
@@ -1,0 +1,19 @@
+package kernel.jdon.moduleapi.domain.review.infrastructure;
+
+import org.springframework.stereotype.Component;
+
+import kernel.jdon.moduleapi.domain.review.core.ReviewStore;
+import kernel.jdon.moduledomain.review.domain.Review;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class ReviewStoreImpl implements ReviewStore {
+	private final ReviewRepository reviewRepository;
+
+	@Override
+	public Review save(final Review initReview) {
+		return reviewRepository.save(initReview);
+	}
+
+}

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/review/presentation/ReviewController.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/review/presentation/ReviewController.java
@@ -43,7 +43,7 @@ public class ReviewController {
 		@PathVariable(name = "jdId") final Long jdId,
 		@RequestParam(value = "page", defaultValue = "0") final int page,
 		@RequestParam(value = "size", defaultValue = "6") final int size) {
-		final ReviewInfo.FindReviewListResponse info = reviewFacade.findReviewList(jdId,
+		final ReviewInfo.FindReviewListResponse info = reviewFacade.getReviewList(jdId,
 			new PageInfoRequest(page, size));
 		final ReviewDto.FindReviewListResponse response = reviewDtoMapper.of(info);
 

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/review/presentation/ReviewController.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/review/presentation/ReviewController.java
@@ -1,0 +1,37 @@
+package kernel.jdon.moduleapi.domain.review.presentation;
+
+import java.net.URI;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+import jakarta.validation.Valid;
+import kernel.jdon.auth.dto.SessionUserInfo;
+import kernel.jdon.moduleapi.domain.review.application.ReviewFacade;
+import kernel.jdon.moduleapi.domain.review.core.ReviewCommand;
+import kernel.jdon.moduleapi.domain.review.core.ReviewInfo;
+import kernel.jdon.moduleapi.global.annotation.LoginUser;
+import kernel.jdon.modulecommon.dto.response.CommonResponse;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+public class ReviewController {
+	private final ReviewFacade reviewFacade;
+	private final ReviewDtoMapper reviewDtoMapper;
+
+	@PostMapping("/api/v1/reviews")
+	public ResponseEntity<CommonResponse<ReviewDto.CreateReviewResponse>> createReview(
+		@RequestBody @Valid final ReviewDto.CreateReviewRequest request,
+		@LoginUser final SessionUserInfo sessionUserInfo) {
+		final ReviewCommand.CreateReviewRequest command = reviewDtoMapper.of(request, sessionUserInfo.getId());
+		final ReviewInfo.CreateReviewResponse info = reviewFacade.createReview(command);
+		final ReviewDto.CreateReviewResponse response = reviewDtoMapper.of(info);
+		final URI uri = URI.create("/api/v1/reviews" + response.getCommandId());
+
+		return ResponseEntity.created(uri).body(CommonResponse.of(response));
+	}
+
+}

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/review/presentation/ReviewController.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/review/presentation/ReviewController.java
@@ -3,8 +3,11 @@ package kernel.jdon.moduleapi.domain.review.presentation;
 import java.net.URI;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import jakarta.validation.Valid;
@@ -13,6 +16,7 @@ import kernel.jdon.moduleapi.domain.review.application.ReviewFacade;
 import kernel.jdon.moduleapi.domain.review.core.ReviewCommand;
 import kernel.jdon.moduleapi.domain.review.core.ReviewInfo;
 import kernel.jdon.moduleapi.global.annotation.LoginUser;
+import kernel.jdon.moduleapi.global.page.PageInfoRequest;
 import kernel.jdon.modulecommon.dto.response.CommonResponse;
 import lombok.RequiredArgsConstructor;
 
@@ -32,6 +36,18 @@ public class ReviewController {
 		final URI uri = URI.create("/api/v1/reviews" + response.getCommandId());
 
 		return ResponseEntity.created(uri).body(CommonResponse.of(response));
+	}
+
+	@GetMapping("/api/v1/reviews/{jdId}")
+	public ResponseEntity<CommonResponse<ReviewDto.CreateReviewResponse>> findReviewList(
+		@PathVariable(name = "jdId") final Long jdId,
+		@RequestParam(value = "page", defaultValue = "0") final int page,
+		@RequestParam(value = "size", defaultValue = "6") final int size) {
+		final ReviewInfo.FindReviewListResponse info = reviewFacade.findReviewList(jdId,
+			new PageInfoRequest(page, size));
+		final ReviewDto.FindReviewListResponse response = reviewDtoMapper.of(info);
+
+		return ResponseEntity.ok().body(CommonResponse.of(response));
 	}
 
 }

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/review/presentation/ReviewController.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/review/presentation/ReviewController.java
@@ -33,7 +33,7 @@ public class ReviewController {
 		final ReviewCommand.CreateReviewRequest command = reviewDtoMapper.of(request, sessionUserInfo.getId());
 		final ReviewInfo.CreateReviewResponse info = reviewFacade.createReview(command);
 		final ReviewDto.CreateReviewResponse response = reviewDtoMapper.of(info);
-		final URI uri = URI.create("/api/v1/reviews" + response.getCommandId());
+		final URI uri = URI.create("/api/v1/reviews" + response.getReviewId());
 
 		return ResponseEntity.created(uri).body(CommonResponse.of(response));
 	}

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/review/presentation/ReviewDto.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/review/presentation/ReviewDto.java
@@ -28,7 +28,7 @@ public class ReviewDto {
 	@Getter
 	@Builder
 	public static class CreateReviewResponse {
-		private final Long commandId;
+		private final Long reviewId;
 	}
 
 	@Getter

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/review/presentation/ReviewDto.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/review/presentation/ReviewDto.java
@@ -6,6 +6,7 @@ import java.util.List;
 import com.fasterxml.jackson.annotation.JsonFormat;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import kernel.jdon.moduleapi.global.page.CustomPageInfo;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -18,7 +19,7 @@ public class ReviewDto {
 	@Getter
 	@Builder
 	public static class CreateReviewRequest {
-		@NotBlank(message = "jd 식별자가 없습니다.")
+		@NotNull(message = "jd 식별자가 없습니다.")
 		private final Long jdId;
 		@NotBlank(message = "내용이 없습니다.")
 		private final String content;

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/review/presentation/ReviewDto.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/review/presentation/ReviewDto.java
@@ -1,6 +1,12 @@
 package kernel.jdon.moduleapi.domain.review.presentation;
 
+import java.time.LocalDateTime;
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+
 import jakarta.validation.constraints.NotBlank;
+import kernel.jdon.moduleapi.global.page.CustomPageInfo;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -23,4 +29,23 @@ public class ReviewDto {
 	public static class CreateReviewResponse {
 		private final Long commandId;
 	}
+
+	@Getter
+	@Builder
+	public static class FindReviewListResponse {
+		private final List<FindReview> content;
+		private final CustomPageInfo pageInfo;
+	}
+
+	@Getter
+	@Builder
+	public static class FindReview {
+		private final Long id;
+		private final String content;
+		private final String nickname;
+		@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm", timezone = "Asia/Seoul")
+		private final LocalDateTime createdDate;
+		private final Long userId;
+	}
+
 }

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/review/presentation/ReviewDto.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/review/presentation/ReviewDto.java
@@ -46,7 +46,7 @@ public class ReviewDto {
 		private final String nickname;
 		@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm", timezone = "Asia/Seoul")
 		private final LocalDateTime createdDate;
-		private final Long userId;
+		private final Long memberId;
 	}
 
 }

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/review/presentation/ReviewDto.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/review/presentation/ReviewDto.java
@@ -1,0 +1,26 @@
+package kernel.jdon.moduleapi.domain.review.presentation;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class ReviewDto {
+
+	@Getter
+	@Builder
+	public static class CreateReviewRequest {
+		@NotBlank(message = "jd 식별자가 없습니다.")
+		private final Long jdId;
+		@NotBlank(message = "내용이 없습니다.")
+		private final String content;
+	}
+
+	@Getter
+	@Builder
+	public static class CreateReviewResponse {
+		private final Long commandId;
+	}
+}

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/review/presentation/ReviewDtoMapper.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/review/presentation/ReviewDtoMapper.java
@@ -1,0 +1,19 @@
+package kernel.jdon.moduleapi.domain.review.presentation;
+
+import org.mapstruct.InjectionStrategy;
+import org.mapstruct.Mapper;
+import org.mapstruct.ReportingPolicy;
+
+import kernel.jdon.moduleapi.domain.review.core.ReviewCommand;
+import kernel.jdon.moduleapi.domain.review.core.ReviewInfo;
+
+@Mapper(
+	componentModel = "spring",
+	injectionStrategy = InjectionStrategy.CONSTRUCTOR,
+	unmappedTargetPolicy = ReportingPolicy.ERROR
+)
+public interface ReviewDtoMapper {
+	ReviewCommand.CreateReviewRequest of(ReviewDto.CreateReviewRequest request, Long memberId);
+
+	ReviewDto.CreateReviewResponse of(ReviewInfo.CreateReviewResponse info);
+}

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/review/presentation/ReviewDtoMapper.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/review/presentation/ReviewDtoMapper.java
@@ -16,4 +16,6 @@ public interface ReviewDtoMapper {
 	ReviewCommand.CreateReviewRequest of(ReviewDto.CreateReviewRequest request, Long memberId);
 
 	ReviewDto.CreateReviewResponse of(ReviewInfo.CreateReviewResponse info);
+
+	ReviewDto.FindReviewListResponse of(ReviewInfo.FindReviewListResponse info);
 }

--- a/module-domain/src/main/java/kernel/jdon/moduledomain/review/domain/Review.java
+++ b/module-domain/src/main/java/kernel/jdon/moduledomain/review/domain/Review.java
@@ -13,6 +13,7 @@ import kernel.jdon.base.AbstractEntity;
 import kernel.jdon.member.domain.Member;
 import kernel.jdon.wantedjd.domain.WantedJd;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -35,4 +36,12 @@ public class Review extends AbstractEntity {
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "wanted_jd_id", columnDefinition = "BIGINT")
 	private WantedJd wantedJd;
+
+	@Builder
+	public Review(Long id, String content, Member member, WantedJd wantedJd) {
+		this.id = id;
+		this.content = content;
+		this.member = member;
+		this.wantedJd = wantedJd;
+	}
 }


### PR DESCRIPTION
## 개요

### 요약

- [리뷰 생성](https://www.notion.so/JD-3d1b6f9cf2134699b1a7f4a5a0a98ea1?pvs=4) API 구현
- [리뷰 목록조회](https://www.notion.so/JD-32527c6e72c74d9a894d67346b5a5fd6?pvs=4) API 구현

### 변경한 부분
- API를 레이어드 아키텍처에 맞게 구현했습니다.
- Querydsl을 사용하는 구현체에서 필요한 DTO를 ReaderInfo로 생성했습니다.

### 변경한 결과
#### 리뷰 목록 조회
  - 캡처를 위해 size를 3으로 설정
<img width="895" alt="image" src="https://github.com/Kernel360/f1-JDON-Backend/assets/59242594/32ba1d18-282a-40a1-b58a-3b4d4e0fbffa">

#### 리뷰 생성
<img width="533" alt="image" src="https://github.com/Kernel360/f1-JDON-Backend/assets/59242594/e90215d7-10de-4aec-b81d-5df13ae35ec9">




### 이슈

- closes: #344 

---

## PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경, 주석 변경)
- [ ] 코드 리팩토링
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 파일 혹은 폴더명 수정, 삭제
- [ ] 배포 관련