### PR TITLE
Refactor: Review 등록 Factory 적용

### DIFF
--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/review/core/ReviewFactory.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/review/core/ReviewFactory.java
@@ -1,0 +1,7 @@
+package kernel.jdon.moduleapi.domain.review.core;
+
+import kernel.jdon.moduledomain.review.domain.Review;
+
+public interface ReviewFactory {
+	Review saveReview(ReviewCommand.CreateReviewRequest command);
+}

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/review/core/ReviewServiceImpl.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/review/core/ReviewServiceImpl.java
@@ -3,14 +3,10 @@ package kernel.jdon.moduleapi.domain.review.core;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import kernel.jdon.moduledomain.member.domain.Member;
-import kernel.jdon.moduleapi.domain.jd.core.JdReader;
-import kernel.jdon.moduleapi.domain.member.core.MemberReader;
 import kernel.jdon.moduleapi.domain.review.error.ReviewErrorCode;
 import kernel.jdon.moduleapi.global.exception.ApiException;
 import kernel.jdon.moduleapi.global.page.PageInfoRequest;
 import kernel.jdon.moduledomain.review.domain.Review;
-import kernel.jdon.moduledomain.wantedjd.domain.WantedJd;
 import lombok.RequiredArgsConstructor;
 
 @Service
@@ -19,15 +15,12 @@ import lombok.RequiredArgsConstructor;
 public class ReviewServiceImpl implements ReviewService {
 	private final ReviewStore reviewStore;
 	private final ReviewReader reviewReader;
-	private final JdReader jdReader;
-	private final MemberReader memberReader;
+	private final ReviewFactory reviewFactory;
 
 	@Override
 	@Transactional
 	public ReviewInfo.CreateReviewResponse createReview(final ReviewCommand.CreateReviewRequest command) {
-		final Member findMember = memberReader.findById(command.getMemberId());
-		final WantedJd findWantedJd = jdReader.findWantedJd(command.getJdId());
-		final Review savedReview = reviewStore.save(command.toEntity(findMember, findWantedJd));
+		final Review savedReview = reviewFactory.saveReview(command);
 
 		return new ReviewInfo.CreateReviewResponse(savedReview.getId());
 	}

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/review/infrastructure/ReviewFactoryImpl.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/review/infrastructure/ReviewFactoryImpl.java
@@ -1,0 +1,29 @@
+package kernel.jdon.moduleapi.domain.review.infrastructure;
+
+import org.springframework.stereotype.Component;
+
+import kernel.jdon.moduleapi.domain.jd.core.JdReader;
+import kernel.jdon.moduleapi.domain.member.core.MemberReader;
+import kernel.jdon.moduleapi.domain.review.core.ReviewCommand;
+import kernel.jdon.moduleapi.domain.review.core.ReviewFactory;
+import kernel.jdon.moduleapi.domain.review.core.ReviewStore;
+import kernel.jdon.moduledomain.member.domain.Member;
+import kernel.jdon.moduledomain.review.domain.Review;
+import kernel.jdon.moduledomain.wantedjd.domain.WantedJd;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class ReviewFactoryImpl implements ReviewFactory {
+	private final MemberReader memberReader;
+	private final JdReader jdReader;
+	private final ReviewStore reviewStore;
+
+	public Review saveReview(final ReviewCommand.CreateReviewRequest command) {
+		final Member findMember = memberReader.findById(command.getMemberId());
+		final WantedJd findWantedJd = jdReader.findWantedJd(command.getJdId());
+
+		return reviewStore.save(command.toEntity(findMember, findWantedJd));
+	}
+
+}


### PR DESCRIPTION
## 개요

### 요약
- 엔티티를 저장할 때 연관관계의 주인이 포함된 엔티티를 저장해야할 경우 도메인 레이어인 serviceImpl에서는 해당 도메인을 등록하라는 메시지만 보내고, 그 엔티티를 저장하기 위해 연관관계가 매핑된 엔티티를 불러오는 로직은 인프라스트럭처 레이어의 Factory 에서 구현할 수 있도록 리팩토링 했습니다.

### 변경한 부분
- 기존의 리뷰를 저장하기위해 ReviewServiceImpl에서 Member와 WantedJd 엔티티를 persist후 Review를 저장했으나 해당 엔티티를 저장하기위해 데이터를 Reader하는 책임을 Factory가 가지도록 변경하고 ReviewServiceImpl 엔티티에서는 Review 엔티티를 저장하라는 메시지를 Factory에게 전달하도록  변경하였습니다.

### 변경한 결과
- api 정상 동작 확인했습니다.
<img width="471" alt="image" src="https://github.com/Kernel360/f1-JDON-Backend/assets/59242594/a3412a89-1716-4d2f-8de8-fb04af9ffe67">


### 이슈

- closes: #405 

---

## PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경, 주석 변경)
- [x] 코드 리팩토링
- [ ] 문서 수정
- [x] 테스트 추가, 테스트 리팩토링
- [ ] 파일 혹은 폴더명 수정, 삭제
- [ ] 배포 관련