### PR TITLE
Test: 회원탈퇴 API | TEST code 작성

### DIFF
--- a/module-api/src/test/java/kernel/jdon/moduleapi/domain/member/application/MemberFacadeTest.java
+++ b/module-api/src/test/java/kernel/jdon/moduleapi/domain/member/application/MemberFacadeTest.java
@@ -1,6 +1,7 @@
 package kernel.jdon.moduleapi.domain.member.application;
 
 import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 import org.junit.jupiter.api.DisplayName;
@@ -9,16 +10,24 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
 
+import kernel.jdon.moduleapi.domain.auth.core.CustomOAuth2UserService;
+import kernel.jdon.moduleapi.domain.auth.error.AuthErrorCode;
 import kernel.jdon.moduleapi.domain.member.core.MemberCommand;
 import kernel.jdon.moduleapi.domain.member.core.MemberInfo;
 import kernel.jdon.moduleapi.domain.member.core.MemberService;
+import kernel.jdon.moduleapi.global.exception.ApiException;
 
 @ExtendWith(MockitoExtension.class)
 @DisplayName("Member Facade 테스트")
 class MemberFacadeTest {
 	@Mock
 	private MemberService memberService;
+
+	@Mock
+	private CustomOAuth2UserService customOAuth2UserService;
+
 	@InjectMocks
 	private MemberFacade memberFacade;
 
@@ -90,5 +99,54 @@ class MemberFacadeTest {
 
 		//verify
 		verify(memberService, times(1)).register(mockCommand);
+	}
+
+	@Test
+	@DisplayName("5: 사용자 탈퇴 정보가 주어졌을 때, withdraw 메서드가 탈퇴 성공하면 탈퇴한 memberId를 응답으로 반환한다.")
+	void givenWithdrawInfo_whenWithdraw_thenReturnWithdrawMemberId() {
+		//given
+		final var mockWithdrawCommand = mockWithdrawCommand();
+		final var mockWithdrawResponse = MemberInfo.WithdrawResponse.of(mockWithdrawCommand.getId());
+
+		//when
+		when(customOAuth2UserService.sendDeleteRequestToOAuth2(mockWithdrawCommand)).thenReturn(true);
+		when(memberService.removeMember(mockWithdrawCommand)).thenReturn(mockWithdrawResponse);
+		final var response = memberFacade.withdrawMember(mockWithdrawCommand);
+
+		//then
+		assertThat(response).isEqualTo(mockWithdrawResponse);
+		assertThat(response.getMemberId()).isEqualTo(mockWithdrawResponse.getMemberId());
+
+		//verify
+		verify(customOAuth2UserService, times(1)).sendDeleteRequestToOAuth2(mockWithdrawCommand);
+		verify(memberService, times(1)).removeMember(mockWithdrawCommand);
+	}
+
+	@Test
+	@DisplayName("6: 사용자 탈퇴 정보가 주어졌을 때, withdraw 메서드가 탈퇴 실패하면 500 에러를 던진다.")
+	void givenWithdrawInfo_whenWithdraw_thenThrowException() {
+		//given
+		final var mockWithdrawCommand = mockWithdrawCommand();
+
+		//when
+		when(customOAuth2UserService.sendDeleteRequestToOAuth2(mockWithdrawCommand)).thenReturn(false);
+		final var thrownException = assertThrows(ApiException.class,
+			() -> memberFacade.withdrawMember(mockWithdrawCommand));
+
+		// then
+		assertThat(thrownException.getErrorCode().getHttpStatus().value())
+			.isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR.value());
+		assertThat(thrownException.getErrorCode().getMessage())
+			.isEqualTo(AuthErrorCode.ERROR_FAIL_TO_UNLINK_OAUTH2.getMessage());
+
+		//verify
+		verify(customOAuth2UserService, times(1)).sendDeleteRequestToOAuth2(mockWithdrawCommand);
+		verify(memberService, times(0)).removeMember(mockWithdrawCommand);
+	}
+
+	private MemberCommand.WithdrawRequest mockWithdrawCommand() {
+		return MemberCommand.WithdrawRequest.builder()
+			.id(1L)
+			.build();
 	}
 }

