### PR TITLE
Fix: JD 상세조회 응답 항목 reviewCount 추가, 기술 스택 목록 중복 제거

### DIFF
--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/jd/core/JdInfo.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/jd/core/JdInfo.java
@@ -7,6 +7,7 @@ import kernel.jdon.skill.domain.Skill;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -32,6 +33,7 @@ public class JdInfo {
 	}
 
 	@Getter
+	@EqualsAndHashCode
 	public static class FindSkill {
 		private Long id;
 		private String keyword;

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/jd/core/JdInfo.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/jd/core/JdInfo.java
@@ -27,6 +27,7 @@ public class JdInfo {
 		private String benefits;
 		private String preferredPoints;
 		private String jobCategoryName;
+		private int reviewCount;
 		private List<FindSkill> skillList;
 	}
 

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/jd/core/JdInfoMapper.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/jd/core/JdInfoMapper.java
@@ -25,6 +25,7 @@ public interface JdInfoMapper {
 	@Mapping(source = "wantedJd.intro", target = "intro")
 	@Mapping(source = "wantedJd.benefits", target = "benefits")
 	@Mapping(source = "wantedJd.preferredPoints", target = "preferredPoints")
+	@Mapping(expression = "java(wantedJd.getReviewList().size())", target = "reviewCount")
 	@Mapping(expression = "java(wantedJd.getJobCategory().getName())", target = "jobCategoryName")
 	JdInfo.FindWantedJdResponse of(WantedJd wantedJd, List<JdInfo.FindSkill> skillList);
 }

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/jd/core/JdInfoMapper.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/jd/core/JdInfoMapper.java
@@ -25,6 +25,7 @@ public interface JdInfoMapper {
 	@Mapping(source = "wantedJd.intro", target = "intro")
 	@Mapping(source = "wantedJd.benefits", target = "benefits")
 	@Mapping(source = "wantedJd.preferredPoints", target = "preferredPoints")
+	@Mapping(source = "skillList", target = "skillList")
 	@Mapping(expression = "java(wantedJd.getReviewList().size())", target = "reviewCount")
 	@Mapping(expression = "java(wantedJd.getJobCategory().getName())", target = "jobCategoryName")
 	JdInfo.FindWantedJdResponse of(WantedJd wantedJd, List<JdInfo.FindSkill> skillList);

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/jd/infrastructure/JdReaderImpl.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/jd/infrastructure/JdReaderImpl.java
@@ -32,6 +32,7 @@ public class JdReaderImpl implements JdReader {
 		return wantedJd.getSkillList().stream()
 			.map(wantedJdSkill -> new JdInfo.FindSkill(
 				wantedJdSkill.getSkill()))
+			.distinct()
 			.toList();
 	}
 

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/jd/presentation/JdDto.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/jd/presentation/JdDto.java
@@ -24,6 +24,7 @@ public class JdDto {
 		private String benefits;
 		private String preferredPoints;
 		private String jobCategoryName;
+		private int reviewCount;
 		private List<FindSkill> skillList;
 	}
 

--- a/module-domain/src/main/java/kernel/jdon/wantedjd/domain/WantedJd.java
+++ b/module-domain/src/main/java/kernel/jdon/wantedjd/domain/WantedJd.java
@@ -19,6 +19,7 @@ import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
 import kernel.jdon.jobcategory.domain.JobCategory;
+import kernel.jdon.moduledomain.review.domain.Review;
 import kernel.jdon.wantedjdskill.domain.WantedJdSkill;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -76,6 +77,9 @@ public class WantedJd {
 
 	@OneToMany(mappedBy = "wantedJd")
 	private List<WantedJdSkill> skillList = new ArrayList<>();
+
+	@OneToMany(mappedBy = "wantedJd")
+	private List<Review> reviewList = new ArrayList<>();
 
 	@Builder
 	public WantedJd(String companyName, String title, Long detailId, String detailUrl, String imageUrl,


### PR DESCRIPTION
## 개요

### 요약

- JD 상세조회 응답 항목 reviewCount 추가
- 기술 스택 목록 중복 제거

### 변경한 부분
- JD 상세조회 API의 응답 항목에 리뷰 개수 `reviewCount` 항목을 추가했습니다.
- JD 데이터 수집 시 JDON에서 사용하지 않는 기술스택인 경우`기타`로 JD에 매핑됩니다.
예를들어 5개의 기술스택이 있는데 3개의 기술스택이 JDON에서 사용하지 않는 기술스택인 경우
`JAVA, GO, 기타, Python, 기타, 기타` 와 같이 반환되고 있는 문제 상황이 있었습니다. 따라서 기술스택 목록을 반환하는 로직에서 Stream을 통해 데이터를 순회하고 distinct를 통해 중복을 제거하여 반환하도록 수정하였습니다. list를 Set으로 변환 후 다시 list로 변환할지 고민하였으나 Stream의 distinct도 내부적으로 equals를 통해 객체를 비교하고 있기 때문에 더 간략한 distinct를 사용하는 방법으로 결정하여 구현했습니다.

### 변경한 결과
#### reviewCount 항목 추가 및 기술스택 목록 기타 키워드 중복 제거
<img width="582" alt="image" src="https://github.com/Kernel360/f1-JDON-Backend/assets/59242594/9e1d36d2-c952-4b5b-8833-a09e6d451a88">

#### 기타 키워드 중복 제거 전
<img width="498" alt="image" src="https://github.com/Kernel360/f1-JDON-Backend/assets/59242594/56f97134-3a2a-4e37-8de4-ce8e0e9cb721">

### 이슈

- closes: #353 

---

## PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경, 주석 변경)
- [ ] 코드 리팩토링
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 파일 혹은 폴더명 수정, 삭제
- [ ] 배포 관련