### PR TITLE
Test: Jd 도메인 단위 테스트 작성 

### DIFF
--- a/module-api/src/test/java/kernel/jdon/moduleapi/domain/favorite/application/FavoriteFacadeTest.java
+++ b/module-api/src/test/java/kernel/jdon/moduleapi/domain/favorite/application/FavoriteFacadeTest.java
@@ -65,7 +65,7 @@ class FavoriteFacadeTest {
 	void whenGetList_thenReturnList() {
 		// given
 		Long memberId = 1L;
-		PageInfoRequest pageInfoRequest = new PageInfoRequest(0, 10);
+		PageInfoRequest pageInfoRequest = new PageInfoRequest("0", "10");
 		FavoriteInfo.FindFavoriteListResponse expectedResponse = mock(FavoriteInfo.FindFavoriteListResponse.class);
 
 		// when

--- a/module-api/src/test/java/kernel/jdon/moduleapi/domain/favorite/core/FavoriteServiceImplTest.java
+++ b/module-api/src/test/java/kernel/jdon/moduleapi/domain/favorite/core/FavoriteServiceImplTest.java
@@ -181,7 +181,7 @@ class FavoriteServiceImplTest {
 	void givenValidMemberAndPageInfo_whenGetFavoriteList_thenReturnFavoriteList() {
 		// given
 		Long memberId = 1L;
-		PageInfoRequest pageInfoRequest = new PageInfoRequest(0, 12);
+		PageInfoRequest pageInfoRequest = new PageInfoRequest("0", "12");
 		List<FavoriteInfo.FindFavorite> expectedFavorites = mockFavoriteList();
 		CustomPageInfo customPageInfo = new CustomJpaPageInfo(
 			new PageImpl<>(expectedFavorites, PageRequest.of(0, 12), expectedFavorites.size()));

--- a/module-api/src/test/java/kernel/jdon/moduleapi/domain/jd/application/JdFacadeTest.java
+++ b/module-api/src/test/java/kernel/jdon/moduleapi/domain/jd/application/JdFacadeTest.java
@@ -1,0 +1,57 @@
+package kernel.jdon.moduleapi.domain.jd.application;
+
+import static org.mockito.Mockito.*;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import kernel.jdon.moduleapi.domain.jd.core.JdInfo;
+import kernel.jdon.moduleapi.domain.jd.core.JdService;
+import kernel.jdon.moduleapi.global.page.PageInfoRequest;
+
+@DisplayName("JD Facade 테스트")
+@ExtendWith(MockitoExtension.class)
+class JdFacadeTest {
+	@InjectMocks
+	private JdFacade jdFacade;
+	@Mock
+	private JdService jdService;
+
+	@Test
+	@DisplayName("1: 올바른 jdId가 주어졌을 때 getJd 메서드가 jd 상세정보와 스킬목록을 반환한다.")
+	void givenValidJdId_whenGetJd_thenReturnCorrectJd() throws Exception {
+		//given
+		final var jdId = 1L;
+		final var mockFindWantedJdResponse = mock(JdInfo.FindWantedJdResponse.class);
+
+		//when
+		when(jdService.getJd(jdId)).thenReturn(mockFindWantedJdResponse);
+		final var response = jdFacade.getJd(jdId);
+
+		//then
+		Assertions.assertThat(response).isNotNull();
+		verify(jdService, times(1)).getJd(jdId);
+	}
+
+	@Test
+	@DisplayName("2: 올바른 keyword가 주어졌을 때 getJdList가 jd 목록을 반환한다.")
+	void givenValidKeyword_whenGetJdList_thenReturnCorrectJdList() throws Exception {
+		//given
+		final var keyword = "keyword";
+		final var mockPageInfoRequest = mock(PageInfoRequest.class);
+		final var mockFindWantedJdListResponse = mock(JdInfo.FindWantedJdListResponse.class);
+
+		//when
+		when(jdService.getJdList(mockPageInfoRequest, keyword)).thenReturn(mockFindWantedJdListResponse);
+		final var response = jdFacade.getJdList(mockPageInfoRequest, keyword);
+
+		//then
+		Assertions.assertThat(response).isNotNull();
+		verify(jdService, times(1)).getJdList(mockPageInfoRequest, keyword);
+	}
+}

--- a/module-api/src/test/java/kernel/jdon/moduleapi/domain/jd/core/JdServiceImplTest.java
+++ b/module-api/src/test/java/kernel/jdon/moduleapi/domain/jd/core/JdServiceImplTest.java
@@ -1,0 +1,70 @@
+package kernel.jdon.moduleapi.domain.jd.core;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import kernel.jdon.moduleapi.global.page.PageInfoRequest;
+import kernel.jdon.moduledomain.wantedjd.domain.WantedJd;
+
+@DisplayName("Jd Service Impl 테스트")
+@ExtendWith(MockitoExtension.class)
+class JdServiceImplTest {
+	@InjectMocks
+	private JdServiceImpl jdServiceImpl;
+	@Mock
+	private JdReader jdReader;
+	@Mock
+	private JdInfoMapper jdInfoMapper;
+
+	@Test
+	@DisplayName("1: 올바른 jdId가 주어졌을 때 getJd 메서드가 jd 상세정보와 스킬목록을 반환한다.")
+	void givenValidJdId_whenGetJd_thenReturnCorrectJd() throws Exception {
+		//given
+		final var jdId = 1L;
+		final var wantedJd = mock(WantedJd.class);
+		final var skillList = List.of(
+			mock(JdInfo.FindSkill.class),
+			mock(JdInfo.FindSkill.class));
+		final var findWantedJdResponse = JdInfo.FindWantedJdResponse.builder()
+			.id(jdId)
+			.skillList(skillList)
+			.build();
+
+		//when
+		when(jdReader.findWantedJd(jdId)).thenReturn(wantedJd);
+		when(jdReader.findSkillListByWantedJd(wantedJd)).thenReturn(skillList);
+		when(jdInfoMapper.of(wantedJd, skillList)).thenReturn(findWantedJdResponse);
+		final var response = jdServiceImpl.getJd(jdId);
+
+		//then
+		assertThat(response.getSkillList()).isEqualTo(skillList);
+		verify(jdReader, times(1)).findWantedJd(jdId);
+		verify(jdReader, times(1)).findSkillListByWantedJd(wantedJd);
+	}
+
+	@Test
+	@DisplayName("2: 올바른 keyword가 주어졌을 때 getJdList가 jd 목록을 반환한다.")
+	void givenValidKeyword_whenGetJdList_thenReturnCorrectJdList() throws Exception {
+		//given
+		final var keyword = "keyword";
+		final var mockPageInfoRequest = mock(PageInfoRequest.class);
+		final var mockFindWantedJdListResponse = mock(JdInfo.FindWantedJdListResponse.class);
+
+		//when
+		when(jdReader.findWantedJdList(mockPageInfoRequest, keyword)).thenReturn(mockFindWantedJdListResponse);
+		final var response = jdServiceImpl.getJdList(mockPageInfoRequest, keyword);
+
+		//then
+		assertThat(response).isNotNull();
+		verify(jdReader, times(1)).findWantedJdList(mockPageInfoRequest, keyword);
+	}
+}


### PR DESCRIPTION
## 개요

### 요약
Jd 도메인의 Facade와 ServiceImpl 단위 테스트 코드를 작성했습니다.

### 변경한 부분
- 단순 조회 로직이기 때문에 모킹한 값이 잘 반환되는지를 비교했습니다.
- mock 객체이기 때문에 내부 값을 비교하기보다 존재 유무를 통해 테스트 통과 유무를 구분했습니다.

### 변경한 결과
![image](https://github.com/Kernel360/f1-JDON-#401 end/assets/59242594/558c43a8-974b-4016-81f3-7bc939e8899d)


### 이슈

- closes: #401

---

## PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경, 주석 변경)
- [ ] 코드 리팩토링
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 파일 혹은 폴더명 수정, 삭제
- [ ] 배포 관련