--- a/module-api/src/test/java/kernel/jdon/moduleapi/domain/member/application/MemberFacadeTest.java
+++ b/module-api/src/test/java/kernel/jdon/moduleapi/domain/member/application/MemberFacadeTest.java
@@ -33,7 +33,7 @@ class MemberFacadeTest {
 
 	@Test
 	@DisplayName("1: 사용자 정보 요청 시, get 메서드가 memberId에 해당되는 멤버의 정보를 응답으로 반환한다.")
-	void whenGetMemberInfo_thenReturnMemberInfo() {
+	void whenGetMemberId_thenReturnMemberInfo() {
 		//given
 		final var memberId = 1L;
 		final var mockFindMemberResponse = mock(MemberInfo.FindMemberResponse.class);
@@ -51,7 +51,7 @@ class MemberFacadeTest {
 
 	@Test
 	@DisplayName("2: 사용자 아이디와 정보 수정 정보가 주어졌을 때, modify 메서드가 수정을 마친 memberId를 응답으로 반환한다.")
-	void givenMemberIdAndMemberModifyInfo_whenModifyMember_thenReturnModifiedMemberId() {
+	void givenMemberIdAndMemberModifyCommand_whenModifyMember_thenReturnModifiedMemberId() {
 		//given
 		final var modifyMemberId = 1L;
 		final var mockModifyMemberCommand = mock(MemberCommand.UpdateMemberRequest.class);
@@ -84,7 +84,7 @@ class MemberFacadeTest {
 
 	@Test
 	@DisplayName("4: 사용자 등록 정보가 주어졌을 때, register 메서드가 등록을 마친 memberId를 응답으로 반환한다.")
-	void givenRegisterInfo_whenRegister_thenReturnMemberId() {
+	void givenRegisterCommand_whenRegister_thenReturnMemberId() {
 		//given
 		final var mockCommand = mock(MemberCommand.RegisterRequest.class);
 		final var mockResponse = MemberInfo.RegisterResponse.of(1L);
@@ -103,7 +103,7 @@ class MemberFacadeTest {
 
 	@Test
 	@DisplayName("5: 사용자 탈퇴 정보가 주어졌을 때, withdraw 메서드가 탈퇴 성공하면 탈퇴한 memberId를 응답으로 반환한다.")
-	void givenWithdrawInfo_whenWithdraw_thenReturnWithdrawMemberId() {
+	void givenWithdrawCommand_whenWithdraw_thenReturnWithdrawMemberId() {
 		//given
 		final var mockWithdrawCommand = mockWithdrawCommand();
 		final var mockWithdrawResponse = MemberInfo.WithdrawResponse.of(mockWithdrawCommand.getId());
@@ -124,7 +124,7 @@ class MemberFacadeTest {
 
 	@Test
 	@DisplayName("6: 사용자 탈퇴 정보가 주어졌을 때, withdraw 메서드가 탈퇴 실패하면 500 에러를 던진다.")
-	void givenWithdrawInfo_whenWithdraw_thenThrowException() {
+	void givenWithdrawCommand_whenWithdraw_thenThrowServerErrorException() {
 		//given
 		final var mockWithdrawCommand = mockWithdrawCommand();
 

--- a/module-api/src/test/java/kernel/jdon/moduleapi/domain/member/core/MemberServiceImplTest.java
+++ b/module-api/src/test/java/kernel/jdon/moduleapi/domain/member/core/MemberServiceImplTest.java
@@ -15,7 +15,6 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
 
-import kernel.jdon.moduleapi.domain.member.error.MemberErrorCode;
 import kernel.jdon.moduleapi.domain.auth.util.CryptoManager;
 import kernel.jdon.moduleapi.domain.member.error.MemberErrorCode;
 import kernel.jdon.moduleapi.domain.member.infrastructure.MemberFactoryImpl;

--- a/module-api/src/test/java/kernel/jdon/moduleapi/domain/member/core/MemberServiceImplTest.java
+++ b/module-api/src/test/java/kernel/jdon/moduleapi/domain/member/core/MemberServiceImplTest.java
@@ -15,6 +15,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
 
+import kernel.jdon.moduleapi.domain.member.error.MemberErrorCode;
 import kernel.jdon.moduleapi.domain.auth.util.CryptoManager;
 import kernel.jdon.moduleapi.domain.member.error.MemberErrorCode;
 import kernel.jdon.moduleapi.domain.member.infrastructure.MemberFactoryImpl;

--- a/module-api/src/test/java/kernel/jdon/moduleapi/domain/member/core/MemberServiceImplTest.java
+++ b/module-api/src/test/java/kernel/jdon/moduleapi/domain/member/core/MemberServiceImplTest.java
@@ -38,6 +38,9 @@ class MemberServiceImplTest {
 	@Mock
 	private CryptoManager cryptoManager;
 
+	@Mock
+	private MemberStore memberStore;
+
 	@InjectMocks
 	private MemberServiceImpl memberService;
 
@@ -140,6 +143,24 @@ class MemberServiceImplTest {
 		//verify
 		verify(cryptoManager, times(1)).getUserInfoFromAuthProvider("hmac", "encrypted");
 		verify(memberFactory, times(1)).save(mockRegisterCommand, mockUserInfo);
+	}
+
+	@Test
+	@DisplayName("6: 사용자 탈퇴 요청 시, remove 메서드가 동작 결과로 탈퇴한 memberId를 응답으로 반환한다.")
+	void givenWithdrawCommand_whenRemoveMember_thenReturnMemberId() {
+		//given
+		final var mockWithdrawCommand = MemberCommand.WithdrawRequest.builder().id(1L).build();
+		final var mockWithdrawResponse = MemberInfo.WithdrawResponse.of(mockWithdrawCommand.getId());
+
+		//when
+		doNothing().when(memberStore).updateAccountStatusWithdrawById(mockWithdrawCommand.getId());
+		final var response = memberService.removeMember(mockWithdrawCommand);
+
+		//then
+		assertThat(response.getMemberId()).isEqualTo(mockWithdrawResponse.getMemberId());
+
+		//verify
+		verify(memberStore, times(1)).updateAccountStatusWithdrawById(mockWithdrawCommand.getId());
 	}
 
 	private Member mockMember() {

--- a/module-api/src/test/java/kernel/jdon/moduleapi/domain/member/core/MemberServiceImplTest.java
+++ b/module-api/src/test/java/kernel/jdon/moduleapi/domain/member/core/MemberServiceImplTest.java
@@ -71,7 +71,7 @@ class MemberServiceImplTest {
 
 	@Test
 	@DisplayName("2: 사용자 정보 수정 요청 시, modify 메서드가 동작 결과로 memberId를 응답으로 반환한다.")
-	void givenMemberUpdateInfo_whenModifyMember_thenReturnMemberId() {
+	void givenMemberUpdateCommand_whenModifyMember_thenReturnMemberId() {
 		//given
 		final var mockFindMember = mockMember();
 		final var memberId = mockFindMember.getId();
@@ -125,7 +125,7 @@ class MemberServiceImplTest {
 
 	@Test
 	@DisplayName("5: 사용자 등록 요청 시, register 메서드가 동작 결과로 등록한 memberId를 응답으로 반환한다.")
-	void givenRegisterInfo_whenRegisterMember_thenReturnMemberId() {
+	void givenRegisterCommand_whenRegisterMember_thenReturnMemberId() {
 		//given
 		final var mockRegisterCommand = mockRegisterCommand();
 		final var mockUserInfo = Map.of("nickname", "nickname", "email", "email");

--- a/module-api/src/test/java/kernel/jdon/moduleapi/domain/member/infrastructure/MemberFactoryImplTest.java
+++ b/module-api/src/test/java/kernel/jdon/moduleapi/domain/member/infrastructure/MemberFactoryImplTest.java
@@ -43,7 +43,7 @@ class MemberFactoryImplTest {
 
 	@Test
 	@DisplayName("1: member와 사용자 수정 정보가 주어지고 정보 수정 요청 시, update 메서드가 member를 업데이트한다.")
-	void givenMemberAndUpdateInfo_whenUpdate() {
+	void givenMemberAndUpdateCommand_whenUpdate() {
 		//given
 		final var mockMember = mockMember();
 		final var mockUpdateCommand = mockUpdateCommand();
@@ -66,7 +66,7 @@ class MemberFactoryImplTest {
 
 	@Test
 	@DisplayName("2: 회원가입 정보가 주어지면, save 메서드가 저장한 Member를 반환한다.")
-	void givenRegisterInfo_whenSave_thenReturnSavedMember() {
+	void givenRegisterCommand_whenSave_thenReturnSavedMember() {
 		//given
 		final var mockRegisterCommand = mockRegisterCommand();
 		final var mockUserInfo = Map.of("email", "email", "provider", "kakao");


### PR DESCRIPTION
## 개요

### 요약

### 변경한 부분
- 회원 탈퇴 API test code 작성했습니다. 

### 변경한 결과
- member facade test
![image](https://github.com/Kernel360/f1-JDON-Backend/assets/68376744/6222dc50-c5bb-4890-9720-7c9b14a06363)

- member service test
![image](https://github.com/Kernel360/f1-JDON-Backend/assets/68376744/638f33ea-ee09-472a-8830-b2091ca8c16b)


### 이슈

- closes: #409

---

## PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경, 주석 변경)
- [ ] 코드 리팩토링
- [ ] 문서 수정
- [x] 테스트 추가, 테스트 리팩토링
- [ ] 파일 혹은 폴더명 수정, 삭제
- [ ] 배포 관련