### PR TITLE
BugFix: 커피챗 상세조회시 필드명 prefix 제외되는 이슈 수정

### DIFF
--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/coffeechat/core/CoffeeChatInfo.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/coffeechat/core/CoffeeChatInfo.java
@@ -21,7 +21,7 @@ public class CoffeeChatInfo {
     public static class FindCoffeeChatResponse {
         private Long coffeeChatId;
         private Long hostId;
-        private Boolean isParticipant;
+        private boolean isParticipant;
         private String nickname;
         private String hostJobCategoryName;
         private String title;
@@ -35,6 +35,10 @@ public class CoffeeChatInfo {
         private String openChatUrl;
         private Long totalRecruitCount;
         private Long currentRecruitCount;
+
+        public boolean getIsParticipant() {
+            return isParticipant;
+        }
     }
 
     @Getter

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/coffeechat/presentation/CoffeeChatDto.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/coffeechat/presentation/CoffeeChatDto.java
@@ -34,6 +34,10 @@ public class CoffeeChatDto {
         private String openChatUrl;
         private Long totalRecruitCount;
         private Long currentRecruitCount;
+
+        public boolean getIsParticipant() {
+            return isParticipant;
+        }
     }
 
     @Getter


### PR DESCRIPTION
## 개요

https://github.com/Kernel360/f1-JDON-Backend/pull/357 에서 응답 dto의 'isParticipant' 필드타입을 Boolean에서 boolean으로 수정하였습니다.
그 이후 API 테스트를 해보니 응답에서 'is' prefix가 제외되고 'participant'로만 직렬화되는 현상 발견하여 수정했습니다.

원인은 Lombok과 Jackson의 동작원리 때문입니다.
Jackson은 직렬화 할때 특정필드의 getter를 보고 필드명을 유추해서 JSON 속성을 생성합니다.
(예를 들어, member라는 필드에 getMember라는 메서드를 보고 get이라는 prefix를 제외하고 M을 소문자화해서 member라는 속성을 만듭니다.)

근데 Lombok의 @getter의 경우 필드 타입이 boolean 원시타입인 경우 getter를 is라는 prefix를 붙여 만듭니다(자바beans 규약에 따라).
그럼 Jackson이 직렬화 할때 is라는 prefix를 떼고 소문자화 하여 JSON속성을 만들기 때문에 'isParticipant'라는 필드가 'participant'로 응답이 나가게 됩니다.

### 변경한 부분
각 계층별 dto에서 boolean값을 갖고 있는 필드의 getter를 직접 선언해서 롬복의 @Getter가 생성하지 않도록 했습니다.
그에 따라 Jackson이 직렬화시 'get' prefix를 제외하고 'isParticipant'로 직렬화 합니다.

### 변경한 결과

### AS-IS

![image](https://github.com/Kernel360/f1-JDON-Backend/assets/111513287/c7cf2f5c-b14f-4e09-b906-4e80c5e8fbee)

### TO-BE

![image](https://github.com/Kernel360/f1-JDON-Backend/assets/111513287/b2845969-0188-4934-9697-72d1eb9e4b47)


### 이슈

- closes: #363 

---

## PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [X] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경, 주석 변경)
- [ ] 코드 리팩토링
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 파일 혹은 폴더명 수정, 삭제
- [ ] 배포 관련