### PR TITLE
Refactor: 공통된 page 변수들을 객체로 바인딩

### DIFF
--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/coffeechat/presentation/CoffeeChatController.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/coffeechat/presentation/CoffeeChatController.java
@@ -8,6 +8,7 @@ import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -33,112 +34,111 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 public class CoffeeChatController {
 
-    private final CoffeeChatFacade coffeeChatFacade;
-    private final CoffeeChatDtoMapper coffeeChatDtoMapper;
+	private final CoffeeChatFacade coffeeChatFacade;
+	private final CoffeeChatDtoMapper coffeeChatDtoMapper;
 
-    @GetMapping("/api/v1/coffeechats")
-    public ResponseEntity<CommonResponse<CoffeeChatInfo.FindCoffeeChatListResponse>> getCoffeeChatList(
-        @RequestParam(value = "page", defaultValue = "0") int page,
-        @RequestParam(value = "size", defaultValue = "12") int size,
-        @RequestParam(value = "sort", defaultValue = "") CoffeeChatSortCondition sort,
-        @RequestParam(value = "keyword", defaultValue = "") String keyword,
-        @RequestParam(value = "jobCategory", defaultValue = "") Long jobCategory) {
+	@GetMapping("/api/v1/coffeechats")
+	public ResponseEntity<CommonResponse<CoffeeChatInfo.FindCoffeeChatListResponse>> getCoffeeChatList(
+		@ModelAttribute final PageInfoRequest pageInfoRequest,
+		@RequestParam(value = "sort", defaultValue = "") final CoffeeChatSortCondition sort,
+		@RequestParam(value = "keyword", defaultValue = "") final String keyword,
+		@RequestParam(value = "jobCategory", defaultValue = "") final Long jobCategory) {
 
-        CoffeeChatCommand.FindCoffeeChatListRequest request = coffeeChatDtoMapper.of(
-            new CoffeeChatCondition(sort, keyword, jobCategory));
-        CoffeeChatInfo.FindCoffeeChatListResponse info = coffeeChatFacade.getCoffeeChatList(
-            new PageInfoRequest(page, size), request);
-        CoffeeChatDto.FindCoffeeChatListResponse response = coffeeChatDtoMapper.of(info);
+		CoffeeChatCommand.FindCoffeeChatListRequest request = coffeeChatDtoMapper.of(
+			new CoffeeChatCondition(sort, keyword, jobCategory));
+		CoffeeChatInfo.FindCoffeeChatListResponse info = coffeeChatFacade.getCoffeeChatList(
+			pageInfoRequest, request);
+		CoffeeChatDto.FindCoffeeChatListResponse response = coffeeChatDtoMapper.of(info);
 
-        return ResponseEntity.ok(CommonResponse.of(response));
-    }
+		return ResponseEntity.ok(CommonResponse.of(response));
+	}
 
-    @GetMapping("/api/v1/coffeechats/{id}")
-    public ResponseEntity<CommonResponse<CoffeeChatDto.FindCoffeeChatResponse>> getCoffeeChat(
-        @PathVariable(name = "id") Long coffeeChatId,
-        @LoginUser SessionUserInfo member
-    ) {
-        Long memberId = getMemberId(member);
-        CoffeeChatInfo.FindCoffeeChatResponse info = coffeeChatFacade.getCoffeeChat(coffeeChatId, memberId);
-        CoffeeChatDto.FindCoffeeChatResponse response = coffeeChatDtoMapper.of(info);
+	@GetMapping("/api/v1/coffeechats/{id}")
+	public ResponseEntity<CommonResponse<CoffeeChatDto.FindCoffeeChatResponse>> getCoffeeChat(
+		@PathVariable(name = "id") Long coffeeChatId,
+		@LoginUser SessionUserInfo member
+	) {
+		Long memberId = getMemberId(member);
+		CoffeeChatInfo.FindCoffeeChatResponse info = coffeeChatFacade.getCoffeeChat(coffeeChatId, memberId);
+		CoffeeChatDto.FindCoffeeChatResponse response = coffeeChatDtoMapper.of(info);
 
-        return ResponseEntity.ok(CommonResponse.of(response));
-    }
+		return ResponseEntity.ok(CommonResponse.of(response));
+	}
 
-    private Long getMemberId(SessionUserInfo member) {
-        return Optional.ofNullable(member)
-            .map(SessionUserInfo::getId)
-            .orElse(null);
-    }
+	private Long getMemberId(SessionUserInfo member) {
+		return Optional.ofNullable(member)
+			.map(SessionUserInfo::getId)
+			.orElse(null);
+	}
 
-    @PostMapping("/api/v1/coffeechats/{id}")
-    public ResponseEntity<CommonResponse<CoffeeChatDto.AppliedCoffeeChatResponse>> applyCoffeeChat(
-        @PathVariable(name = "id") Long coffeeChatId,
-        @LoginUser SessionUserInfo member
-    ) {
-        CoffeeChatInfo.AppliedCoffeeChatResponse info = coffeeChatFacade.applyCoffeeChat(
-            coffeeChatId, member.getId());
-        CoffeeChatDto.AppliedCoffeeChatResponse response = coffeeChatDtoMapper.of(info);
+	@PostMapping("/api/v1/coffeechats/{id}")
+	public ResponseEntity<CommonResponse<CoffeeChatDto.AppliedCoffeeChatResponse>> applyCoffeeChat(
+		@PathVariable(name = "id") Long coffeeChatId,
+		@LoginUser SessionUserInfo member
+	) {
+		CoffeeChatInfo.AppliedCoffeeChatResponse info = coffeeChatFacade.applyCoffeeChat(
+			coffeeChatId, member.getId());
+		CoffeeChatDto.AppliedCoffeeChatResponse response = coffeeChatDtoMapper.of(info);
 
-        return ResponseEntity.ok().body(CommonResponse.of(response));
-    }
+		return ResponseEntity.ok().body(CommonResponse.of(response));
+	}
 
-    @PostMapping("/api/v1/coffeechats")
-    public ResponseEntity<CommonResponse<CoffeeChatDto.CreatedCoffeeChatResponse>> createCoffeeChat(
-        @RequestBody @Valid CoffeeChatDto.CreateCoffeeChatRequest request,
-        @LoginUser SessionUserInfo member
-    ) {
-        CoffeeChatCommand.CreateCoffeeChatRequest createCommand = coffeeChatDtoMapper.of(request);
-        CoffeeChatInfo.CreatedCoffeeChatResponse info = coffeeChatFacade.createCoffeeChat(createCommand,
-            member.getId());
-        CoffeeChatDto.CreatedCoffeeChatResponse response = coffeeChatDtoMapper.of(info);
-        URI uri = URI.create("/v1/coffeechats/" + info.getCoffeeChatId());
+	@PostMapping("/api/v1/coffeechats")
+	public ResponseEntity<CommonResponse<CoffeeChatDto.CreatedCoffeeChatResponse>> createCoffeeChat(
+		@RequestBody @Valid CoffeeChatDto.CreateCoffeeChatRequest request,
+		@LoginUser SessionUserInfo member
+	) {
+		CoffeeChatCommand.CreateCoffeeChatRequest createCommand = coffeeChatDtoMapper.of(request);
+		CoffeeChatInfo.CreatedCoffeeChatResponse info = coffeeChatFacade.createCoffeeChat(createCommand,
+			member.getId());
+		CoffeeChatDto.CreatedCoffeeChatResponse response = coffeeChatDtoMapper.of(info);
+		URI uri = URI.create("/v1/coffeechats/" + info.getCoffeeChatId());
 
-        return ResponseEntity.created(uri).body(CommonResponse.of(response));
-    }
+		return ResponseEntity.created(uri).body(CommonResponse.of(response));
+	}
 
-    @PutMapping("/api/v1/coffeechats/{id}")
-    public ResponseEntity<CommonResponse<CoffeeChatDto.UpdatedCoffeeChatResponse>> modifyCoffeeChat(
-        @PathVariable(name = "id") Long coffeeChatId,
-        @RequestBody @Valid CoffeeChatDto.UpdateCoffeeChatRequest request
-    ) {
-        CoffeeChatCommand.UpdateCoffeeChatRequest updateCommand = coffeeChatDtoMapper.of(request);
-        CoffeeChatInfo.UpdatedCoffeeChatResponse info = coffeeChatFacade.modifyCoffeeChat(
-            updateCommand, coffeeChatId);
-        CoffeeChatDto.UpdatedCoffeeChatResponse response = coffeeChatDtoMapper.of(info);
+	@PutMapping("/api/v1/coffeechats/{id}")
+	public ResponseEntity<CommonResponse<CoffeeChatDto.UpdatedCoffeeChatResponse>> modifyCoffeeChat(
+		@PathVariable(name = "id") Long coffeeChatId,
+		@RequestBody @Valid CoffeeChatDto.UpdateCoffeeChatRequest request
+	) {
+		CoffeeChatCommand.UpdateCoffeeChatRequest updateCommand = coffeeChatDtoMapper.of(request);
+		CoffeeChatInfo.UpdatedCoffeeChatResponse info = coffeeChatFacade.modifyCoffeeChat(
+			updateCommand, coffeeChatId);
+		CoffeeChatDto.UpdatedCoffeeChatResponse response = coffeeChatDtoMapper.of(info);
 
-        return ResponseEntity.ok().body(CommonResponse.of(response));
-    }
+		return ResponseEntity.ok().body(CommonResponse.of(response));
+	}
 
-    @DeleteMapping("/api/v1/coffeechats/{id}")
-    public ResponseEntity<CommonResponse<CoffeeChatDto.DeletedCoffeeChatResponse>> removeCoffeeChat(
-        @PathVariable(name = "id") Long coffeeChatId) {
-        CoffeeChatInfo.DeletedCoffeeChatResponse info = coffeeChatFacade.deleteCoffeeChat(
-            coffeeChatId);
-        CoffeeChatDto.DeletedCoffeeChatResponse response = coffeeChatDtoMapper.of(info);
+	@DeleteMapping("/api/v1/coffeechats/{id}")
+	public ResponseEntity<CommonResponse<CoffeeChatDto.DeletedCoffeeChatResponse>> removeCoffeeChat(
+		@PathVariable(name = "id") Long coffeeChatId) {
+		CoffeeChatInfo.DeletedCoffeeChatResponse info = coffeeChatFacade.deleteCoffeeChat(
+			coffeeChatId);
+		CoffeeChatDto.DeletedCoffeeChatResponse response = coffeeChatDtoMapper.of(info);
 
-        return ResponseEntity.ok().body(CommonResponse.of(response));
-    }
+		return ResponseEntity.ok().body(CommonResponse.of(response));
+	}
 
-    @GetMapping("/api/v1/coffeechats/guest")
-    public ResponseEntity<CommonResponse<CustomPageResponse<CoffeeChatInfo.FindCoffeeChat>>> getGuestCoffeeChatList(
-        @LoginUser SessionUserInfo member,
-        @PageableDefault(size = 12) Pageable pageable
-    ) {
-        CustomPageResponse<CoffeeChatInfo.FindCoffeeChat> response = coffeeChatFacade.getGuestCoffeeChatList(
-            member.getId(), pageable);
+	@GetMapping("/api/v1/coffeechats/guest")
+	public ResponseEntity<CommonResponse<CustomPageResponse<CoffeeChatInfo.FindCoffeeChat>>> getGuestCoffeeChatList(
+		@LoginUser SessionUserInfo member,
+		@PageableDefault(size = 12) Pageable pageable
+	) {
+		CustomPageResponse<CoffeeChatInfo.FindCoffeeChat> response = coffeeChatFacade.getGuestCoffeeChatList(
+			member.getId(), pageable);
 
-        return ResponseEntity.ok().body(CommonResponse.of(response));
-    }
+		return ResponseEntity.ok().body(CommonResponse.of(response));
+	}
 
-    @GetMapping("/api/v1/coffeechats/host")
-    public ResponseEntity<CommonResponse<CustomPageResponse<CoffeeChatInfo.FindCoffeeChat>>> getHostCoffeeChatList(
-        @LoginUser SessionUserInfo member,
-        @PageableDefault(size = 12) Pageable pageable
-    ) {
-        CustomPageResponse<CoffeeChatInfo.FindCoffeeChat> response = coffeeChatFacade.getHostCoffeeChatList(
-            member.getId(), pageable);
+	@GetMapping("/api/v1/coffeechats/host")
+	public ResponseEntity<CommonResponse<CustomPageResponse<CoffeeChatInfo.FindCoffeeChat>>> getHostCoffeeChatList(
+		@LoginUser SessionUserInfo member,
+		@PageableDefault(size = 12) Pageable pageable
+	) {
+		CustomPageResponse<CoffeeChatInfo.FindCoffeeChat> response = coffeeChatFacade.getHostCoffeeChatList(
+			member.getId(), pageable);
 
-        return ResponseEntity.ok().body(CommonResponse.of(response));
-    }
+		return ResponseEntity.ok().body(CommonResponse.of(response));
+	}
 }

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/favorite/presentation/FavoriteController.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/favorite/presentation/FavoriteController.java
@@ -4,9 +4,9 @@ import java.net.URI;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import jakarta.validation.Valid;
@@ -28,10 +28,9 @@ public class FavoriteController {
 	@GetMapping("/api/v1/favorites")
 	public ResponseEntity<CommonResponse<FavoriteDto.FindFavoriteListResponse>> getList(
 		@LoginUser final SessionUserInfo member,
-		@RequestParam(value = "page", defaultValue = "0") final int page,
-		@RequestParam(value = "size", defaultValue = "12") final int size) {
+		@ModelAttribute final PageInfoRequest pageInfoRequest) {
 		final FavoriteInfo.FindFavoriteListResponse info = favoriteFacade.getFavoriteList(member.getId(),
-			new PageInfoRequest(page, size));
+			pageInfoRequest);
 		final FavoriteDto.FindFavoriteListResponse response = favoriteDtoMapper.of(info);
 
 		return ResponseEntity.ok(CommonResponse.of(response));

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/jd/presentation/JdController.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/jd/presentation/JdController.java
@@ -2,6 +2,7 @@ package kernel.jdon.moduleapi.domain.jd.presentation;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -29,10 +30,9 @@ public class JdController {
 
 	@GetMapping("/api/v1/jds")
 	public ResponseEntity<CommonResponse<JdDto.FindWantedJdListResponse>> getJdList(
-		@RequestParam(value = "page", defaultValue = "0") final int page,
-		@RequestParam(value = "size", defaultValue = "12") final int size,
+		@ModelAttribute final PageInfoRequest pageInfoRequest,
 		@RequestParam(value = "keyword", defaultValue = "") final String keyword) {
-		final JdInfo.FindWantedJdListResponse info = jdFacade.getJdList(new PageInfoRequest(page, size), keyword);
+		final JdInfo.FindWantedJdListResponse info = jdFacade.getJdList(pageInfoRequest, keyword);
 		final JdDto.FindWantedJdListResponse response = jdDtoMapper.of(info);
 
 		return ResponseEntity.ok().body(CommonResponse.of(response));

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/review/presentation/ReviewController.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/review/presentation/ReviewController.java
@@ -5,10 +5,10 @@ import java.net.URI;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import jakarta.validation.Valid;
@@ -42,10 +42,9 @@ public class ReviewController {
 	@GetMapping("/api/v1/reviews/{jdId}")
 	public ResponseEntity<CommonResponse<ReviewDto.CreateReviewResponse>> findReviewList(
 		@PathVariable(name = "jdId") final Long jdId,
-		@RequestParam(value = "page", defaultValue = "0") final int page,
-		@RequestParam(value = "size", defaultValue = "6") final int size) {
+		@ModelAttribute final PageInfoRequest pageInfoRequest) {
 		final ReviewInfo.FindReviewListResponse info = reviewFacade.getReviewList(jdId,
-			new PageInfoRequest(page, size));
+			pageInfoRequest);
 		final ReviewDto.FindReviewListResponse response = reviewDtoMapper.of(info);
 
 		return ResponseEntity.ok().body(CommonResponse.of(response));

--- a/module-api/src/main/java/kernel/jdon/moduleapi/global/page/PageInfoRequest.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/global/page/PageInfoRequest.java
@@ -1,14 +1,48 @@
 package kernel.jdon.moduleapi.global.page;
 
+import java.util.Optional;
+
 import lombok.Getter;
 
 @Getter
 public class PageInfoRequest {
-	private int page;
-	private int size;
+	private final int page;
+	private final int size;
 
-	public PageInfoRequest(int page, int size) {
-		this.page = page;
-		this.size = size;
+	public PageInfoRequest(final String page, final String size) {
+		final Integer getPage = getIntegerValue(page);
+		final Integer getSize = getIntegerValue(size);
+		this.page = initPage(getPage);
+		this.size = initSize(getSize);
 	}
+
+	private Integer getIntegerValue(final String value) {
+		return isInteger(value) ? Integer.parseInt(value) : null;
+	}
+
+	private int initPage(final Integer page) {
+		final int defaultPage = 0;
+		final int minimumPage = 0;
+		return Optional.ofNullable(page)
+			.map(p -> p < minimumPage ? defaultPage : page)
+			.orElse(defaultPage);
+	}
+
+	private int initSize(final Integer size) {
+		final int defaultSize = 12;
+		final int minimumSize = 1;
+		return Optional.ofNullable(size)
+			.map(p -> p < minimumSize ? defaultSize : size)
+			.orElse(defaultSize);
+	}
+
+	public boolean isInteger(String str) {
+		try {
+			Integer.parseInt(str);
+			return true;
+		} catch (NumberFormatException e) {
+			return false;
+		}
+	}
+
 }


### PR DESCRIPTION
## 개요

### 요약

### 변경한 부분

페이징이 필요한 API의 controller에서
```
@RequestParam(value = "page", defaultValue = "0") int page,
@RequestParam(value = "size", defaultValue = "12") int size,
```
위와같이 매개변수로 받던 페이징 변수를 
```
@ModelAttribute final PageInfoRequest pageInfoRequest
```
객체로 바인딩 되도록 수정했습니다.

### 변경한 결과
### JD 목록조회
#### page: 0, size: 3 조회
<img width="513" alt="image" src="https://github.com/Kernel360/f1-JDON-Backend/assets/59242594/0d4145ec-fdad-46ac-9c6b-e3263ead4e79">

#### page 또는 size에 숫자가 아닌 임의의 값을 입력할 경우(테스트에서는 page: 문자열, size: 문자열) 기본값인 page: 0, size: 12로 조회 되도록 구현
<img width="864" alt="image" src="https://github.com/Kernel360/f1-JDON-Backend/assets/59242594/469a6971-b037-4f4c-a8e2-e7a574c55aa1">

### 커피챗 목록 조회
<img width="632" alt="image" src="https://github.com/Kernel360/f1-JDON-Backend/assets/59242594/8da2ebfe-413f-4f53-b2c0-63c40bb0966f">

### 찜한 목록 조회
<img width="731" alt="image" src="https://github.com/Kernel360/f1-JDON-Backend/assets/59242594/c1e91c3e-e7b9-4d21-8922-65d55366dd2b">

### 내가 오픈한 커피챗 목록 조회
<img width="610" alt="image" src="https://github.com/Kernel360/f1-JDON-Backend/assets/59242594/0b8bd0b4-f984-4104-8da4-4942e8ef5f03">

### 내가 참여한 커피챗 목록 조회
<img width="468" alt="image" src="https://github.com/Kernel360/f1-JDON-Backend/assets/59242594/29c8480b-ede2-416e-89e6-a5d84f9ee9e1">



### 이슈

- closes: #

---

## PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경, 주석 변경)
- [ ] 코드 리팩토링
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 파일 혹은 폴더명 수정, 삭제
- [ ] 배포 관련