### PR TITLE
Feature: 커피챗 상세 조회시 응답에 로그인 유저의 기존 신청여부 추가

### DIFF
--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/coffeechat/application/CoffeeChatFacade.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/coffeechat/application/CoffeeChatFacade.java
@@ -33,8 +33,9 @@ public class CoffeeChatFacade {
         return coffeeChatService.getCoffeeChatList(pageInfoRequest, command);
     }
 
-    public CoffeeChatInfo.FindCoffeeChatResponse getCoffeeChat(Long coffeeChatId) {
-        CoffeeChatInfo.FindCoffeeChatResponse findCoffeeChatResponse = coffeeChatService.getCoffeeChat(coffeeChatId);
+    public CoffeeChatInfo.FindCoffeeChatResponse getCoffeeChat(Long coffeeChatId, Long memberId) {
+        CoffeeChatInfo.FindCoffeeChatResponse findCoffeeChatResponse = coffeeChatService.getCoffeeChat(coffeeChatId,
+            memberId);
         coffeeChatService.increaseViewCount(coffeeChatId);
 
         return findCoffeeChatResponse;

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/coffeechat/core/CoffeeChatInfo.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/coffeechat/core/CoffeeChatInfo.java
@@ -21,6 +21,7 @@ public class CoffeeChatInfo {
     public static class FindCoffeeChatResponse {
         private Long coffeeChatId;
         private Long hostId;
+        private Boolean isParticipant;
         private String nickname;
         private String hostJobCategoryName;
         private String title;

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/coffeechat/core/CoffeeChatInfoMapper.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/coffeechat/core/CoffeeChatInfoMapper.java
@@ -19,7 +19,7 @@ public interface CoffeeChatInfoMapper {
     @Mapping(expression = "java(coffeeChat.getMember().getNickname())", target = "nickname")
     @Mapping(expression = "java(coffeeChat.getMember().getJobCategory().getName())", target = "hostJobCategoryName")
     @Mapping(expression = "java(coffeeChat.getCoffeeChatStatus().getActiveStatus())", target = "status")
-    CoffeeChatInfo.FindCoffeeChatResponse of(CoffeeChat coffeeChat);
+    CoffeeChatInfo.FindCoffeeChatResponse of(CoffeeChat coffeeChat, Boolean isParticipant);
 
     @Mapping(source = "coffeeChat.id", target = "coffeeChatId")
     @Mapping(source = "coffeeChat.title", target = "title")

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/coffeechat/core/CoffeeChatInfoMapper.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/coffeechat/core/CoffeeChatInfoMapper.java
@@ -19,7 +19,7 @@ public interface CoffeeChatInfoMapper {
     @Mapping(expression = "java(coffeeChat.getMember().getNickname())", target = "nickname")
     @Mapping(expression = "java(coffeeChat.getMember().getJobCategory().getName())", target = "hostJobCategoryName")
     @Mapping(expression = "java(coffeeChat.getCoffeeChatStatus().getActiveStatus())", target = "status")
-    CoffeeChatInfo.FindCoffeeChatResponse of(CoffeeChat coffeeChat, Boolean isParticipant);
+    CoffeeChatInfo.FindCoffeeChatResponse of(CoffeeChat coffeeChat, boolean isParticipant);
 
     @Mapping(source = "coffeeChat.id", target = "coffeeChatId")
     @Mapping(source = "coffeeChat.title", target = "title")

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/coffeechat/core/CoffeeChatService.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/coffeechat/core/CoffeeChatService.java
@@ -10,7 +10,7 @@ public interface CoffeeChatService {
     CoffeeChatInfo.FindCoffeeChatListResponse getCoffeeChatList(PageInfoRequest pageInfoRequest,
         CoffeeChatCommand.FindCoffeeChatListRequest command);
 
-    CoffeeChatInfo.FindCoffeeChatResponse getCoffeeChat(Long coffeeChatId);
+    CoffeeChatInfo.FindCoffeeChatResponse getCoffeeChat(Long coffeeChatId, Long memberId);
 
     Long createCoffeeChat(CoffeeChatCommand.CreateCoffeeChatRequest request, Long memberId);
 

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/coffeechat/core/CoffeeChatServiceImpl.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/coffeechat/core/CoffeeChatServiceImpl.java
@@ -47,10 +47,16 @@ public class CoffeeChatServiceImpl implements CoffeeChatService {
     }
 
     @Override
-    public CoffeeChatInfo.FindCoffeeChatResponse getCoffeeChat(Long coffeeChatId) {
+    public CoffeeChatInfo.FindCoffeeChatResponse getCoffeeChat(Long coffeeChatId, Long memberId) {
         CoffeeChat findCoffeeChat = coffeeChatReader.findExistCoffeeChat(coffeeChatId);
+        Boolean isParticipant;
+        if (memberId != null) {
+            isParticipant = coffeeChatReader.existsByCoffeeChatIdAndMemberId(coffeeChatId, memberId);
+        } else {
+            isParticipant = false;
+        }
 
-        return coffeeChatInfoMapper.of(findCoffeeChat);
+        return coffeeChatInfoMapper.of(findCoffeeChat, isParticipant);
     }
 
     @Override

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/coffeechat/core/CoffeeChatServiceImpl.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/coffeechat/core/CoffeeChatServiceImpl.java
@@ -49,14 +49,20 @@ public class CoffeeChatServiceImpl implements CoffeeChatService {
     @Override
     public CoffeeChatInfo.FindCoffeeChatResponse getCoffeeChat(Long coffeeChatId, Long memberId) {
         CoffeeChat findCoffeeChat = coffeeChatReader.findExistCoffeeChat(coffeeChatId);
-        Boolean isParticipant;
+        boolean isParticipant = checkIfMemberParticipated(coffeeChatId, memberId);
+
+        return coffeeChatInfoMapper.of(findCoffeeChat, isParticipant);
+    }
+
+    private boolean checkIfMemberParticipated(Long coffeeChatId, Long memberId) {
+        boolean isParticipant;
         if (memberId != null) {
             isParticipant = coffeeChatReader.existsByCoffeeChatIdAndMemberId(coffeeChatId, memberId);
         } else {
             isParticipant = false;
         }
 
-        return coffeeChatInfoMapper.of(findCoffeeChat, isParticipant);
+        return isParticipant;
     }
 
     @Override

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/coffeechat/infrastructure/CoffeeChatReaderImpl.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/coffeechat/infrastructure/CoffeeChatReaderImpl.java
@@ -59,6 +59,6 @@ public class CoffeeChatReaderImpl implements CoffeeChatReader {
 
     @Override
     public boolean existsByCoffeeChatIdAndMemberId(Long coffeeChatId, Long memberId) {
-        return coffeeChatMemberRepository.existsByCoffeeChatIdAndMemberId(coffeeChatId, coffeeChatId);
+        return coffeeChatMemberRepository.existsByCoffeeChatIdAndMemberId(coffeeChatId, memberId);
     }
 }

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/coffeechat/presentation/CoffeeChatController.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/coffeechat/presentation/CoffeeChatController.java
@@ -1,6 +1,7 @@
 package kernel.jdon.moduleapi.domain.coffeechat.presentation;
 
 import java.net.URI;
+import java.util.Optional;
 
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
@@ -53,11 +54,20 @@ public class CoffeeChatController {
 
     @GetMapping("/api/v1/coffeechats/{id}")
     public ResponseEntity<CommonResponse<CoffeeChatDto.FindCoffeeChatResponse>> getCoffeeChat(
-        @PathVariable(name = "id") Long coffeeChatId) {
-        CoffeeChatInfo.FindCoffeeChatResponse info = coffeeChatFacade.getCoffeeChat(coffeeChatId);
+        @PathVariable(name = "id") Long coffeeChatId,
+        @LoginUser SessionUserInfo member
+    ) {
+        Long memberId = getMemberId(member);
+        CoffeeChatInfo.FindCoffeeChatResponse info = coffeeChatFacade.getCoffeeChat(coffeeChatId, memberId);
         CoffeeChatDto.FindCoffeeChatResponse response = coffeeChatDtoMapper.of(info);
 
         return ResponseEntity.ok(CommonResponse.of(response));
+    }
+
+    private Long getMemberId(SessionUserInfo member) {
+        return Optional.ofNullable(member)
+            .map(SessionUserInfo::getId)
+            .orElse(null);
     }
 
     @PostMapping("/api/v1/coffeechats/{id}")

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/coffeechat/presentation/CoffeeChatDto.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/coffeechat/presentation/CoffeeChatDto.java
@@ -20,7 +20,7 @@ public class CoffeeChatDto {
     public static class FindCoffeeChatResponse {
         private Long coffeeChatId;
         private Long hostId;
-        private Boolean isParticipant;
+        private boolean isParticipant;
         private String nickname;
         private String hostJobCategoryName;
         private String title;

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/coffeechat/presentation/CoffeeChatDto.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/coffeechat/presentation/CoffeeChatDto.java
@@ -20,6 +20,7 @@ public class CoffeeChatDto {
     public static class FindCoffeeChatResponse {
         private Long coffeeChatId;
         private Long hostId;
+        private Boolean isParticipant;
         private String nickname;
         private String hostJobCategoryName;
         private String title;

--- a/module-api/src/test/java/kernel/jdon/moduleapi/domain/coffeechat/application/CoffeeChatFacadeTest.java
+++ b/module-api/src/test/java/kernel/jdon/moduleapi/domain/coffeechat/application/CoffeeChatFacadeTest.java
@@ -25,19 +25,20 @@ class CoffeeChatFacadeTest {
     @DisplayName("커피챗 조회 성공 시, 해당 커피챗 조회수를 증가시키고, 올바른 응답을 반환한다")
     void givenValidId_whenGetCoffeeChat_thenIncreaseViewCount_thenReturnCorrectResponse() {
         //given
+        Long memberId = 2L;
         Long coffeeChatId = 1L;
         CoffeeChatInfo.FindCoffeeChatResponse mockFindCoffeeChatResponse = mock(
             CoffeeChatInfo.FindCoffeeChatResponse.class);
-        when(coffeeChatService.getCoffeeChat(coffeeChatId)).thenReturn(mockFindCoffeeChatResponse);
+        when(coffeeChatService.getCoffeeChat(coffeeChatId, memberId)).thenReturn(mockFindCoffeeChatResponse);
 
         //when
-        CoffeeChatInfo.FindCoffeeChatResponse response = coffeeChatFacade.getCoffeeChat(coffeeChatId);
+        CoffeeChatInfo.FindCoffeeChatResponse response = coffeeChatFacade.getCoffeeChat(coffeeChatId, memberId);
 
         //then
         assertThat(response).isEqualTo(mockFindCoffeeChatResponse);
 
         //verify
-        verify(coffeeChatService, times(1)).getCoffeeChat(coffeeChatId);
+        verify(coffeeChatService, times(1)).getCoffeeChat(coffeeChatId, memberId);
         verify(coffeeChatService, times(1)).increaseViewCount(coffeeChatId);
     }
 }

--- a/module-api/src/test/java/kernel/jdon/moduleapi/domain/coffeechat/core/CoffeeChatServiceImplTest.java
+++ b/module-api/src/test/java/kernel/jdon/moduleapi/domain/coffeechat/core/CoffeeChatServiceImplTest.java
@@ -29,21 +29,22 @@ class CoffeeChatServiceImplTest {
     @DisplayName("유효한 ID로 커피챗 조회 성공 시, 올바른 응답을 반환한다")
     void givenValidCoffeeChatId_whenGetCoffeeChat_thenReturnCorrectCoffeeChat() {
         //given
+        Long memberId = 2L;
         Long coffeeChatId = 1L;
         CoffeeChat mockCoffeeChat = mockCoffeeChat();
         CoffeeChatInfo.FindCoffeeChatResponse mockFindCoffeeChatResponse = mockFindResponse();
 
         //when
         when(coffeeChatReader.findExistCoffeeChat(coffeeChatId)).thenReturn(mockCoffeeChat);
-        when(coffeeChatInfoMapper.of(mockCoffeeChat)).thenReturn(mockFindCoffeeChatResponse);
+        when(coffeeChatInfoMapper.of(eq(mockCoffeeChat), anyBoolean())).thenReturn(mockFindCoffeeChatResponse);
 
         //then
-        CoffeeChatInfo.FindCoffeeChatResponse response = coffeeChatService.getCoffeeChat(coffeeChatId);
+        CoffeeChatInfo.FindCoffeeChatResponse response = coffeeChatService.getCoffeeChat(coffeeChatId, memberId);
         Assertions.assertThat(response).isEqualTo(mockFindCoffeeChatResponse);
 
         //verify
         verify(coffeeChatReader, times(1)).findExistCoffeeChat(coffeeChatId);
-        verify(coffeeChatInfoMapper, times(1)).of(mockCoffeeChat);
+        verify(coffeeChatInfoMapper, times(1)).of(eq(mockCoffeeChat), anyBoolean());
     }
 
     private CoffeeChat mockCoffeeChat() {

--- a/module-domain/src/main/java/kernel/jdon/coffeechat/domain/CoffeeChat.java
+++ b/module-domain/src/main/java/kernel/jdon/coffeechat/domain/CoffeeChat.java
@@ -34,9 +34,9 @@ import lombok.NoArgsConstructor;
 @Table(name = "coffee_chat")
 public class CoffeeChat extends AbstractEntity {
 
-	@Id
-	@GeneratedValue(strategy = GenerationType.IDENTITY)
-	private Long id;
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
 
     @Column(name = "title", columnDefinition = "VARCHAR(255)", nullable = false)
     private String title;
@@ -85,13 +85,9 @@ public class CoffeeChat extends AbstractEntity {
         this.member = member;
     }
 
-	public boolean isAuthor(Long memberId) {
-		return member.getId().equals(memberId);
-	}
-
-	public void increaseViewCount() {
-		this.viewCount += 1;
-	}
+    public void increaseViewCount() {
+        this.viewCount += 1;
+    }
 
     public void addCoffeeChatMember(Member member) {
         CoffeeChatMember coffeeChatMember = CoffeeChatMember.builder()


### PR DESCRIPTION
## 개요

커피챗 상세조회시 신청여부에 따라 UI를 다르게 렌더링 하기위해 응답항목을 추가했습니다.
- AS-IS
로그인한 유저가 커피챗을 상세조회 했을 때 본인이 해당 커피챗을 신청했는지 여부를 알 수 없음
- TO-BE
상세조회 응답에 isParticipant(boolean값)을 내려주어 이미 신청한 커피챗일 경우 '신청하기' 버튼을 비활성화하여 신청여부 식별 가능

### 변경한 부분
- presentation 계층에서 상세조회시 로그인 유저정보를 받습니다.
  - 계층간 유저정보는 식별자(Long)로 전달합니다.  
- application, core 계층에서도 memberId를 전달받아야 하므로 인터페이스 메서드 시그니처가 변경되어 해당 내용 반영했습니다.
  - 그에 따라 해당 계층 테스트코드도 수정했습니다. 
- CoffeeChatServiceImpl에서 memberId의 null 여부에 따라 분기해서 isParticipant 값을 결정하도록 했습니다.

### 변경한 결과
![image](https://github.com/Kernel360/f1-JDON-Backend/assets/111513287/1712919d-5758-4340-8809-7de21ee16ffe)
비로그인 조회시 isParticipant에 false반환.
![image](https://github.com/Kernel360/f1-JDON-Backend/assets/111513287/8cb86c3c-13f2-4152-a9ff-01595ee4085f)
로그인 후 참여신청하지 않은 커피챗 조회시 isParticipant에 false반환.
![image](https://github.com/Kernel360/f1-JDON-Backend/assets/111513287/e1f157bf-ada5-408d-b06c-286b03362338)
로그인 후 참여신청한 커피챗 조회시 isParticipant true반환.
### 이슈

- closes: #348 

---

## PR 유형

어떤 변경 사항이 있나요?

- [X] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경, 주석 변경)
- [ ] 코드 리팩토링
- [ ] 문서 수정
- [X] 테스트 추가, 테스트 리팩토링
- [ ] 파일 혹은 폴더명 수정, 삭제
- [ ] 배포 관련