### PR TITLE
Refactor: 찜하기/취소하기, 찜 조회하기 컨벤션에 맞게 수정

### DIFF
--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/favorite/application/FavoriteFacade.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/favorite/application/FavoriteFacade.java
@@ -13,17 +13,17 @@ import lombok.RequiredArgsConstructor;
 public class FavoriteFacade {
 	private final FavoriteService favoriteService;
 
-	public FavoriteInfo.UpdateResponse update(final Long memberId, FavoriteCommand.UpdateRequest request) {
+	public FavoriteInfo.UpdateResponse modify(final Long memberId, FavoriteCommand.UpdateRequest request) {
 		if (request.getIsFavorite()) {
-			return favoriteService.save(memberId, request.getLectureId());
+			return favoriteService.create(memberId, request.getLectureId());
 		}
-		return favoriteService.delete(memberId, request.getLectureId());
+		return favoriteService.remove(memberId, request.getLectureId());
 	}
 
-	public FavoriteInfo.FindFavoriteListResponse getList(
+	public FavoriteInfo.FindFavoriteListResponse getFavoriteList(
 		final Long memberId,
 		final PageInfoRequest pageInfoRequest) {
 
-		return favoriteService.getList(memberId, pageInfoRequest);
+		return favoriteService.getFavoriteList(memberId, pageInfoRequest);
 	}
 }

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/favorite/application/FavoriteFacade.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/favorite/application/FavoriteFacade.java
@@ -13,15 +13,14 @@ import lombok.RequiredArgsConstructor;
 public class FavoriteFacade {
 	private final FavoriteService favoriteService;
 
-	public FavoriteInfo.UpdateResponse modify(final Long memberId, FavoriteCommand.UpdateRequest request) {
+	public FavoriteInfo.UpdateResponse modify(final Long memberId, final FavoriteCommand.UpdateRequest request) {
 		if (request.getIsFavorite()) {
 			return favoriteService.create(memberId, request.getLectureId());
 		}
 		return favoriteService.remove(memberId, request.getLectureId());
 	}
 
-	public FavoriteInfo.FindFavoriteListResponse getFavoriteList(
-		final Long memberId,
+	public FavoriteInfo.FindFavoriteListResponse getFavoriteList(final Long memberId,
 		final PageInfoRequest pageInfoRequest) {
 
 		return favoriteService.getFavoriteList(memberId, pageInfoRequest);

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/favorite/core/FavoriteFactory.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/favorite/core/FavoriteFactory.java
@@ -1,0 +1,9 @@
+package kernel.jdon.moduleapi.domain.favorite.core;
+
+import kernel.jdon.moduledomain.favorite.domain.Favorite;
+
+public interface FavoriteFactory {
+	Favorite create(Long memberId, Long lectureId);
+
+	Favorite delete(Long memberId, Long lectureId);
+}

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/favorite/core/FavoriteService.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/favorite/core/FavoriteService.java
@@ -3,9 +3,9 @@ package kernel.jdon.moduleapi.domain.favorite.core;
 import kernel.jdon.moduleapi.global.page.PageInfoRequest;
 
 public interface FavoriteService {
-	FavoriteInfo.UpdateResponse save(Long memberId, Long lectureId);
+	FavoriteInfo.UpdateResponse create(Long memberId, Long lectureId);
 
-	FavoriteInfo.UpdateResponse delete(Long memberId, Long lectureId);
-	
-	FavoriteInfo.FindFavoriteListResponse getList(Long memberId, PageInfoRequest pageInfoRequest);
+	FavoriteInfo.UpdateResponse remove(Long memberId, Long lectureId);
+
+	FavoriteInfo.FindFavoriteListResponse getFavoriteList(Long memberId, PageInfoRequest pageInfoRequest);
 }

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/favorite/core/FavoriteServiceImpl.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/favorite/core/FavoriteServiceImpl.java
@@ -25,18 +25,18 @@ public class FavoriteServiceImpl implements FavoriteService {
 
 	@Override
 	@Transactional
-	public FavoriteInfo.UpdateResponse save(Long memberId, Long lectureId) {
+	public FavoriteInfo.UpdateResponse create(Long memberId, Long lectureId) {
 		Member findMember = memberReader.findById(memberId);
 		InflearnCourse findInflearnCourse = inflearnReader.findById(lectureId);
 		Favorite findFavorite = favoriteReader.findFavoriteByMemberIdAndInflearnCourseId(findMember.getId(),
 				findInflearnCourse.getId())
-			.orElseGet(() -> saveNewFavorite(findMember, findInflearnCourse));
+			.orElseGet(() -> createNewFavorite(findMember, findInflearnCourse));
 		Favorite saveFavorite = favoriteStore.save(findFavorite);
 
 		return new FavoriteInfo.UpdateResponse(saveFavorite.getId());
 	}
 
-	private Favorite saveNewFavorite(Member member, InflearnCourse inflearnCourse) {
+	private Favorite createNewFavorite(Member member, InflearnCourse inflearnCourse) {
 		Favorite favorite = new Favorite(member, inflearnCourse);
 
 		return favoriteReader.save(favorite);
@@ -44,7 +44,7 @@ public class FavoriteServiceImpl implements FavoriteService {
 
 	@Override
 	@Transactional
-	public FavoriteInfo.UpdateResponse delete(Long memberId, Long lectureId) {
+	public FavoriteInfo.UpdateResponse remove(Long memberId, Long lectureId) {
 		boolean memberExists = memberReader.existsById(memberId);
 		if (!memberExists) {
 			throw new ApiException(MemberErrorCode.NOT_FOUND_MEMBER);
@@ -59,7 +59,7 @@ public class FavoriteServiceImpl implements FavoriteService {
 	}
 
 	@Override
-	public FavoriteInfo.FindFavoriteListResponse getList(Long memberId, PageInfoRequest pageInfoRequest) {
+	public FavoriteInfo.FindFavoriteListResponse getFavoriteList(Long memberId, PageInfoRequest pageInfoRequest) {
 		FavoriteInfo.FindFavoriteListResponse favoriteList = favoriteReader.findList(memberId, pageInfoRequest);
 
 		return favoriteList;

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/favorite/core/FavoriteServiceImpl.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/favorite/core/FavoriteServiceImpl.java
@@ -25,31 +25,31 @@ public class FavoriteServiceImpl implements FavoriteService {
 
 	@Override
 	@Transactional
-	public FavoriteInfo.UpdateResponse create(Long memberId, Long lectureId) {
-		Member findMember = memberReader.findById(memberId);
-		InflearnCourse findInflearnCourse = inflearnReader.findById(lectureId);
-		Favorite findFavorite = favoriteReader.findFavoriteByMemberIdAndInflearnCourseId(findMember.getId(),
+	public FavoriteInfo.UpdateResponse create(final Long memberId, final Long lectureId) {
+		final Member findMember = memberReader.findById(memberId);
+		final InflearnCourse findInflearnCourse = inflearnReader.findById(lectureId);
+		final Favorite findFavorite = favoriteReader.findFavoriteByMemberIdAndInflearnCourseId(findMember.getId(),
 				findInflearnCourse.getId())
 			.orElseGet(() -> createNewFavorite(findMember, findInflearnCourse));
-		Favorite saveFavorite = favoriteStore.save(findFavorite);
+		final Favorite saveFavorite = favoriteStore.save(findFavorite);
 
 		return new FavoriteInfo.UpdateResponse(saveFavorite.getId());
 	}
 
-	private Favorite createNewFavorite(Member member, InflearnCourse inflearnCourse) {
-		Favorite favorite = new Favorite(member, inflearnCourse);
+	private Favorite createNewFavorite(final Member member, final InflearnCourse inflearnCourse) {
+		final Favorite favorite = new Favorite(member, inflearnCourse);
 
 		return favoriteReader.save(favorite);
 	}
 
 	@Override
 	@Transactional
-	public FavoriteInfo.UpdateResponse remove(Long memberId, Long lectureId) {
+	public FavoriteInfo.UpdateResponse remove(final Long memberId, final Long lectureId) {
 		boolean memberExists = memberReader.existsById(memberId);
 		if (!memberExists) {
 			throw new ApiException(MemberErrorCode.NOT_FOUND_MEMBER);
 		}
-		Favorite findFavorite = favoriteReader.findFavoriteByMemberIdAndInflearnCourseId(memberId, lectureId)
+		final Favorite findFavorite = favoriteReader.findFavoriteByMemberIdAndInflearnCourseId(memberId, lectureId)
 			.map(favoriteResponse -> favoriteReader.findById(favoriteResponse.getId())
 				.orElseThrow(FavoriteErrorCode.NOT_FOUND_FAVORITE::throwException))
 			.orElseThrow(FavoriteErrorCode.NOT_FOUND_FAVORITE::throwException);
@@ -60,7 +60,7 @@ public class FavoriteServiceImpl implements FavoriteService {
 
 	@Override
 	public FavoriteInfo.FindFavoriteListResponse getFavoriteList(Long memberId, PageInfoRequest pageInfoRequest) {
-		FavoriteInfo.FindFavoriteListResponse favoriteList = favoriteReader.findList(memberId, pageInfoRequest);
+		final FavoriteInfo.FindFavoriteListResponse favoriteList = favoriteReader.findList(memberId, pageInfoRequest);
 
 		return favoriteList;
 	}

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/favorite/infrastructure/FavoriteFactoryImpl.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/favorite/infrastructure/FavoriteFactoryImpl.java
@@ -1,0 +1,58 @@
+package kernel.jdon.moduleapi.domain.favorite.infrastructure;
+
+import org.springframework.stereotype.Component;
+
+import kernel.jdon.inflearncourse.domain.InflearnCourse;
+import kernel.jdon.member.domain.Member;
+import kernel.jdon.moduleapi.domain.favorite.core.FavoriteFactory;
+import kernel.jdon.moduleapi.domain.favorite.core.FavoriteReader;
+import kernel.jdon.moduleapi.domain.favorite.core.FavoriteStore;
+import kernel.jdon.moduleapi.domain.favorite.error.FavoriteErrorCode;
+import kernel.jdon.moduleapi.domain.inflearncourse.core.InflearnReader;
+import kernel.jdon.moduleapi.domain.member.core.MemberReader;
+import kernel.jdon.moduleapi.domain.member.error.MemberErrorCode;
+import kernel.jdon.moduleapi.global.exception.ApiException;
+import kernel.jdon.moduledomain.favorite.domain.Favorite;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class FavoriteFactoryImpl implements FavoriteFactory {
+	private final FavoriteReader favoriteReader;
+	private final FavoriteStore favoriteStore;
+	private final MemberReader memberReader;
+	private final InflearnReader inflearnReader;
+
+	@Override
+	public Favorite create(Long memberId, Long lectureId) {
+		final Member findMember = memberReader.findById(memberId);
+		final InflearnCourse findInflearnCourse = inflearnReader.findById(lectureId);
+		final Favorite findFavorite = favoriteReader.findFavoriteByMemberIdAndInflearnCourseId(findMember.getId(),
+				findInflearnCourse.getId())
+			.orElseGet(() -> createNewFavorite(findMember, findInflearnCourse));
+		final Favorite saveFavorite = favoriteStore.save(findFavorite);
+
+		return saveFavorite;
+	}
+
+	private Favorite createNewFavorite(final Member member, final InflearnCourse inflearnCourse) {
+		final Favorite favorite = new Favorite(member, inflearnCourse);
+
+		return favoriteReader.save(favorite);
+	}
+
+	@Override
+	public Favorite delete(Long memberId, Long lectureId) {
+		boolean memberExists = memberReader.existsById(memberId);
+		if (!memberExists) {
+			throw new ApiException(MemberErrorCode.NOT_FOUND_MEMBER);
+		}
+		final Favorite findFavorite = favoriteReader.findFavoriteByMemberIdAndInflearnCourseId(memberId, lectureId)
+			.map(favoriteResponse -> favoriteReader.findById(favoriteResponse.getId())
+				.orElseThrow(FavoriteErrorCode.NOT_FOUND_FAVORITE::throwException))
+			.orElseThrow(FavoriteErrorCode.NOT_FOUND_FAVORITE::throwException);
+		favoriteStore.delete(findFavorite);
+
+		return findFavorite;
+	}
+}

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/favorite/infrastructure/FavoriteReaderImpl.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/favorite/infrastructure/FavoriteReaderImpl.java
@@ -23,13 +23,14 @@ public class FavoriteReaderImpl implements FavoriteReader {
 	private final FavoriteInfoMapper favoriteInfoMapper;
 
 	@Override
-	public FavoriteInfo.FindFavoriteListResponse findList(Long memberId, PageInfoRequest pageInfoRequest) {
+	public FavoriteInfo.FindFavoriteListResponse findList(final Long memberId, final PageInfoRequest pageInfoRequest) {
 		Pageable pageable = PageRequest.of(pageInfoRequest.getPage(), pageInfoRequest.getSize());
 
-		Page<Favorite> favoritePage = favoriteRepository.findFavoriteByMemberId(memberId, pageable);
-		Page<FavoriteReaderInfo.FindFavoriteListResponse> favoritesPage = favoritePage.map(favoriteInfoMapper::of);
+		final Page<Favorite> favoritePage = favoriteRepository.findFavoriteByMemberId(memberId, pageable);
+		final Page<FavoriteReaderInfo.FindFavoriteListResponse> favoritesPage = favoritePage.map(
+			favoriteInfoMapper::of);
 
-		List<FavoriteInfo.FindFavorite> list = favoritesPage.getContent().stream()
+		final List<FavoriteInfo.FindFavorite> list = favoritesPage.getContent().stream()
 			.map(FavoriteInfo.FindFavorite::of)
 			.toList();
 
@@ -37,17 +38,17 @@ public class FavoriteReaderImpl implements FavoriteReader {
 	}
 
 	@Override
-	public Optional<Favorite> findFavoriteByMemberIdAndInflearnCourseId(Long memberId, Long lectureId) {
+	public Optional<Favorite> findFavoriteByMemberIdAndInflearnCourseId(final Long memberId, final Long lectureId) {
 		return favoriteRepository.findFavoriteByMemberIdAndInflearnCourseId(memberId, lectureId);
 	}
 
 	@Override
-	public Optional<Favorite> findById(Long favoriteId) {
+	public Optional<Favorite> findById(final Long favoriteId) {
 		return favoriteRepository.findById(favoriteId);
 	}
 
 	@Override
-	public Favorite save(Favorite favorite) {
+	public Favorite save(final Favorite favorite) {
 		return favoriteRepository.save(favorite);
 	}
 }

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/favorite/infrastructure/FavoriteStoreImpl.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/favorite/infrastructure/FavoriteStoreImpl.java
@@ -12,12 +12,12 @@ public class FavoriteStoreImpl implements FavoriteStore {
 	private final FavoriteRepository favoriteRepository;
 
 	@Override
-	public Favorite save(Favorite favorite) {
+	public Favorite save(final Favorite favorite) {
 		return favoriteRepository.save(favorite);
 	}
 
 	@Override
-	public void delete(Favorite favorite) {
+	public void delete(final Favorite favorite) {
 		favoriteRepository.delete(favorite);
 	}
 

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/favorite/presentation/FavoriteController.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/favorite/presentation/FavoriteController.java
@@ -27,9 +27,9 @@ public class FavoriteController {
 
 	@GetMapping("/api/v1/favorites")
 	public ResponseEntity<CommonResponse<FavoriteDto.FindFavoriteListResponse>> getList(
-		@LoginUser SessionUserInfo member,
-		@RequestParam(value = "page", defaultValue = "0") int page,
-		@RequestParam(value = "size", defaultValue = "12") int size) {
+		@LoginUser final SessionUserInfo member,
+		@RequestParam(value = "page", defaultValue = "0") final int page,
+		@RequestParam(value = "size", defaultValue = "12") final int size) {
 		final FavoriteInfo.FindFavoriteListResponse info = favoriteFacade.getFavoriteList(member.getId(),
 			new PageInfoRequest(page, size));
 		final FavoriteDto.FindFavoriteListResponse response = favoriteDtoMapper.of(info);
@@ -38,8 +38,8 @@ public class FavoriteController {
 	}
 
 	@PostMapping("/api/v1/favorites")
-	public ResponseEntity<CommonResponse<FavoriteDto.UpdateResponse>> modify(@LoginUser SessionUserInfo member,
-		@RequestBody @Valid FavoriteDto.UpdateRequest request) {
+	public ResponseEntity<CommonResponse<FavoriteDto.UpdateResponse>> modify(@LoginUser final SessionUserInfo member,
+		@RequestBody @Valid final FavoriteDto.UpdateRequest request) {
 		final FavoriteCommand.UpdateRequest command = favoriteDtoMapper.of(request);
 		final FavoriteInfo.UpdateResponse info = favoriteFacade.modify(member.getId(), command);
 		final FavoriteDto.UpdateResponse response = favoriteDtoMapper.of(info);

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/favorite/presentation/FavoriteController.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/favorite/presentation/FavoriteController.java
@@ -30,7 +30,7 @@ public class FavoriteController {
 		@LoginUser SessionUserInfo member,
 		@RequestParam(value = "page", defaultValue = "0") int page,
 		@RequestParam(value = "size", defaultValue = "12") int size) {
-		final FavoriteInfo.FindFavoriteListResponse info = favoriteFacade.getList(member.getId(),
+		final FavoriteInfo.FindFavoriteListResponse info = favoriteFacade.getFavoriteList(member.getId(),
 			new PageInfoRequest(page, size));
 		final FavoriteDto.FindFavoriteListResponse response = favoriteDtoMapper.of(info);
 
@@ -38,10 +38,10 @@ public class FavoriteController {
 	}
 
 	@PostMapping("/api/v1/favorites")
-	public ResponseEntity<CommonResponse<FavoriteDto.UpdateResponse>> update(@LoginUser SessionUserInfo member,
+	public ResponseEntity<CommonResponse<FavoriteDto.UpdateResponse>> modify(@LoginUser SessionUserInfo member,
 		@RequestBody @Valid FavoriteDto.UpdateRequest request) {
 		final FavoriteCommand.UpdateRequest command = favoriteDtoMapper.of(request);
-		final FavoriteInfo.UpdateResponse info = favoriteFacade.update(member.getId(), command);
+		final FavoriteInfo.UpdateResponse info = favoriteFacade.modify(member.getId(), command);
 		final FavoriteDto.UpdateResponse response = favoriteDtoMapper.of(info);
 
 		URI uri = URI.create("/api/v1/favorites/" + response.getLectureId());

--- a/module-api/src/test/java/kernel/jdon/moduleapi/domain/favorite/application/FavoriteFacadeTest.java
+++ b/module-api/src/test/java/kernel/jdon/moduleapi/domain/favorite/application/FavoriteFacadeTest.java
@@ -34,12 +34,12 @@ class FavoriteFacadeTest {
 		FavoriteInfo.UpdateResponse expectedResponse = new FavoriteInfo.UpdateResponse(2L);
 
 		// when
-		when(favoriteService.save(memberId, request.getLectureId())).thenReturn(expectedResponse);
-		FavoriteInfo.UpdateResponse actualResponse = favoriteFacade.update(memberId, request);
+		when(favoriteService.create(memberId, request.getLectureId())).thenReturn(expectedResponse);
+		FavoriteInfo.UpdateResponse actualResponse = favoriteFacade.modify(memberId, request);
 
 		// then
 		assertThat(expectedResponse.getLectureId()).isEqualTo(actualResponse.getLectureId());
-		verify(favoriteService, times(1)).save(memberId, request.getLectureId());
+		verify(favoriteService, times(1)).create(memberId, request.getLectureId());
 	}
 
 	@DisplayName("2: 유효한 요청으로 즐겨찾기 삭제하면, 삭제된 favorite id를 응답한다.")
@@ -52,12 +52,12 @@ class FavoriteFacadeTest {
 		FavoriteInfo.UpdateResponse expectedResponse = new FavoriteInfo.UpdateResponse(lectureId);
 
 		// when
-		when(favoriteService.delete(memberId, lectureId)).thenReturn(expectedResponse);
-		FavoriteInfo.UpdateResponse actualResponse = favoriteFacade.update(memberId, request);
+		when(favoriteService.remove(memberId, lectureId)).thenReturn(expectedResponse);
+		FavoriteInfo.UpdateResponse actualResponse = favoriteFacade.modify(memberId, request);
 
 		// then
 		assertThat(actualResponse).isEqualTo(expectedResponse);
-		verify(favoriteService, times(1)).delete(memberId, lectureId);
+		verify(favoriteService, times(1)).remove(memberId, lectureId);
 	}
 
 	@DisplayName("3: 내가 찜한 목록을 요청하면, 찜한 목록을 응답한다.")
@@ -69,12 +69,13 @@ class FavoriteFacadeTest {
 		FavoriteInfo.FindFavoriteListResponse expectedResponse = mock(FavoriteInfo.FindFavoriteListResponse.class);
 
 		// when
-		when(favoriteService.getList(memberId, pageInfoRequest)).thenReturn(expectedResponse);
-		FavoriteInfo.FindFavoriteListResponse actualResponse = favoriteFacade.getList(memberId, pageInfoRequest);
+		when(favoriteService.getFavoriteList(memberId, pageInfoRequest)).thenReturn(expectedResponse);
+		FavoriteInfo.FindFavoriteListResponse actualResponse = favoriteFacade.getFavoriteList(memberId,
+			pageInfoRequest);
 
 		// then
 		assertThat(expectedResponse).isEqualTo(actualResponse);
-		verify(favoriteService, times(1)).getList(memberId, pageInfoRequest);
+		verify(favoriteService, times(1)).getFavoriteList(memberId, pageInfoRequest);
 	}
 
 }


### PR DESCRIPTION
## 개요

### 요약
- 찜하기/취소하기, 찜 조회하기 컨벤션에 맞게 수정했습니다.

### 변경한 부분
- command, info에 final 붙이기
- factory 사용
- 메소드명 수정
  - controller, service, facade (create, modify, get, remove)
    - 주의: get의 경우 get + 도메인
  - repository (save, find, update, delete)


### 변경한 결과
- 찜 취소하기(없는 찜에 대해 취소할 경우)
![image](https://github.com/Kernel360/f1-JDON-Backend/assets/86637372/d0a618cb-99b2-469f-b837-6509069c4944)
- 찜 조회하기
![image](https://github.com/Kernel360/f1-JDON-Backend/assets/86637372/73b777e6-2049-4133-9b2b-5f1d1574f30d)

### 이슈

- closes: #346

---

## PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [x] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경, 주석 변경)
- [x] 코드 리팩토링
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 파일 혹은 폴더명 수정, 삭제
- [ ] 배포 관련