### PR TITLE
Test: 내 정보 조회 & 수정 API의 TEST code 작성

### DIFF
--- a/module-api/src/main/java/kernel/jdon/moduleapi/global/validate/PastDateValidator.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/global/validate/PastDateValidator.java
@@ -14,7 +14,7 @@ public class PastDateValidator implements ConstraintValidator<IsPastDate, String
 		LocalDate date = null;
 
 		try {
-			date = LocalDate.from(LocalDate.parse(value, DateTimeFormatter.ofPattern("yyyy-MM-dd")));
+			date = LocalDate.parse(value, DateTimeFormatter.ofPattern("yyyy-MM-dd"));
 		} catch (Exception e) {
 			return false;
 		}

--- a/module-api/src/test/java/kernel/jdon/moduleapi/domain/member/application/MemberFacadeTest.java
+++ b/module-api/src/test/java/kernel/jdon/moduleapi/domain/member/application/MemberFacadeTest.java
@@ -1,0 +1,42 @@
+package kernel.jdon.moduleapi.domain.member.application;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import kernel.jdon.moduleapi.domain.member.core.MemberInfo;
+import kernel.jdon.moduleapi.domain.member.core.MemberService;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("Member Facade 테스트")
+class MemberFacadeTest {
+	@Mock
+	private MemberService memberService;
+	@InjectMocks
+	private MemberFacade memberFacade;
+
+	@Test
+	@DisplayName("1: 사용자 정보 요청 시, memberId에 해당되는 멤버의 정보를 응답으로 반환한다.")
+	void getMember() {
+		//given
+		var memberId = 1L;
+		var mockFindMemberResponse = mock(MemberInfo.FindMemberResponse.class);
+		when(memberService.getMember(memberId)).thenReturn(mockFindMemberResponse);
+
+		//when
+		var response = memberFacade.getMember(memberId);
+
+		//then
+		assertThat(response).isEqualTo(mockFindMemberResponse);
+
+		//verify
+		verify(memberService, times(1)).getMember(memberId);
+	}
+
+}

--- a/module-api/src/test/java/kernel/jdon/moduleapi/domain/member/application/MemberFacadeTest.java
+++ b/module-api/src/test/java/kernel/jdon/moduleapi/domain/member/application/MemberFacadeTest.java
@@ -58,5 +58,4 @@ class MemberFacadeTest {
 		//verify
 		verify(memberService, times(1)).modifyMember(modifyMemberId, mockModifyMemberCommand);
 	}
-
 }

--- a/module-api/src/test/java/kernel/jdon/moduleapi/domain/member/application/MemberFacadeTest.java
+++ b/module-api/src/test/java/kernel/jdon/moduleapi/domain/member/application/MemberFacadeTest.java
@@ -10,6 +10,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import kernel.jdon.moduleapi.domain.member.core.MemberCommand;
 import kernel.jdon.moduleapi.domain.member.core.MemberInfo;
 import kernel.jdon.moduleapi.domain.member.core.MemberService;
 
