### PR TITLE
Test: 회원가입, 닉네임 중복확인 API | TEST code 작성 

### DIFF
--- a/module-api/src/test/java/kernel/jdon/moduleapi/domain/member/application/MemberFacadeTest.java
+++ b/module-api/src/test/java/kernel/jdon/moduleapi/domain/member/application/MemberFacadeTest.java
@@ -58,4 +58,37 @@ class MemberFacadeTest {
 		//verify
 		verify(memberService, times(1)).modifyMember(modifyMemberId, mockModifyMemberCommand);
 	}
+
+	@Test
+	@DisplayName("3: 사용자 아이디와 정보 수정 정보가 주어졌을 때, modify 메서드가 수정을 마친 memberId를 응답으로 반환한다.")
+	void givenNickname_whenCheckNicknameDuplicate() {
+		//given
+		final var mockCommand = mock(MemberCommand.NicknameDuplicateRequest.class);
+
+		//when
+		doNothing().when(memberService).checkNicknameDuplicate(any(MemberCommand.NicknameDuplicateRequest.class));
+		memberFacade.checkNicknameDuplicate(mockCommand);
+
+		//verify
+		verify(memberService, times(1)).checkNicknameDuplicate(any(MemberCommand.NicknameDuplicateRequest.class));
+	}
+
+	@Test
+	@DisplayName("4: 사용자 등록 정보가 주어졌을 때, register 메서드가 등록을 마친 memberId를 응답으로 반환한다.")
+	void givenRegisterInfo_whenRegister_thenReturnMemberId() {
+		//given
+		final var mockCommand = mock(MemberCommand.RegisterRequest.class);
+		final var mockResponse = MemberInfo.RegisterResponse.of(1L);
+
+		//when
+		when(memberService.register(mockCommand)).thenReturn(mockResponse);
+		final var response = memberFacade.register(mockCommand);
+
+		//then
+		assertThat(response).isEqualTo(mockResponse);
+		assertThat(response.getMemberId()).isEqualTo(mockResponse.getMemberId());
+
+		//verify
+		verify(memberService, times(1)).register(mockCommand);
+	}
 }

--- a/module-api/src/test/java/kernel/jdon/moduleapi/domain/member/application/MemberFacadeTest.java
+++ b/module-api/src/test/java/kernel/jdon/moduleapi/domain/member/application/MemberFacadeTest.java
@@ -60,7 +60,7 @@ class MemberFacadeTest {
 	}
 
 	@Test
