### PR TITLE
Refactor: 커피챗 도메인 DTO에 final 키워드 추가 및 커피챗 목록 조회 API 응답 viewCount 추가

### DIFF
--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/coffeechat/core/CoffeeChatCommand.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/coffeechat/core/CoffeeChatCommand.java
@@ -12,54 +12,54 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class CoffeeChatCommand {
 
-    @Getter
-    @Builder
-    public static class FindCoffeeChatListRequest {
-        private CoffeeChatSortCondition sort;
-        private String keyword;
-        private Long jobCategory;
-    }
+	@Getter
+	@Builder
+	public static class FindCoffeeChatListRequest {
+		private final CoffeeChatSortCondition sort;
+		private final String keyword;
+		private final Long jobCategory;
+	}
 
-    @Getter
-    @Builder
-    public static class CreateCoffeeChatRequest {
+	@Getter
+	@Builder
+	public static class CreateCoffeeChatRequest {
 
-        private String title;
-        private String content;
-        private Long totalRecruitCount;
-        private LocalDateTime meetDate;
-        private String openChatUrl;
+		private final String title;
+		private final String content;
+		private final Long totalRecruitCount;
+		private final LocalDateTime meetDate;
+		private final String openChatUrl;
 
-        public CoffeeChat toEntity(Member member) {
-            return CoffeeChat.builder()
-                .title(title)
-                .content(content)
-                .totalRecruitCount(totalRecruitCount)
-                .meetDate(meetDate)
-                .openChatUrl(openChatUrl)
-                .member(member)
-                .build();
-        }
+		public CoffeeChat toEntity(Member member) {
+			return CoffeeChat.builder()
+				.title(title)
+				.content(content)
+				.totalRecruitCount(totalRecruitCount)
+				.meetDate(meetDate)
+				.openChatUrl(openChatUrl)
+				.member(member)
+				.build();
+		}
 
-    }
+	}
 
-    @Getter
-    @Builder
-    public static class UpdateCoffeeChatRequest {
-        private String title;
-        private String content;
-        private Long totalRecruitCount;
-        private LocalDateTime meetDate;
-        private String openChatUrl;
+	@Getter
+	@Builder
+	public static class UpdateCoffeeChatRequest {
+		private final String title;
+		private final String content;
+		private final Long totalRecruitCount;
+		private final LocalDateTime meetDate;
+		private final String openChatUrl;
 
-        public CoffeeChat toEntity() {
-            return CoffeeChat.builder()
-                .title(title)
-                .content(content)
-                .totalRecruitCount(totalRecruitCount)
-                .meetDate(meetDate)
-                .openChatUrl(openChatUrl)
-                .build();
-        }
-    }
+		public CoffeeChat toEntity() {
+			return CoffeeChat.builder()
+				.title(title)
+				.content(content)
+				.totalRecruitCount(totalRecruitCount)
+				.meetDate(meetDate)
+				.openChatUrl(openChatUrl)
+				.build();
+		}
+	}
 }

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/coffeechat/core/CoffeeChatInfo.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/coffeechat/core/CoffeeChatInfo.java
@@ -3,7 +3,6 @@ package kernel.jdon.moduleapi.domain.coffeechat.core;
 import java.time.LocalDateTime;
 import java.util.List;
 
-import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonInclude;
 
 import kernel.jdon.moduleapi.domain.coffeechat.infrastructure.CoffeeChatReaderInfo;