@@ -22,14 +23,14 @@ class MemberFacadeTest {
 	private MemberFacade memberFacade;
 
 	@Test
-	@DisplayName("1: 사용자 정보 요청 시, memberId에 해당되는 멤버의 정보를 응답으로 반환한다.")
-	void getMember() {
+	@DisplayName("1: 사용자 정보 요청 시, get 메서드가 memberId에 해당되는 멤버의 정보를 응답으로 반환한다.")
+	void whenGetMemberInfo_thenReturnMemberInfo() {
 		//given
 		var memberId = 1L;
 		var mockFindMemberResponse = mock(MemberInfo.FindMemberResponse.class);
-		when(memberService.getMember(memberId)).thenReturn(mockFindMemberResponse);
 
 		//when
+		when(memberService.getMember(memberId)).thenReturn(mockFindMemberResponse);
 		var response = memberFacade.getMember(memberId);
 
 		//then
@@ -37,6 +38,25 @@ class MemberFacadeTest {
 
 		//verify
 		verify(memberService, times(1)).getMember(memberId);
+	}
+
+	@Test
+	@DisplayName("2: 사용자 아이디와 정보 수정 정보가 주어졌을 때, modify 메서드가 수정을 마친 memberId를 응답으로 반환한다.")
+	void givenMemberIdAndMemberModifyInfo_whenModifyMember_thenReturnModifiedMemberId() {
+		//given
+		final var modifyMemberId = 1L;
+		final var mockModifyMemberCommand = mock(MemberCommand.UpdateMemberRequest.class);
+		final var modifyMemberResponse = MemberInfo.UpdateMemberResponse.of(modifyMemberId);
+
+		//when
+		when(memberService.modifyMember(modifyMemberId, mockModifyMemberCommand)).thenReturn(modifyMemberResponse);
+		final var response = memberFacade.modifyMember(modifyMemberId, mockModifyMemberCommand);
+
+		//then
+		assertThat(response.getMemberId()).isEqualTo(modifyMemberId);
+
+		//verify
+		verify(memberService, times(1)).modifyMember(modifyMemberId, mockModifyMemberCommand);
 	}
 
 }

--- a/module-api/src/test/java/kernel/jdon/moduleapi/domain/member/application/MemberFacadeTest.java
+++ b/module-api/src/test/java/kernel/jdon/moduleapi/domain/member/application/MemberFacadeTest.java
@@ -26,12 +26,12 @@ class MemberFacadeTest {
 	@DisplayName("1: 사용자 정보 요청 시, get 메서드가 memberId에 해당되는 멤버의 정보를 응답으로 반환한다.")
 	void whenGetMemberInfo_thenReturnMemberInfo() {
 		//given
-		var memberId = 1L;
-		var mockFindMemberResponse = mock(MemberInfo.FindMemberResponse.class);
+		final var memberId = 1L;
+		final var mockFindMemberResponse = mock(MemberInfo.FindMemberResponse.class);
 
 		//when
 		when(memberService.getMember(memberId)).thenReturn(mockFindMemberResponse);
-		var response = memberFacade.getMember(memberId);
+		final var response = memberFacade.getMember(memberId);
 
 		//then
 		assertThat(response).isEqualTo(mockFindMemberResponse);

--- a/module-api/src/test/java/kernel/jdon/moduleapi/domain/member/core/MemberServiceImplTest.java
+++ b/module-api/src/test/java/kernel/jdon/moduleapi/domain/member/core/MemberServiceImplTest.java
@@ -76,15 +76,7 @@ class MemberServiceImplTest {
 		verify(memberReader, times(1)).findById(memberId);
 		verify(memberFactory, times(1)).update(mockFindMember, mockUpdateCommand);
 	}
-
-	public MemberInfo.UpdateMemberResponse modifyMember(final Long memberId,
-		final MemberCommand.UpdateMemberRequest command) {
-		final Member findMember = memberReader.findById(memberId);
-		memberFactory.update(findMember, command);
-
-		return MemberInfo.UpdateMemberResponse.of(findMember.getId());
-	}
-
+	
 	private Member mockMember() {
 		return Member.builder()
 			.id(1L)

--- a/module-api/src/test/java/kernel/jdon/moduleapi/domain/member/core/MemberServiceImplTest.java
+++ b/module-api/src/test/java/kernel/jdon/moduleapi/domain/member/core/MemberServiceImplTest.java
@@ -12,6 +12,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import kernel.jdon.moduleapi.domain.member.infrastructure.MemberFactoryImpl;
 import kernel.jdon.moduledomain.jobcategory.domain.JobCategory;
 import kernel.jdon.moduledomain.member.domain.Gender;
 import kernel.jdon.moduledomain.member.domain.Member;
@@ -24,6 +25,9 @@ class MemberServiceImplTest {
 	private MemberReader memberReader;
 	@Mock
 	private MemberInfoMapper memberInfoMapper;
+
+	@Mock
+	private MemberFactoryImpl memberFactory;
 
 	@InjectMocks
 	private MemberServiceImpl memberService;
@@ -54,7 +58,31 @@ class MemberServiceImplTest {
 	}
 
 	@Test
-	void modifyMember() {
+	@DisplayName("2: 사용자 정보 수정 요청 시, modify 메서드가 동작 결과로 memberId를 응답으로 반환한다.")
+	void givenMemberUpdateInfo_whenModifyMember_thenReturnMemberId() {
+		//given
+		final var mockFindMember = mockMember();
+		final var memberId = mockFindMember.getId();
+		final var mockUpdateCommand = mock(MemberCommand.UpdateMemberRequest.class);
+
+		//when
+		when(memberReader.findById(memberId)).thenReturn(mockFindMember);
+		final var response = memberService.modifyMember(memberId, mockUpdateCommand);
+
+		//then
+		assertThat(response.getMemberId()).isEqualTo(memberId);
+
+		//verify
+		verify(memberReader, times(1)).findById(memberId);
+		verify(memberFactory, times(1)).update(mockFindMember, mockUpdateCommand);
+	}
+
+	public MemberInfo.UpdateMemberResponse modifyMember(final Long memberId,
+		final MemberCommand.UpdateMemberRequest command) {
+		final Member findMember = memberReader.findById(memberId);
+		memberFactory.update(findMember, command);
+
+		return MemberInfo.UpdateMemberResponse.of(findMember.getId());
 	}
 
 	private Member mockMember() {

--- a/module-api/src/test/java/kernel/jdon/moduleapi/domain/member/core/MemberServiceImplTest.java
+++ b/module-api/src/test/java/kernel/jdon/moduleapi/domain/member/core/MemberServiceImplTest.java
@@ -1,0 +1,74 @@
+package kernel.jdon.moduleapi.domain.member.core;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import kernel.jdon.moduledomain.jobcategory.domain.JobCategory;
+import kernel.jdon.moduledomain.member.domain.Gender;
+import kernel.jdon.moduledomain.member.domain.Member;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("Member Service 테스트")
+class MemberServiceImplTest {
+
+	@Mock
+	private MemberReader memberReader;
+	@Mock
+	private MemberInfoMapper memberInfoMapper;
+
+	@InjectMocks
+	private MemberServiceImpl memberService;
+
+	@Test
+	@DisplayName("1: 사용자 정보 요청 시, get 메서드가 memberId에 해당되는 멤버의 정보를 응답으로 반환한다.")
+	void givenMemberId_whenGetMember_thenReturnMemberInfo() {
+		//given
+		final var memberId = 1L;
+		final var findMember = mockMember();
+		final var mockFindMemberResponse = MemberInfo.FindMemberResponse.builder().email("email").build();
+		final var mockSkillIdList = mockSkillIdList();
+
+		//when
+		when(memberReader.findById(memberId)).thenReturn(findMember);
+		when(memberReader.findSkillIdListByMember(findMember)).thenReturn(mockSkillIdList);
+		when(memberInfoMapper.of(findMember, mockSkillIdList)).thenReturn(mockFindMemberResponse);
+		final var response = memberService.getMember(memberId);
+
+		//then
+		assertThat(response).isEqualTo(mockFindMemberResponse);
+		assertThat(response.getEmail()).isEqualTo(findMember.getEmail());
+
+		//verify
+		verify(memberReader, times(1)).findById(memberId);
+		verify(memberReader, times(1)).findSkillIdListByMember(findMember);
+		verify(memberInfoMapper, times(1)).of(findMember, mockSkillIdList);
+	}
+
+	@Test
+	void modifyMember() {
+	}
+
+	private Member mockMember() {
+		return Member.builder()
+			.id(1L)
+			.email("email")
+			.nickname("nickname")
+			.birth("2020-02-02")
+			.gender(Gender.MALE)
+			.jobCategory(mock(JobCategory.class))
+			.build();
+	}
+
+	private List<Long> mockSkillIdList() {
+		return List.of(1L, 2L, 3L);
+	}
+}

--- a/module-api/src/test/java/kernel/jdon/moduleapi/domain/member/infrastructure/MemberFactoryImplTest.java
+++ b/module-api/src/test/java/kernel/jdon/moduleapi/domain/member/infrastructure/MemberFactoryImplTest.java
@@ -1,0 +1,82 @@
+package kernel.jdon.moduleapi.domain.member.infrastructure;
+
+import static org.mockito.Mockito.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import kernel.jdon.moduleapi.domain.jobcategory.core.JobCategoryReader;
+import kernel.jdon.moduleapi.domain.member.core.MemberCommand;
+import kernel.jdon.moduleapi.domain.member.core.MemberStore;
+import kernel.jdon.moduleapi.domain.skill.core.SkillReader;
+import kernel.jdon.moduledomain.jobcategory.domain.JobCategory;
+import kernel.jdon.moduledomain.member.domain.Gender;
+import kernel.jdon.moduledomain.member.domain.Member;
+import kernel.jdon.moduledomain.skill.domain.Skill;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("Member Factory 테스트")
+class MemberFactoryImplTest {
+	@Mock
+	private JobCategoryReader jobCategoryReader;
+
+	@Mock
+	private SkillReader skillReader;
+
+	@Mock
+	private MemberStore memberStore;
+
+	@InjectMocks
+	private MemberFactoryImpl memberFactory;
+
+	@Test
+	@DisplayName("1: member와 사용자 수정 정보가 주어지고 정보 수정 요청 시, update 메서드가 member를 업데이트한다.")
+	void givenMemberAndUpdateInfo_whenUpdate() {
+		//given
+		final var mockMember = mockMember();
+		final var mockUpdateCommand = mockUpdateCommand();
+		final var mockFindJobCategory = mock(JobCategory.class);
+		final var mockFindSkillList = List.of(mock(Skill.class), mock(Skill.class), mock(Skill.class));
+
+		//when
+		when(jobCategoryReader.findById(mockUpdateCommand.getJobCategoryId())).thenReturn(mockFindJobCategory);
+		when(skillReader.findAllByIdList(mockUpdateCommand.getSkillList())).thenReturn(mockFindSkillList);
+		doNothing().when(memberStore).update(any(Member.class), any(Member.class));
+		memberFactory.update(mockMember, mockUpdateCommand);
+
+		//assert
+
+		//verify
+		verify(jobCategoryReader, times(1)).findById(mockUpdateCommand.getJobCategoryId());
+		verify(skillReader, times(1)).findAllByIdList(mockUpdateCommand.getSkillList());
+		verify(memberStore, times(1)).update(any(Member.class), any(Member.class));
+	}
+
+	private Member mockMember() {
+		return Member.builder()
+			.id(1L)
+			.email("email")
+			.nickname("nickname")
+			.birth("2020-02-02")
+			.gender(Gender.MALE)
+			.jobCategory(mock(JobCategory.class))
+			.build();
+	}
+
+	private MemberCommand.UpdateMemberRequest mockUpdateCommand() {
+		return MemberCommand.UpdateMemberRequest.builder()
+			.jobCategoryId(1L)
+			.skillList(mockSkillIdList())
+			.build();
+	}
+
+	private List<Long> mockSkillIdList() {
+		return List.of(1L, 2L, 3L);
+	}
+}


### PR DESCRIPTION
## 개요

### 요약

### 변경한 부분
- 내 정보 조회, 수정 API에 대한 test 작성했습니다. 
- dto에서 생일날짜에 대한 유효성을 검증하는 validator에서 불필요하게 LocalDate 객체를 연달아 두번 만들고 있어서 수정했습니다. 

### 변경한 결과
- MemberFacade test
![image](https://github.com/Kernel360/f1-JDON-Backend/assets/68376744/e6cf87ac-09f5-4560-8a2a-a14e7e7616c1)

- MemberService test
![image](https://github.com/Kernel360/f1-JDON-Backend/assets/68376744/86beff8d-d0e4-4c86-abf0-cbd73e17b421)

- MemberFactory test 
![image](https://github.com/Kernel360/f1-JDON-Backend/assets/68376744/b8bd3bcd-47bd-4bd8-8861-8237e8f4bed4)


### 이슈

- closes: #370 

---

## PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경, 주석 변경)
- [ ] 코드 리팩토링
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 파일 혹은 폴더명 수정, 삭제
- [ ] 배포 관련