-	@DisplayName("3: 사용자 아이디와 정보 수정 정보가 주어졌을 때, modify 메서드가 수정을 마친 memberId를 응답으로 반환한다.")
+	@DisplayName("3: 닉네임이 주어졌을 때, checkNicknameDuplicate 메서드가 service의 checkNicknameDuplicate를 실행한다.")
 	void givenNickname_whenCheckNicknameDuplicate() {
 		//given
 		final var mockCommand = mock(MemberCommand.NicknameDuplicateRequest.class);

--- a/module-api/src/test/java/kernel/jdon/moduleapi/domain/member/core/MemberServiceImplTest.java
+++ b/module-api/src/test/java/kernel/jdon/moduleapi/domain/member/core/MemberServiceImplTest.java
@@ -90,26 +90,26 @@ class MemberServiceImplTest {
 	@DisplayName("3: 닉네임 중복 확인 요청 시, checkNicknameDuplicate 메서드가 중복 닉네임이 아니면 아무것도 반환하지 않는다.")
 	void givenNickname_whenNicknameIsNotDuplicate() {
 		//given
-		final var mockCommand = mockNicknameDuplicateCommand();
+		final var mockNicknameDuplicateCommand = mockNicknameDuplicateCommand();
 
 		//when
-		when(memberReader.existsByNickname(mockCommand.getNickname())).thenReturn(false);
-		memberService.checkNicknameDuplicate(mockCommand);
+		when(memberReader.existsByNickname(mockNicknameDuplicateCommand.getNickname())).thenReturn(false);
+		memberService.checkNicknameDuplicate(mockNicknameDuplicateCommand);
 
 		//verify
-		verify(memberReader, times(1)).existsByNickname(mockCommand.getNickname());
+		verify(memberReader, times(1)).existsByNickname(mockNicknameDuplicateCommand.getNickname());
 	}
 
 	@Test
 	@DisplayName("4: 닉네임 중복 확인 요청 시, checkNicknameDuplicate 메서드가 중복 닉네임이면 409 에러를 던진다.")
 	void givenNickname_whenNicknameIsDuplicate_thenThrowConflictError() {
 		//given
-		final var mockCommand = mock(MemberCommand.NicknameDuplicateRequest.class);
+		final var mockNicknameDuplicateCommand = mock(MemberCommand.NicknameDuplicateRequest.class);
 
 		//when
-		when(memberReader.existsByNickname(mockCommand.getNickname())).thenReturn(true);
+		when(memberReader.existsByNickname(mockNicknameDuplicateCommand.getNickname())).thenReturn(true);
 		ApiException thrownException = assertThrows(ApiException.class,
-			() -> memberService.checkNicknameDuplicate(mockCommand));
+			() -> memberService.checkNicknameDuplicate(mockNicknameDuplicateCommand));
 
 		// then
 		assertThat(thrownException.getErrorCode().getHttpStatus().value()).isEqualTo(HttpStatus.CONFLICT.value());
@@ -117,29 +117,29 @@ class MemberServiceImplTest {
 			MemberErrorCode.CONFLICT_DUPLICATE_NICKNAME.getMessage());
 
 		//verify
-		verify(memberReader, times(1)).existsByNickname(mockCommand.getNickname());
+		verify(memberReader, times(1)).existsByNickname(mockNicknameDuplicateCommand.getNickname());
 	}
 
 	@Test
 	@DisplayName("5: 사용자 등록 요청 시, register 메서드가 동작 결과로 등록한 memberId를 응답으로 반환한다.")
 	void givenRegisterInfo_whenRegisterMember_thenReturnMemberId() {
 		//given
-		final var mockCommand = mockRegisterCommand();
+		final var mockRegisterCommand = mockRegisterCommand();
 		final var mockUserInfo = Map.of("nickname", "nickname", "email", "email");
 		final var mockSavedMember = mockMember();
 
 		//when
-		when(cryptoManager.getUserInfoFromAuthProvider(mockCommand.getHmac(), mockCommand.getEncrypted()))
-			.thenReturn(mockUserInfo);
-		when(memberFactory.save(mockCommand, mockUserInfo)).thenReturn(mockSavedMember);
-		final var response = memberService.register(mockCommand);
+		when(cryptoManager.getUserInfoFromAuthProvider(mockRegisterCommand.getHmac(),
+			mockRegisterCommand.getEncrypted())).thenReturn(mockUserInfo);
+		when(memberFactory.save(mockRegisterCommand, mockUserInfo)).thenReturn(mockSavedMember);
+		final var response = memberService.register(mockRegisterCommand);
 
 		//then
 		assertThat(response.getMemberId()).isEqualTo(mockSavedMember.getId());
 
 		//verify
 		verify(cryptoManager, times(1)).getUserInfoFromAuthProvider("hmac", "encrypted");
-		verify(memberFactory, times(1)).save(mockCommand, mockUserInfo);
+		verify(memberFactory, times(1)).save(mockRegisterCommand, mockUserInfo);
 	}
 
 	private Member mockMember() {


### PR DESCRIPTION
## 개요

### 요약

### 변경한 부분
- 회원가입 API test
- 닉네임 중복 확인 API test

### 변경한 결과
- member facade test
![image](https://github.com/Kernel360/f1-JDON-Backend/assets/68376744/a084e4c2-a55a-4025-abae-b0934b0dd035)

- member service test
![image](https://github.com/Kernel360/f1-JDON-Backend/assets/68376744/0a9ff7fb-73c9-4284-85fc-8a04b1c20ea2)

- member factory test
![image](https://github.com/Kernel360/f1-JDON-Backend/assets/68376744/007f241f-7985-4bdb-8f7b-cfba2dccb077)

### 이슈

- closes: #403 

---

## PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경, 주석 변경)
- [ ] 코드 리팩토링
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 파일 혹은 폴더명 수정, 삭제
- [ ] 배포 관련