### PR TITLE
Fix: 로그인 상태 조회 API의 json key값 수정

### DIFF
--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/member/presentation/MemberDto.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/member/presentation/MemberDto.java
@@ -91,6 +91,10 @@ public class MemberDto {
 		public static MemberDto.AuthenticateResponse of(final boolean isLoginUser, final Long memberId) {
 			return new MemberDto.AuthenticateResponse(isLoginUser, memberId);
 		}
+
+		public boolean getIsLoginUser() {
+			return isLoginUser;
+		}
 	}
 
 	@Getter


### PR DESCRIPTION
## 개요

### 요약

primitive 타입 boolean을 사용하여 json key값에서 is가 빠지는 버그가 있었습니다. 
getter를 추가하여 수정했습니다. 

### 변경한 부분
![image](https://github.com/Kernel360/f1-JDON-Backend/assets/68376744/4070455b-0ba5-4b73-aa46-3898750625fb)


### 변경한 결과
![image](https://github.com/Kernel360/f1-JDON-Backend/assets/68376744/cbc786d2-26e2-45aa-bc10-935233c95cae)


### 이슈

- closes: #373 

---

## PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경, 주석 변경)
- [ ] 코드 리팩토링
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 파일 혹은 폴더명 수정, 삭제
- [ ] 배포 관련