@@ -16,72 +15,67 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class CoffeeChatInfo {
 
-    @Getter
-    @Builder
-    public static class FindCoffeeChatResponse {
-        private Long coffeeChatId;
-        private Long hostId;
-        private boolean isParticipant;
-        private String nickname;
-        private String hostJobCategoryName;
-        private String title;
-        private String content;
-        private Long viewCount;
-        private String status;
-        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm", timezone = "Asia/Seoul")
-        private LocalDateTime meetDate;
-        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm", timezone = "Asia/Seoul")
-        private LocalDateTime createdDate;
-        private String openChatUrl;
-        private Long totalRecruitCount;
-        private Long currentRecruitCount;
+	@Getter
+	@Builder
+	public static class FindCoffeeChatResponse {
+		private final Long coffeeChatId;
+		private final Long hostId;
+		private final boolean isParticipant;
+		private final String nickname;
+		private final String hostJobCategoryName;
+		private final String title;
+		private final String content;
+		private final Long viewCount;
+		private final String status;
+		private final LocalDateTime meetDate;
+		private final LocalDateTime createdDate;
+		private final String openChatUrl;
+		private final Long totalRecruitCount;
+		private final Long currentRecruitCount;
 
-        public boolean getIsParticipant() {
-            return isParticipant;
-        }
-    }
+		public boolean getIsParticipant() {
+			return isParticipant;
+		}
+	}
 
-    @Getter
-    public static class FindCoffeeChatListResponse {
-        private List<FindCoffeeChat> content;
-        private CustomPageInfo pageInfo;
+	@Getter
+	public static class FindCoffeeChatListResponse {
+		private List<FindCoffeeChat> content;
+		private CustomPageInfo pageInfo;
 
-        public FindCoffeeChatListResponse(List<FindCoffeeChat> content, CustomPageInfo pageInfo) {
-            this.content = content;
-            this.pageInfo = pageInfo;
-        }
-    }
+		public FindCoffeeChatListResponse(List<FindCoffeeChat> content, CustomPageInfo pageInfo) {
+			this.content = content;
+			this.pageInfo = pageInfo;
+		}
+	}
 
-    @Getter
-    @Builder
-    public static class FindCoffeeChat {
-        private Long coffeeChatId;
-        private String nickname;
-        private String hostJobCategoryName;
-        private String title;
-        private String activeStatus;
-        @JsonInclude(JsonInclude.Include.NON_NULL)
-        private Boolean isDeleted;
-        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm", timezone = "Asia/Seoul")
-        private LocalDateTime meetDate;
-        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm", timezone = "Asia/Seoul")
-        private LocalDateTime createdDate;
-        private Long totalRecruitCount;
-        private Long currentRecruitCount;
+	@Getter
+	@Builder
+	public static class FindCoffeeChat {
+		private final Long coffeeChatId;
+		private final String nickname;
+		private final String hostJobCategoryName;
+		private final String title;
+		private final String activeStatus;
+		@JsonInclude(JsonInclude.Include.NON_NULL)
+		private final Boolean isDeleted;
+		private final LocalDateTime meetDate;
+		private final LocalDateTime createdDate;
+		private final Long totalRecruitCount;
+		private final Long currentRecruitCount;
 
-        public static FindCoffeeChat of(CoffeeChatReaderInfo.FindCoffeeChatListResponse readerInfo) {
-            return FindCoffeeChat.builder()
-                .coffeeChatId(readerInfo.getCoffeeChatId())
-                .nickname(readerInfo.getNickname())
-                .hostJobCategoryName(readerInfo.getHostJobCategoryName())
-                .title(readerInfo.getTitle())
-                .activeStatus(readerInfo.getActiveStatus())
-                .isDeleted(readerInfo.getIsDeleted())
-                .meetDate(readerInfo.getMeetDate())
-                .createdDate(readerInfo.getCreatedDate())
-                .totalRecruitCount(readerInfo.getTotalRecruitCount())
-                .currentRecruitCount(readerInfo.getCurrentRecruitCount())
-                .build();
-        }
-    }
+		public static FindCoffeeChat of(CoffeeChatReaderInfo.FindCoffeeChatListResponse readerInfo) {
+			return FindCoffeeChat.builder()
+				.coffeeChatId(readerInfo.getCoffeeChatId())
+				.nickname(readerInfo.getNickname())
+				.hostJobCategoryName(readerInfo.getHostJobCategoryName())
+				.title(readerInfo.getTitle())
+				.activeStatus(readerInfo.getActiveStatus())
+				.meetDate(readerInfo.getMeetDate())
+				.createdDate(readerInfo.getCreatedDate())
+				.totalRecruitCount(readerInfo.getTotalRecruitCount())
+				.currentRecruitCount(readerInfo.getCurrentRecruitCount())
+				.build();
+		}
+	}
 }

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/coffeechat/core/CoffeeChatInfo.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/coffeechat/core/CoffeeChatInfo.java
@@ -63,6 +63,7 @@ public class CoffeeChatInfo {
 		private final LocalDateTime createdDate;
 		private final Long totalRecruitCount;
 		private final Long currentRecruitCount;
+		private final Long viewCount;
 
 		public static FindCoffeeChat of(CoffeeChatReaderInfo.FindCoffeeChatListResponse readerInfo) {
 			return FindCoffeeChat.builder()
@@ -75,6 +76,7 @@ public class CoffeeChatInfo {
 				.createdDate(readerInfo.getCreatedDate())
 				.totalRecruitCount(readerInfo.getTotalRecruitCount())
 				.currentRecruitCount(readerInfo.getCurrentRecruitCount())
+				.viewCount(readerInfo.getViewCount())
 				.build();
 		}
 	}

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/coffeechat/infrastructure/CoffeeChatReaderInfo.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/coffeechat/infrastructure/CoffeeChatReaderInfo.java
@@ -23,11 +23,12 @@ public class CoffeeChatReaderInfo {
 		private final LocalDateTime createdDate;
 		private final Long totalRecruitCount;
 		private final Long currentRecruitCount;
+		private final Long viewCount;
 
 		@QueryProjection
 		public FindCoffeeChatListResponse(Long coffeeChatId, String nickname, String job, String title,
-			CoffeeChatActiveStatus activeStatus,
-			LocalDateTime meetDate, LocalDateTime createdDate, Long totalRecruitCount, Long currentRecruitCount) {
+			CoffeeChatActiveStatus activeStatus, LocalDateTime meetDate, LocalDateTime createdDate,
+			Long totalRecruitCount, Long currentRecruitCount, Long viewCount) {
 			this.coffeeChatId = coffeeChatId;
 			this.nickname = nickname;
 			this.hostJobCategoryName = job;
@@ -37,6 +38,7 @@ public class CoffeeChatReaderInfo {
 			this.createdDate = createdDate;
 			this.totalRecruitCount = totalRecruitCount;
 			this.currentRecruitCount = currentRecruitCount;
+			this.viewCount = viewCount;
 		}
 	}
 }

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/coffeechat/infrastructure/CoffeeChatReaderInfo.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/coffeechat/infrastructure/CoffeeChatReaderInfo.java
@@ -2,8 +2,6 @@ package kernel.jdon.moduleapi.domain.coffeechat.infrastructure;
 
 import java.time.LocalDateTime;
 
-import com.fasterxml.jackson.annotation.JsonFormat;
-import com.fasterxml.jackson.annotation.JsonInclude;
 import com.querydsl.core.annotations.QueryProjection;
 
 import kernel.jdon.moduledomain.coffeechat.domain.CoffeeChatActiveStatus;
@@ -16,19 +14,15 @@ public class CoffeeChatReaderInfo {
 
 	@Getter
 	public static class FindCoffeeChatListResponse {
-		private Long coffeeChatId;
-		private String nickname;
-		private String hostJobCategoryName;
-		private String title;
-		private String activeStatus;
-		@JsonInclude(JsonInclude.Include.NON_NULL)
-		private Boolean isDeleted;
-		@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm", timezone = "Asia/Seoul")
-		private LocalDateTime meetDate;
-		@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm", timezone = "Asia/Seoul")
-		private LocalDateTime createdDate;
-		private Long totalRecruitCount;
-		private Long currentRecruitCount;
+		private final Long coffeeChatId;
+		private final String nickname;
+		private final String hostJobCategoryName;
+		private final String title;
+		private final String activeStatus;
+		private final LocalDateTime meetDate;
+		private final LocalDateTime createdDate;
+		private final Long totalRecruitCount;
+		private final Long currentRecruitCount;
 
 		@QueryProjection
 		public FindCoffeeChatListResponse(Long coffeeChatId, String nickname, String job, String title,

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/coffeechat/infrastructure/CoffeeChatRepositoryImpl.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/coffeechat/infrastructure/CoffeeChatRepositoryImpl.java
@@ -38,7 +38,8 @@ public class CoffeeChatRepositoryImpl implements CustomCoffeeChatRepository {
 				coffeeChat.meetDate,
 				coffeeChat.createdDate,
 				coffeeChat.totalRecruitCount,
-				coffeeChat.currentRecruitCount))
+				coffeeChat.currentRecruitCount,
+				coffeeChat.viewCount))
 			.from(coffeeChat)
 			.join(member)
 			.on(coffeeChat.member.eq(member))

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/coffeechat/presentation/CoffeeChatDto.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/coffeechat/presentation/CoffeeChatDto.java
@@ -89,5 +89,6 @@ public class CoffeeChatDto {
 		private final LocalDateTime createdDate;
 		private final Long totalRecruitCount;
 		private final Long currentRecruitCount;
+		private final Long viewCount;
 	}
 }

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/coffeechat/presentation/CoffeeChatDto.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/coffeechat/presentation/CoffeeChatDto.java
@@ -15,79 +15,79 @@ import lombok.NoArgsConstructor;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class CoffeeChatDto {
-    @Getter
-    @Builder
-    public static class FindCoffeeChatResponse {
-        private Long coffeeChatId;
-        private Long hostId;
-        private boolean isParticipant;
-        private String nickname;
-        private String hostJobCategoryName;
-        private String title;
-        private String content;
-        private Long viewCount;
-        private String status;
-        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm", timezone = "Asia/Seoul")
-        private LocalDateTime meetDate;
-        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm", timezone = "Asia/Seoul")
-        private LocalDateTime createdDate;
-        private String openChatUrl;
-        private Long totalRecruitCount;
-        private Long currentRecruitCount;
+	@Getter
+	@Builder
+	public static class FindCoffeeChatResponse {
+		private final Long coffeeChatId;
+		private final Long hostId;
+		private final boolean isParticipant;
+		private final String nickname;
+		private final String hostJobCategoryName;
+		private final String title;
+		private final String content;
+		private final Long viewCount;
+		private final String status;
+		@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm", timezone = "Asia/Seoul")
+		private final LocalDateTime meetDate;
+		@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm", timezone = "Asia/Seoul")
+		private final LocalDateTime createdDate;
+		private final String openChatUrl;
+		private final Long totalRecruitCount;
+		private final Long currentRecruitCount;
 
-        public boolean getIsParticipant() {
-            return isParticipant;
-        }
-    }
+		public boolean getIsParticipant() {
+			return isParticipant;
+		}
+	}
 
-    @Getter
-    @Builder
-    @NoArgsConstructor
-    @AllArgsConstructor
-    public static class CreateCoffeeChatRequest {
-        private String title;
-        private String content;
-        private Long totalRecruitCount;
-        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm", timezone = "Asia/Seoul")
-        private LocalDateTime meetDate;
-        private String openChatUrl;
-    }
+	@Getter
+	@Builder
+	@NoArgsConstructor
+	@AllArgsConstructor
+	public static class CreateCoffeeChatRequest {
+		private String title;
+		private String content;
+		private Long totalRecruitCount;
+		@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm", timezone = "Asia/Seoul")
+		private LocalDateTime meetDate;
+		private String openChatUrl;
+	}
 
-    @Getter
-    @Builder
-    @NoArgsConstructor
-    @AllArgsConstructor
-    public static class UpdateCoffeeChatRequest {
-        private String title;
-        private String content;
-        private Long totalRecruitCount;
-        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm", timezone = "Asia/Seoul")
-        private LocalDateTime meetDate;
-        private String openChatUrl;
-    }
+	@Getter
+	@Builder
+	@NoArgsConstructor
+	@AllArgsConstructor
+	public static class UpdateCoffeeChatRequest {
+		private String title;
+		private String content;
+		private Long totalRecruitCount;
+		@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm", timezone = "Asia/Seoul")
+		private LocalDateTime meetDate;
+		private String openChatUrl;
+	}
 
-    @Getter
-    @Builder
-    public static class FindCoffeeChatListResponse {
-        private List<FindCoffeeChat> content;
-        private CustomPageInfo pageInfo;
-    }
+	@Getter
+	@Builder
+	public static class FindCoffeeChatListResponse {
+		private final List<FindCoffeeChat> content;
+		private final CustomPageInfo pageInfo;
+	}
 
-    @Getter
-    @Builder
-    public static class FindCoffeeChat {
-        private Long coffeeChatId;
-        private String nickname;
-        private String hostJobCategoryName;
-        private String title;
-        private String activeStatus;
-        @JsonInclude(JsonInclude.Include.NON_NULL)
-        private Boolean isDeleted;
-        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm", timezone = "Asia/Seoul")
-        private LocalDateTime meetDate;
-        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm", timezone = "Asia/Seoul")
-        private LocalDateTime createdDate;
-        private Long totalRecruitCount;
-        private Long currentRecruitCount;
-    }
+	@Getter
+	@Builder
+	public static class FindCoffeeChat {
+		private final Long coffeeChatId;
+		private final String nickname;
+		private final String hostJobCategoryName;
+		private final String title;
+		private final String activeStatus;
+		@JsonInclude(JsonInclude.Include.NON_NULL)
+		private final Boolean isDeleted;
+		@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm", timezone = "Asia/Seoul")
+		private final LocalDateTime meetDate;
+		@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm", timezone = "Asia/Seoul")
+		private final LocalDateTime createdDate;
+		private final Long totalRecruitCount;
+		private final Long currentRecruitCount;
+	}
 }

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/jd/presentation/JdController.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/jd/presentation/JdController.java
@@ -20,9 +20,9 @@ public class JdController {
 
 	@GetMapping("/api/v1/jds/{id}")
 	public ResponseEntity<CommonResponse<JdDto.FindWantedJdResponse>> getJd(
-		@PathVariable(name = "id") Long jdId) {
-		JdInfo.FindWantedJdResponse info = jdFacade.getJd(jdId);
-		JdDto.FindWantedJdResponse response = jdDtoMapper.of(info);
+		@PathVariable(name = "id") final Long jdId) {
+		final JdInfo.FindWantedJdResponse info = jdFacade.getJd(jdId);
+		final JdDto.FindWantedJdResponse response = jdDtoMapper.of(info);
 
 		return ResponseEntity.ok().body(CommonResponse.of(response));
 	}

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/review/presentation/ReviewController.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/review/presentation/ReviewController.java
@@ -30,8 +30,8 @@ public class ReviewController {
 	@PostMapping("/api/v1/reviews")
 	public ResponseEntity<CommonResponse<ReviewDto.CreateReviewResponse>> createReview(
 		@RequestBody @Valid final ReviewDto.CreateReviewRequest request,
-		@LoginUser final SessionUserInfo sessionUserInfo) {
-		final ReviewCommand.CreateReviewRequest command = reviewDtoMapper.of(request, sessionUserInfo.getId());
+		@LoginUser final SessionUserInfo member) {
+		final ReviewCommand.CreateReviewRequest command = reviewDtoMapper.of(request, member.getId());
 		final ReviewInfo.CreateReviewResponse info = reviewFacade.createReview(command);
 		final ReviewDto.CreateReviewResponse response = reviewDtoMapper.of(info);
 		final URI uri = URI.create("/api/v1/reviews" + response.getReviewId());


### PR DESCRIPTION
## 개요

### 요약
- 커피챗 도메인 DTO에 final 키워드를 추가했습니다.
- 커피챗 목록 조회 API 응답 항목에 조회수 항목을 추가했습니다.

### 변경한 부분

- 커피챗 도메인 DTO에 final 키워드를 추가했습니다.
- 커피챗 목록 조회 API 응답 항목에 `viewCount` 항목을 추가했습니다.

### 변경한 결과
- API 정상 호출 및`viewCount` 항목을 추가를 확인했습니다.
<img width="805" alt="image" src="https://github.com/Kernel360/f1-JDON-Backend/assets/59242594/9bc29fdf-3a6f-4728-a5de-8f9de8d6c9f6">


### 이슈

- closes: #315 #360 

---

## PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경, 주석 변경)
- [ ] 코드 리팩토링
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 파일 혹은 폴더명 수정, 삭제
- [ ] 배포 관련