### PR TITLE
Feat: 커피챗 신청 취소 API 구현

### DIFF
--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/coffeechat/application/CoffeeChatFacade.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/coffeechat/application/CoffeeChatFacade.java
@@ -83,4 +83,8 @@ public class CoffeeChatFacade {
             lock.unlock();
         }
     }
+
+    public CoffeeChatInfo.CanceledCoffeeChatResponse cancelCoffeeChatApplication(Long coffeeChatId, Long memberId) {
+        return coffeeChatService.cancelCoffeeChat(coffeeChatId, memberId);
+    }
 }

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/coffeechat/application/CoffeeChatFacade.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/coffeechat/application/CoffeeChatFacade.java
@@ -84,7 +84,7 @@ public class CoffeeChatFacade {
         }
     }
 
-    public CoffeeChatInfo.CanceledCoffeeChatResponse cancelCoffeeChatApplication(Long coffeeChatId, Long memberId) {
+    public CoffeeChatInfo.CancelCoffeeChatResponse cancelCoffeeChatApplication(Long coffeeChatId, Long memberId) {
         return coffeeChatService.cancelCoffeeChat(coffeeChatId, memberId);
     }
 }

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/coffeechat/application/CoffeeChatFacade.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/coffeechat/application/CoffeeChatFacade.java
@@ -41,17 +41,17 @@ public class CoffeeChatFacade {
         return findCoffeeChatResponse;
     }
 
-    public CoffeeChatInfo.CreatedCoffeeChatResponse createCoffeeChat(CoffeeChatCommand.CreateCoffeeChatRequest request,
+    public CoffeeChatInfo.CreateCoffeeChatResponse createCoffeeChat(CoffeeChatCommand.CreateCoffeeChatRequest request,
         Long memberId) {
         return coffeeChatService.createCoffeeChat(request, memberId);
     }
 
-    public CoffeeChatInfo.UpdatedCoffeeChatResponse modifyCoffeeChat(CoffeeChatCommand.UpdateCoffeeChatRequest request,
+    public CoffeeChatInfo.UpdateCoffeeChatResponse modifyCoffeeChat(CoffeeChatCommand.UpdateCoffeeChatRequest request,
         Long coffeeChatId) {
         return coffeeChatService.modifyCoffeeChat(request, coffeeChatId);
     }
 
-    public CoffeeChatInfo.DeletedCoffeeChatResponse deleteCoffeeChat(Long coffeeChatId) {
+    public CoffeeChatInfo.DeleteCoffeeChatResponse deleteCoffeeChat(Long coffeeChatId) {
         return coffeeChatService.deleteCoffeeChat(coffeeChatId);
     }
 
@@ -64,7 +64,7 @@ public class CoffeeChatFacade {
         return coffeeChatService.getHostCoffeeChatList(memberId, pageable);
     }
 
-    public CoffeeChatInfo.AppliedCoffeeChatResponse applyCoffeeChat(Long coffeeChatId, Long memberId) {
+    public CoffeeChatInfo.ApplyCoffeeChatResponse applyCoffeeChat(Long coffeeChatId, Long memberId) {
         RLock lock = redissonClient.getLock(String.format("apply:coffeeChat:%d", coffeeChatId));
         try {
             boolean available = lock.tryLock(lockConfig.getWaitTime(), lockConfig.getLeaseTime(),

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/coffeechat/core/CoffeeChatInfo.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/coffeechat/core/CoffeeChatInfo.java
@@ -107,7 +107,7 @@ public class CoffeeChatInfo {
 
     @Getter
     @Builder
-    public static class CanceledCoffeeChatResponse {
+    public static class CancelCoffeeChatResponse {
         private final Long coffeeChatId;
     }
 }

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/coffeechat/core/CoffeeChatInfo.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/coffeechat/core/CoffeeChatInfo.java
@@ -104,4 +104,10 @@ public class CoffeeChatInfo {
                 .build();
         }
     }
+
+    @Getter
+    @Builder
+    public static class CanceledCoffeeChatResponse {
+        private final Long coffeeChatId;
+    }
 }

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/coffeechat/core/CoffeeChatInfo.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/coffeechat/core/CoffeeChatInfo.java
@@ -17,25 +17,25 @@ public class CoffeeChatInfo {
 
     @Getter
     @Builder
-    public static class UpdatedCoffeeChatResponse {
+    public static class UpdateCoffeeChatResponse {
         private final Long coffeeChatId;
     }
 
     @Getter
     @Builder
-    public static class CreatedCoffeeChatResponse {
+    public static class CreateCoffeeChatResponse {
         private final Long coffeeChatId;
     }
 
     @Getter
     @Builder
-    public static class AppliedCoffeeChatResponse {
+    public static class ApplyCoffeeChatResponse {
         private final Long coffeeChatId;
     }
 
     @Getter
     @Builder
-    public static class DeletedCoffeeChatResponse {
+    public static class DeleteCoffeeChatResponse {
         private final Long coffeeChatId;
     }
 

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/coffeechat/core/CoffeeChatReader.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/coffeechat/core/CoffeeChatReader.java
@@ -3,9 +3,9 @@ package kernel.jdon.moduleapi.domain.coffeechat.core;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
+import kernel.jdon.moduleapi.global.page.PageInfoRequest;
 import kernel.jdon.moduledomain.coffeechat.domain.CoffeeChat;
 import kernel.jdon.moduledomain.coffeechatmember.domain.CoffeeChatMember;
-import kernel.jdon.moduleapi.global.page.PageInfoRequest;
 
 public interface CoffeeChatReader {
     CoffeeChat findExistCoffeeChat(Long coffeeChatId);
@@ -19,4 +19,5 @@ public interface CoffeeChatReader {
 
     boolean existsByCoffeeChatIdAndMemberId(Long coffeeChatId, Long memberId);
 
+    CoffeeChatMember findCoffeeChatMember(Long coffeeChatId, Long memberId);
 }

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/coffeechat/core/CoffeeChatService.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/coffeechat/core/CoffeeChatService.java
@@ -12,21 +12,21 @@ public interface CoffeeChatService {
 
     CoffeeChatInfo.FindCoffeeChatResponse getCoffeeChat(Long coffeeChatId, Long memberId);
 
-    CoffeeChatInfo.CreatedCoffeeChatResponse createCoffeeChat(CoffeeChatCommand.CreateCoffeeChatRequest request,
+    CoffeeChatInfo.CreateCoffeeChatResponse createCoffeeChat(CoffeeChatCommand.CreateCoffeeChatRequest request,
         Long memberId);
 
     void increaseViewCount(Long coffeeChatId);
 
-    CoffeeChatInfo.UpdatedCoffeeChatResponse modifyCoffeeChat(CoffeeChatCommand.UpdateCoffeeChatRequest request,
+    CoffeeChatInfo.UpdateCoffeeChatResponse modifyCoffeeChat(CoffeeChatCommand.UpdateCoffeeChatRequest request,
         Long coffeeChatId);
 
-    CoffeeChatInfo.DeletedCoffeeChatResponse deleteCoffeeChat(Long coffeeChatId);
+    CoffeeChatInfo.DeleteCoffeeChatResponse deleteCoffeeChat(Long coffeeChatId);
 
     CustomPageResponse getGuestCoffeeChatList(Long memberId, Pageable pageable);
 
     CustomPageResponse getHostCoffeeChatList(Long memberId, Pageable pageable);
 
-    CoffeeChatInfo.AppliedCoffeeChatResponse applyCoffeeChat(Long coffeeChatId, Long memberId);
+    CoffeeChatInfo.ApplyCoffeeChatResponse applyCoffeeChat(Long coffeeChatId, Long memberId);
 
     CoffeeChatInfo.CanceledCoffeeChatResponse cancelCoffeeChat(Long coffeeChatId, Long memberId);
 }

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/coffeechat/core/CoffeeChatService.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/coffeechat/core/CoffeeChatService.java
@@ -28,5 +28,5 @@ public interface CoffeeChatService {
 
     CoffeeChatInfo.ApplyCoffeeChatResponse applyCoffeeChat(Long coffeeChatId, Long memberId);
 
-    CoffeeChatInfo.CanceledCoffeeChatResponse cancelCoffeeChat(Long coffeeChatId, Long memberId);
+    CoffeeChatInfo.CancelCoffeeChatResponse cancelCoffeeChat(Long coffeeChatId, Long memberId);
 }

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/coffeechat/core/CoffeeChatService.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/coffeechat/core/CoffeeChatService.java
@@ -27,4 +27,6 @@ public interface CoffeeChatService {
     CustomPageResponse getHostCoffeeChatList(Long memberId, Pageable pageable);
 
     CoffeeChatInfo.AppliedCoffeeChatResponse applyCoffeeChat(Long coffeeChatId, Long memberId);
+
+    CoffeeChatInfo.CanceledCoffeeChatResponse cancelCoffeeChat(Long coffeeChatId, Long memberId);
 }

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/coffeechat/core/CoffeeChatServiceImpl.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/coffeechat/core/CoffeeChatServiceImpl.java
@@ -177,13 +177,13 @@ public class CoffeeChatServiceImpl implements CoffeeChatService {
 
     @Override
     @Transactional
-    public CoffeeChatInfo.CanceledCoffeeChatResponse cancelCoffeeChat(Long coffeeChatId, Long memberId) {
+    public CoffeeChatInfo.CancelCoffeeChatResponse cancelCoffeeChat(Long coffeeChatId, Long memberId) {
         CoffeeChat findCoffeeChat = coffeeChatReader.findExistCoffeeChat(coffeeChatId);
 
         CoffeeChatMember findCoffeeChatMember = coffeeChatReader.findCoffeeChatMember(coffeeChatId, memberId);
         coffeeChatStore.cancel(findCoffeeChat, findCoffeeChatMember);
 
-        return new CoffeeChatInfo.CanceledCoffeeChatResponse(findCoffeeChat.getId());
+        return new CoffeeChatInfo.CancelCoffeeChatResponse(findCoffeeChat.getId());
     }
 
 }

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/coffeechat/core/CoffeeChatServiceImpl.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/coffeechat/core/CoffeeChatServiceImpl.java
@@ -29,12 +29,12 @@ public class CoffeeChatServiceImpl implements CoffeeChatService {
 
     @Override
     @Transactional
-    public CoffeeChatInfo.CreatedCoffeeChatResponse createCoffeeChat(CoffeeChatCommand.CreateCoffeeChatRequest request,
+    public CoffeeChatInfo.CreateCoffeeChatResponse createCoffeeChat(CoffeeChatCommand.CreateCoffeeChatRequest request,
         Long memberId) {
         Member findMember = memberReader.findById(memberId);
         CoffeeChat savedCoffeeChat = coffeeChatStore.save(request.toEntity(findMember));
 
-        return new CoffeeChatInfo.CreatedCoffeeChatResponse(savedCoffeeChat.getId());
+        return new CoffeeChatInfo.CreateCoffeeChatResponse(savedCoffeeChat.getId());
     }
 
     @Override
@@ -75,7 +75,7 @@ public class CoffeeChatServiceImpl implements CoffeeChatService {
 
     @Override
     @Transactional
-    public CoffeeChatInfo.UpdatedCoffeeChatResponse modifyCoffeeChat(CoffeeChatCommand.UpdateCoffeeChatRequest request,
+    public CoffeeChatInfo.UpdateCoffeeChatResponse modifyCoffeeChat(CoffeeChatCommand.UpdateCoffeeChatRequest request,
         Long coffeeChatId) {
         CoffeeChat findCoffeeChat = coffeeChatReader.findExistCoffeeChat(coffeeChatId);
         CoffeeChat updateCoffeeChat = request.toEntity();
@@ -83,7 +83,7 @@ public class CoffeeChatServiceImpl implements CoffeeChatService {
         validateUpdateRequest(findCoffeeChat, updateCoffeeChat);
         coffeeChatStore.update(findCoffeeChat, updateCoffeeChat);
 
-        return new CoffeeChatInfo.UpdatedCoffeeChatResponse(findCoffeeChat.getId());
+        return new CoffeeChatInfo.UpdateCoffeeChatResponse(findCoffeeChat.getId());
     }
 
     private void validateUpdateRequest(CoffeeChat findCoffeeChat, CoffeeChat updateCoffeeChat) {
@@ -108,11 +108,11 @@ public class CoffeeChatServiceImpl implements CoffeeChatService {
 
     @Override
     @Transactional
-    public CoffeeChatInfo.DeletedCoffeeChatResponse deleteCoffeeChat(Long coffeeChatId) {
+    public CoffeeChatInfo.DeleteCoffeeChatResponse deleteCoffeeChat(Long coffeeChatId) {
         CoffeeChat findCoffeeChat = coffeeChatReader.findExistCoffeeChat(coffeeChatId);
         coffeeChatStore.deleteById(findCoffeeChat.getId());
 
-        return new CoffeeChatInfo.DeletedCoffeeChatResponse(findCoffeeChat.getId());
+        return new CoffeeChatInfo.DeleteCoffeeChatResponse(findCoffeeChat.getId());
     }
 
     @Override
@@ -139,14 +139,14 @@ public class CoffeeChatServiceImpl implements CoffeeChatService {
 
     @Override
     @Transactional
-    public CoffeeChatInfo.AppliedCoffeeChatResponse applyCoffeeChat(Long coffeeChatId, Long memberId) {
+    public CoffeeChatInfo.ApplyCoffeeChatResponse applyCoffeeChat(Long coffeeChatId, Long memberId) {
         CoffeeChat findCoffeeChat = findExistAndOpenCoffeeChat(coffeeChatId);
         Member findMember = memberReader.findById(memberId);
 
         validateApplyRequest(findMember, findCoffeeChat);
         findCoffeeChat.addCoffeeChatMember(findMember);
 
-        return new CoffeeChatInfo.AppliedCoffeeChatResponse(findCoffeeChat.getId());
+        return new CoffeeChatInfo.ApplyCoffeeChatResponse(findCoffeeChat.getId());
     }
 
     private void validateApplyRequest(Member findMember, CoffeeChat findCoffeeChat) {

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/coffeechat/core/CoffeeChatServiceImpl.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/coffeechat/core/CoffeeChatServiceImpl.java
@@ -1,5 +1,7 @@
 package kernel.jdon.moduleapi.domain.coffeechat.core;
 
+import java.util.Optional;
+
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -56,14 +58,9 @@ public class CoffeeChatServiceImpl implements CoffeeChatService {
     }
 
     private boolean checkIfMemberParticipated(Long coffeeChatId, Long memberId) {
-        boolean isParticipant;
-        if (memberId != null) {
-            isParticipant = coffeeChatReader.existsByCoffeeChatIdAndMemberId(coffeeChatId, memberId);
-        } else {
-            isParticipant = false;
-        }
-
-        return isParticipant;
+        return Optional.ofNullable(memberId)
+            .map(id -> coffeeChatReader.existsByCoffeeChatIdAndMemberId(coffeeChatId, id))
+            .orElse(false);
     }
 
     @Override

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/coffeechat/core/CoffeeChatServiceImpl.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/coffeechat/core/CoffeeChatServiceImpl.java
@@ -177,10 +177,12 @@ public class CoffeeChatServiceImpl implements CoffeeChatService {
     @Override
     @Transactional
     public CoffeeChatInfo.CanceledCoffeeChatResponse cancelCoffeeChat(Long coffeeChatId, Long memberId) {
-        CoffeeChatMember findCoffeeChatMember = coffeeChatReader.findCoffeeChatMember(coffeeChatId, memberId);
-        coffeeChatStore.delete(findCoffeeChatMember);
+        CoffeeChat findCoffeeChat = coffeeChatReader.findExistCoffeeChat(coffeeChatId);
 
-        return new CoffeeChatInfo.CanceledCoffeeChatResponse(findCoffeeChatMember.getCoffeeChat().getId());
+        CoffeeChatMember coffeeChatMember = coffeeChatReader.findCoffeeChatMember(coffeeChatId, memberId);
+        findCoffeeChat.removeCoffeeChatMember(coffeeChatMember);
+
+        return new CoffeeChatInfo.CanceledCoffeeChatResponse(findCoffeeChat.getId());
     }
 
 }

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/coffeechat/core/CoffeeChatServiceImpl.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/coffeechat/core/CoffeeChatServiceImpl.java
@@ -181,7 +181,7 @@ public class CoffeeChatServiceImpl implements CoffeeChatService {
         CoffeeChat findCoffeeChat = coffeeChatReader.findExistCoffeeChat(coffeeChatId);
 
         CoffeeChatMember findCoffeeChatMember = coffeeChatReader.findCoffeeChatMember(coffeeChatId, memberId);
-        findCoffeeChat.removeCoffeeChatMember(findCoffeeChatMember);
+        coffeeChatStore.cancel(findCoffeeChat, findCoffeeChatMember);
 
         return new CoffeeChatInfo.CanceledCoffeeChatResponse(findCoffeeChat.getId());
     }

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/coffeechat/core/CoffeeChatServiceImpl.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/coffeechat/core/CoffeeChatServiceImpl.java
@@ -94,7 +94,8 @@ public class CoffeeChatServiceImpl implements CoffeeChatService {
     private void checkMeetDate(CoffeeChat findCoffeeChat, CoffeeChat updateCoffeeChat) {
         if (findCoffeeChat.isExpired()) {
             throw CoffeeChatErrorCode.EXPIRED_COFFEECHAT.throwException();
-        } else if (updateCoffeeChat.isPastDate()) {
+        }
+        if (updateCoffeeChat.isExpired()) {
             throw CoffeeChatErrorCode.MEET_DATE_ISBEFORE_NOW.throwException();
         }
     }

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/coffeechat/core/CoffeeChatServiceImpl.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/coffeechat/core/CoffeeChatServiceImpl.java
@@ -173,6 +173,16 @@ public class CoffeeChatServiceImpl implements CoffeeChatService {
 
         return findCoffeeChat;
     }
+
+    @Override
+    @Transactional
+    public CoffeeChatInfo.CanceledCoffeeChatResponse cancelCoffeeChat(Long coffeeChatId, Long memberId) {
+        CoffeeChatMember findCoffeeChatMember = coffeeChatReader.findCoffeeChatMember(coffeeChatId, memberId);
+        coffeeChatStore.delete(findCoffeeChatMember);
+
+        return new CoffeeChatInfo.CanceledCoffeeChatResponse(findCoffeeChatMember.getCoffeeChat().getId());
+    }
+
 }
 
 

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/coffeechat/core/CoffeeChatServiceImpl.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/coffeechat/core/CoffeeChatServiceImpl.java
@@ -180,8 +180,8 @@ public class CoffeeChatServiceImpl implements CoffeeChatService {
     public CoffeeChatInfo.CanceledCoffeeChatResponse cancelCoffeeChat(Long coffeeChatId, Long memberId) {
         CoffeeChat findCoffeeChat = coffeeChatReader.findExistCoffeeChat(coffeeChatId);
 
-        CoffeeChatMember coffeeChatMember = coffeeChatReader.findCoffeeChatMember(coffeeChatId, memberId);
-        findCoffeeChat.removeCoffeeChatMember(coffeeChatMember);
+        CoffeeChatMember findCoffeeChatMember = coffeeChatReader.findCoffeeChatMember(coffeeChatId, memberId);
+        findCoffeeChat.removeCoffeeChatMember(findCoffeeChatMember);
 
         return new CoffeeChatInfo.CanceledCoffeeChatResponse(findCoffeeChat.getId());
     }

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/coffeechat/core/CoffeeChatStore.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/coffeechat/core/CoffeeChatStore.java
@@ -1,7 +1,6 @@
 package kernel.jdon.moduleapi.domain.coffeechat.core;
 
 import kernel.jdon.moduledomain.coffeechat.domain.CoffeeChat;
-import kernel.jdon.moduledomain.coffeechatmember.domain.CoffeeChatMember;
 
 public interface CoffeeChatStore {
 
@@ -11,5 +10,4 @@ public interface CoffeeChatStore {
 
     void deleteById(Long id);
 
-    void delete(CoffeeChatMember coffeeChatMember);
 }

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/coffeechat/core/CoffeeChatStore.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/coffeechat/core/CoffeeChatStore.java
@@ -1,6 +1,7 @@
 package kernel.jdon.moduleapi.domain.coffeechat.core;
 
 import kernel.jdon.moduledomain.coffeechat.domain.CoffeeChat;
+import kernel.jdon.moduledomain.coffeechatmember.domain.CoffeeChatMember;
 
 public interface CoffeeChatStore {
 
@@ -9,4 +10,6 @@ public interface CoffeeChatStore {
     void update(CoffeeChat findCoffeeChat, CoffeeChat updateCoffeeChat);
 
     void deleteById(Long id);
+
+    void delete(CoffeeChatMember coffeeChatMember);
 }

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/coffeechat/core/CoffeeChatStore.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/coffeechat/core/CoffeeChatStore.java
@@ -1,6 +1,7 @@
 package kernel.jdon.moduleapi.domain.coffeechat.core;
 
 import kernel.jdon.moduledomain.coffeechat.domain.CoffeeChat;
+import kernel.jdon.moduledomain.coffeechatmember.domain.CoffeeChatMember;
 
 public interface CoffeeChatStore {
 
@@ -9,5 +10,7 @@ public interface CoffeeChatStore {
     void update(CoffeeChat findCoffeeChat, CoffeeChat updateCoffeeChat);
 
     void deleteById(Long id);
+
+    void cancel(CoffeeChat findCoffeeChat, CoffeeChatMember findCoffeeChatMember);
 
 }

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/coffeechat/error/CoffeeChatErrorCode.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/coffeechat/error/CoffeeChatErrorCode.java
@@ -18,7 +18,6 @@ public enum CoffeeChatErrorCode implements ErrorCode, BaseThrowException<CoffeeC
     LOCK_ACQUISITION_FAILURE(HttpStatus.SERVICE_UNAVAILABLE, "현재 많은 요청으로 인해 처리가 지연되고 있습니다. 잠시 후 다시 시도해주세요."),
     THREAD_INTERRUPTED(HttpStatus.SERVICE_UNAVAILABLE, "처리 중 문제가 발생했습니다. 잠시 후 다시 시도해주세요."),
     ALREADY_JOINED_COFFEECHAT(HttpStatus.CONFLICT, "이미 참여한 커피챗 입니다."),
-
     NOT_FOUND_APPLICATION(HttpStatus.CONFLICT, "해당 커피챗을 신청한 정보가 없습니다.");
 
     private final HttpStatus httpStatus;

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/coffeechat/error/CoffeeChatErrorCode.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/coffeechat/error/CoffeeChatErrorCode.java
@@ -18,7 +18,7 @@ public enum CoffeeChatErrorCode implements ErrorCode, BaseThrowException<CoffeeC
     LOCK_ACQUISITION_FAILURE(HttpStatus.SERVICE_UNAVAILABLE, "현재 많은 요청으로 인해 처리가 지연되고 있습니다. 잠시 후 다시 시도해주세요."),
     THREAD_INTERRUPTED(HttpStatus.SERVICE_UNAVAILABLE, "처리 중 문제가 발생했습니다. 잠시 후 다시 시도해주세요."),
     ALREADY_JOINED_COFFEECHAT(HttpStatus.CONFLICT, "이미 참여한 커피챗 입니다."),
-    NOT_FOUND_APPLICATION(HttpStatus.CONFLICT, "해당 커피챗을 신청한 정보가 없습니다.");
+    NOT_FOUND_APPLICATION(HttpStatus.NOT_FOUND, "해당 커피챗을 신청한 정보가 없습니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/coffeechat/error/CoffeeChatErrorCode.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/coffeechat/error/CoffeeChatErrorCode.java
@@ -9,37 +9,39 @@ import lombok.AllArgsConstructor;
 
 @AllArgsConstructor
 public enum CoffeeChatErrorCode implements ErrorCode, BaseThrowException<CoffeeChatErrorCode.CoffeeChatBaseException> {
-	NOT_FOUND_COFFEECHAT(HttpStatus.NOT_FOUND, "존재하지 않는 커피챗 입니다."),
-	NOT_OPEN_COFFEECHAT(HttpStatus.BAD_REQUEST, "모집중이 아닌 커피챗 입니다."),
-	INVALID_TOTAL_RECRUIT_COUNT(HttpStatus.BAD_REQUEST, "총 모집인원을 현재 모집인원보다 작게 설정할 수 없습니다."),
-	CANNOT_JOIN_OWN_COFFEECHAT(HttpStatus.CONFLICT, "본인이 개설한 커피챗에 참여할 수 없습니다."),
-	EXPIRED_COFFEECHAT(HttpStatus.CONFLICT, "지난 일자의 커피챗은 수정할 수 없습니다."),
-	MEET_DATE_ISBEFORE_NOW(HttpStatus.BAD_REQUEST, "지금보다 이전 시점으로 설정할 수 없습니다."),
-	LOCK_ACQUISITION_FAILURE(HttpStatus.SERVICE_UNAVAILABLE, "현재 많은 요청으로 인해 처리가 지연되고 있습니다. 잠시 후 다시 시도해주세요."),
-	THREAD_INTERRUPTED(HttpStatus.SERVICE_UNAVAILABLE, "처리 중 문제가 발생했습니다. 잠시 후 다시 시도해주세요."),
-	ALREADY_JOINED_COFFEECHAT(HttpStatus.CONFLICT, "이미 참여한 커피챗 입니다.");
+    NOT_FOUND_COFFEECHAT(HttpStatus.NOT_FOUND, "존재하지 않는 커피챗 입니다."),
+    NOT_OPEN_COFFEECHAT(HttpStatus.BAD_REQUEST, "모집중이 아닌 커피챗 입니다."),
+    INVALID_TOTAL_RECRUIT_COUNT(HttpStatus.BAD_REQUEST, "총 모집인원을 현재 모집인원보다 작게 설정할 수 없습니다."),
+    CANNOT_JOIN_OWN_COFFEECHAT(HttpStatus.CONFLICT, "본인이 개설한 커피챗에 참여할 수 없습니다."),
+    EXPIRED_COFFEECHAT(HttpStatus.CONFLICT, "지난 일자의 커피챗은 수정할 수 없습니다."),
+    MEET_DATE_ISBEFORE_NOW(HttpStatus.BAD_REQUEST, "지금보다 이전 시점으로 설정할 수 없습니다."),
+    LOCK_ACQUISITION_FAILURE(HttpStatus.SERVICE_UNAVAILABLE, "현재 많은 요청으로 인해 처리가 지연되고 있습니다. 잠시 후 다시 시도해주세요."),
+    THREAD_INTERRUPTED(HttpStatus.SERVICE_UNAVAILABLE, "처리 중 문제가 발생했습니다. 잠시 후 다시 시도해주세요."),
+    ALREADY_JOINED_COFFEECHAT(HttpStatus.CONFLICT, "이미 참여한 커피챗 입니다."),
 
-	private final HttpStatus httpStatus;
-	private final String message;
+    NOT_FOUND_APPLICATION(HttpStatus.CONFLICT, "해당 커피챗을 신청한 정보가 없습니다.");
 
-	@Override
-	public HttpStatus getHttpStatus() {
-		return httpStatus;
-	}
+    private final HttpStatus httpStatus;
+    private final String message;
 
-	@Override
-	public String getMessage() {
-		return message;
-	}
+    @Override
+    public HttpStatus getHttpStatus() {
+        return httpStatus;
+    }
 
-	@Override
-	public CoffeeChatErrorCode.CoffeeChatBaseException throwException() {
-		return new CoffeeChatErrorCode.CoffeeChatBaseException(this);
-	}
+    @Override
+    public String getMessage() {
+        return message;
+    }
 
-	public class CoffeeChatBaseException extends ApiException {
-		public CoffeeChatBaseException(CoffeeChatErrorCode coffeeChatErrorCode) {
-			super(coffeeChatErrorCode);
-		}
-	}
+    @Override
+    public CoffeeChatErrorCode.CoffeeChatBaseException throwException() {
+        return new CoffeeChatErrorCode.CoffeeChatBaseException(this);
+    }
+
+    public class CoffeeChatBaseException extends ApiException {
+        public CoffeeChatBaseException(CoffeeChatErrorCode coffeeChatErrorCode) {
+            super(coffeeChatErrorCode);
+        }
+    }
 }

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/coffeechat/infrastructure/CoffeeChatMemberRepository.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/coffeechat/infrastructure/CoffeeChatMemberRepository.java
@@ -1,5 +1,7 @@
 package kernel.jdon.moduleapi.domain.coffeechat.infrastructure;
 
+import java.util.Optional;
+
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.Query;
@@ -13,4 +15,5 @@ public interface CoffeeChatMemberRepository extends CoffeeChatMemberDomainReposi
 
     boolean existsByCoffeeChatIdAndMemberId(Long coffeeChatId, Long memberId);
 
+    Optional<CoffeeChatMember> findByCoffeeChatIdAndMemberId(Long coffeeChatId, Long memberId);
 }

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/coffeechat/infrastructure/CoffeeChatReaderImpl.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/coffeechat/infrastructure/CoffeeChatReaderImpl.java
@@ -7,14 +7,14 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Component;
 
-import kernel.jdon.moduledomain.coffeechat.domain.CoffeeChat;
-import kernel.jdon.moduledomain.coffeechatmember.domain.CoffeeChatMember;
 import kernel.jdon.moduleapi.domain.coffeechat.core.CoffeeChatCommand;
 import kernel.jdon.moduleapi.domain.coffeechat.core.CoffeeChatInfo;
 import kernel.jdon.moduleapi.domain.coffeechat.core.CoffeeChatReader;
 import kernel.jdon.moduleapi.domain.coffeechat.error.CoffeeChatErrorCode;
 import kernel.jdon.moduleapi.global.page.CustomJpaPageInfo;
 import kernel.jdon.moduleapi.global.page.PageInfoRequest;
+import kernel.jdon.moduledomain.coffeechat.domain.CoffeeChat;
+import kernel.jdon.moduledomain.coffeechatmember.domain.CoffeeChatMember;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -60,5 +60,11 @@ public class CoffeeChatReaderImpl implements CoffeeChatReader {
     @Override
     public boolean existsByCoffeeChatIdAndMemberId(Long coffeeChatId, Long memberId) {
         return coffeeChatMemberRepository.existsByCoffeeChatIdAndMemberId(coffeeChatId, memberId);
+    }
+
+    @Override
+    public CoffeeChatMember findCoffeeChatMember(Long coffeeChatId, Long memberId) {
+        return coffeeChatMemberRepository.findByCoffeeChatIdAndMemberId(coffeeChatId, memberId)
+            .orElseThrow(CoffeeChatErrorCode.NOT_FOUND_APPLICATION::throwException);
     }
 }

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/coffeechat/infrastructure/CoffeeChatStoreImpl.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/coffeechat/infrastructure/CoffeeChatStoreImpl.java
@@ -4,6 +4,7 @@ import org.springframework.stereotype.Component;
 
 import kernel.jdon.moduleapi.domain.coffeechat.core.CoffeeChatStore;
 import kernel.jdon.moduledomain.coffeechat.domain.CoffeeChat;
+import kernel.jdon.moduledomain.coffeechatmember.domain.CoffeeChatMember;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -13,6 +14,7 @@ import lombok.extern.slf4j.Slf4j;
 public class CoffeeChatStoreImpl implements CoffeeChatStore {
 
     private final CoffeeChatRepository coffeeChatRepository;
+    private final CoffeeChatMemberRepository coffeeChatMemberRepository;
 
     @Override
     public CoffeeChat save(CoffeeChat coffeeChat) {
@@ -27,5 +29,10 @@ public class CoffeeChatStoreImpl implements CoffeeChatStore {
     @Override
     public void deleteById(Long coffeeChatId) {
         coffeeChatRepository.deleteById(coffeeChatId);
+    }
+
+    @Override
+    public void delete(CoffeeChatMember coffeeChatMember) {
+        coffeeChatMemberRepository.delete(coffeeChatMember);
     }
 }

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/coffeechat/infrastructure/CoffeeChatStoreImpl.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/coffeechat/infrastructure/CoffeeChatStoreImpl.java
@@ -2,8 +2,8 @@ package kernel.jdon.moduleapi.domain.coffeechat.infrastructure;
 
 import org.springframework.stereotype.Component;
 
-import kernel.jdon.moduledomain.coffeechat.domain.CoffeeChat;
 import kernel.jdon.moduleapi.domain.coffeechat.core.CoffeeChatStore;
+import kernel.jdon.moduledomain.coffeechat.domain.CoffeeChat;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -25,7 +25,7 @@ public class CoffeeChatStoreImpl implements CoffeeChatStore {
     }
 
     @Override
-    public void deleteById(Long coffeeChatid) {
-        coffeeChatRepository.deleteById(coffeeChatid);
+    public void deleteById(Long coffeeChatId) {
+        coffeeChatRepository.deleteById(coffeeChatId);
     }
 }

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/coffeechat/infrastructure/CoffeeChatStoreImpl.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/coffeechat/infrastructure/CoffeeChatStoreImpl.java
@@ -13,7 +13,6 @@ import lombok.extern.slf4j.Slf4j;
 public class CoffeeChatStoreImpl implements CoffeeChatStore {
 
     private final CoffeeChatRepository coffeeChatRepository;
-    private final CoffeeChatMemberRepository coffeeChatMemberRepository;
 
     @Override
     public CoffeeChat save(CoffeeChat coffeeChat) {

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/coffeechat/infrastructure/CoffeeChatStoreImpl.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/coffeechat/infrastructure/CoffeeChatStoreImpl.java
@@ -4,7 +4,6 @@ import org.springframework.stereotype.Component;
 
 import kernel.jdon.moduleapi.domain.coffeechat.core.CoffeeChatStore;
 import kernel.jdon.moduledomain.coffeechat.domain.CoffeeChat;
-import kernel.jdon.moduledomain.coffeechatmember.domain.CoffeeChatMember;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -29,10 +28,5 @@ public class CoffeeChatStoreImpl implements CoffeeChatStore {
     @Override
     public void deleteById(Long coffeeChatId) {
         coffeeChatRepository.deleteById(coffeeChatId);
-    }
-
-    @Override
-    public void delete(CoffeeChatMember coffeeChatMember) {
-        coffeeChatMemberRepository.delete(coffeeChatMember);
     }
 }

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/coffeechat/infrastructure/CoffeeChatStoreImpl.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/coffeechat/infrastructure/CoffeeChatStoreImpl.java
@@ -4,6 +4,7 @@ import org.springframework.stereotype.Component;
 
 import kernel.jdon.moduleapi.domain.coffeechat.core.CoffeeChatStore;
 import kernel.jdon.moduledomain.coffeechat.domain.CoffeeChat;
+import kernel.jdon.moduledomain.coffeechatmember.domain.CoffeeChatMember;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -27,5 +28,10 @@ public class CoffeeChatStoreImpl implements CoffeeChatStore {
     @Override
     public void deleteById(Long coffeeChatId) {
         coffeeChatRepository.deleteById(coffeeChatId);
+    }
+
+    @Override
+    public void cancel(CoffeeChat findCoffeeChat, CoffeeChatMember findCoffeeChatMember) {
+        findCoffeeChat.removeCoffeeChatMember(findCoffeeChatMember);
     }
 }

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/coffeechat/presentation/CoffeeChatController.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/coffeechat/presentation/CoffeeChatController.java
@@ -34,111 +34,123 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 public class CoffeeChatController {
 
-	private final CoffeeChatFacade coffeeChatFacade;
-	private final CoffeeChatDtoMapper coffeeChatDtoMapper;
+    private final CoffeeChatFacade coffeeChatFacade;
+    private final CoffeeChatDtoMapper coffeeChatDtoMapper;
 
-	@GetMapping("/api/v1/coffeechats")
-	public ResponseEntity<CommonResponse<CoffeeChatInfo.FindCoffeeChatListResponse>> getCoffeeChatList(
-		@ModelAttribute final PageInfoRequest pageInfoRequest,
-		@RequestParam(value = "sort", defaultValue = "") final CoffeeChatSortCondition sort,
-		@RequestParam(value = "keyword", defaultValue = "") final String keyword,
-		@RequestParam(value = "jobCategory", defaultValue = "") final Long jobCategory) {
+    @GetMapping("/api/v1/coffeechats")
+    public ResponseEntity<CommonResponse<CoffeeChatInfo.FindCoffeeChatListResponse>> getCoffeeChatList(
+        @ModelAttribute final PageInfoRequest pageInfoRequest,
+        @RequestParam(value = "sort", defaultValue = "") final CoffeeChatSortCondition sort,
+        @RequestParam(value = "keyword", defaultValue = "") final String keyword,
+        @RequestParam(value = "jobCategory", defaultValue = "") final Long jobCategory) {
 
-		CoffeeChatCommand.FindCoffeeChatListRequest request = coffeeChatDtoMapper.of(
-			new CoffeeChatCondition(sort, keyword, jobCategory));
-		CoffeeChatInfo.FindCoffeeChatListResponse info = coffeeChatFacade.getCoffeeChatList(
-			pageInfoRequest, request);
-		CoffeeChatDto.FindCoffeeChatListResponse response = coffeeChatDtoMapper.of(info);
+        CoffeeChatCommand.FindCoffeeChatListRequest request = coffeeChatDtoMapper.of(
+            new CoffeeChatCondition(sort, keyword, jobCategory));
+        CoffeeChatInfo.FindCoffeeChatListResponse info = coffeeChatFacade.getCoffeeChatList(
+            pageInfoRequest, request);
+        CoffeeChatDto.FindCoffeeChatListResponse response = coffeeChatDtoMapper.of(info);
 
-		return ResponseEntity.ok(CommonResponse.of(response));
-	}
+        return ResponseEntity.ok(CommonResponse.of(response));
+    }
 
-	@GetMapping("/api/v1/coffeechats/{id}")
-	public ResponseEntity<CommonResponse<CoffeeChatDto.FindCoffeeChatResponse>> getCoffeeChat(
-		@PathVariable(name = "id") Long coffeeChatId,
-		@LoginUser SessionUserInfo member
-	) {
-		Long memberId = getMemberId(member);
-		CoffeeChatInfo.FindCoffeeChatResponse info = coffeeChatFacade.getCoffeeChat(coffeeChatId, memberId);
-		CoffeeChatDto.FindCoffeeChatResponse response = coffeeChatDtoMapper.of(info);
+    @GetMapping("/api/v1/coffeechats/{id}")
+    public ResponseEntity<CommonResponse<CoffeeChatDto.FindCoffeeChatResponse>> getCoffeeChat(
+        @PathVariable(name = "id") Long coffeeChatId,
+        @LoginUser SessionUserInfo member
+    ) {
+        Long memberId = getMemberId(member);
+        CoffeeChatInfo.FindCoffeeChatResponse info = coffeeChatFacade.getCoffeeChat(coffeeChatId, memberId);
+        CoffeeChatDto.FindCoffeeChatResponse response = coffeeChatDtoMapper.of(info);
 
-		return ResponseEntity.ok(CommonResponse.of(response));
-	}
+        return ResponseEntity.ok(CommonResponse.of(response));
+    }
 
-	private Long getMemberId(SessionUserInfo member) {
-		return Optional.ofNullable(member)
-			.map(SessionUserInfo::getId)
-			.orElse(null);
-	}
+    private Long getMemberId(SessionUserInfo member) {
+        return Optional.ofNullable(member)
+            .map(SessionUserInfo::getId)
+            .orElse(null);
+    }
 
-	@PostMapping("/api/v1/coffeechats/{id}")
-	public ResponseEntity<CommonResponse<CoffeeChatDto.AppliedCoffeeChatResponse>> applyCoffeeChat(
-		@PathVariable(name = "id") Long coffeeChatId,
-		@LoginUser SessionUserInfo member
-	) {
-		CoffeeChatInfo.AppliedCoffeeChatResponse info = coffeeChatFacade.applyCoffeeChat(
-			coffeeChatId, member.getId());
-		CoffeeChatDto.AppliedCoffeeChatResponse response = coffeeChatDtoMapper.of(info);
+    @PostMapping("/api/v1/coffeechats/{id}")
+    public ResponseEntity<CommonResponse<CoffeeChatDto.AppliedCoffeeChatResponse>> applyCoffeeChat(
+        @PathVariable(name = "id") Long coffeeChatId,
+        @LoginUser SessionUserInfo member
+    ) {
+        CoffeeChatInfo.AppliedCoffeeChatResponse info = coffeeChatFacade.applyCoffeeChat(
+            coffeeChatId, member.getId());
+        CoffeeChatDto.AppliedCoffeeChatResponse response = coffeeChatDtoMapper.of(info);
 
-		return ResponseEntity.ok().body(CommonResponse.of(response));
-	}
+        return ResponseEntity.ok().body(CommonResponse.of(response));
+    }
 
-	@PostMapping("/api/v1/coffeechats")
-	public ResponseEntity<CommonResponse<CoffeeChatDto.CreatedCoffeeChatResponse>> createCoffeeChat(
-		@RequestBody @Valid CoffeeChatDto.CreateCoffeeChatRequest request,
-		@LoginUser SessionUserInfo member
-	) {
-		CoffeeChatCommand.CreateCoffeeChatRequest createCommand = coffeeChatDtoMapper.of(request);
-		CoffeeChatInfo.CreatedCoffeeChatResponse info = coffeeChatFacade.createCoffeeChat(createCommand,
-			member.getId());
-		CoffeeChatDto.CreatedCoffeeChatResponse response = coffeeChatDtoMapper.of(info);
-		URI uri = URI.create("/v1/coffeechats/" + info.getCoffeeChatId());
+    @PostMapping("/api/v1/coffeechats/{id}/cancel")
+    public ResponseEntity<CommonResponse<CoffeeChatDto.CanceledCoffeeChatResponse>> cancelCoffeeChat(
+        @PathVariable(name = "id") Long coffeeChatId,
+        @LoginUser SessionUserInfo member
+    ) {
+        CoffeeChatInfo.CanceledCoffeeChatResponse info = coffeeChatFacade.cancelCoffeeChatApplication(
+            coffeeChatId, member.getId());
+        CoffeeChatDto.CanceledCoffeeChatResponse response = coffeeChatDtoMapper.of(info);
 
-		return ResponseEntity.created(uri).body(CommonResponse.of(response));
-	}
+        return ResponseEntity.ok(CommonResponse.of(response));
+    }
 
-	@PutMapping("/api/v1/coffeechats/{id}")
-	public ResponseEntity<CommonResponse<CoffeeChatDto.UpdatedCoffeeChatResponse>> modifyCoffeeChat(
-		@PathVariable(name = "id") Long coffeeChatId,
-		@RequestBody @Valid CoffeeChatDto.UpdateCoffeeChatRequest request
-	) {
-		CoffeeChatCommand.UpdateCoffeeChatRequest updateCommand = coffeeChatDtoMapper.of(request);
-		CoffeeChatInfo.UpdatedCoffeeChatResponse info = coffeeChatFacade.modifyCoffeeChat(
-			updateCommand, coffeeChatId);
-		CoffeeChatDto.UpdatedCoffeeChatResponse response = coffeeChatDtoMapper.of(info);
+    @PostMapping("/api/v1/coffeechats")
+    public ResponseEntity<CommonResponse<CoffeeChatDto.CreatedCoffeeChatResponse>> createCoffeeChat(
+        @RequestBody @Valid CoffeeChatDto.CreateCoffeeChatRequest request,
+        @LoginUser SessionUserInfo member
+    ) {
+        CoffeeChatCommand.CreateCoffeeChatRequest createCommand = coffeeChatDtoMapper.of(request);
+        CoffeeChatInfo.CreatedCoffeeChatResponse info = coffeeChatFacade.createCoffeeChat(createCommand,
+            member.getId());
+        CoffeeChatDto.CreatedCoffeeChatResponse response = coffeeChatDtoMapper.of(info);
+        URI uri = URI.create("/v1/coffeechats/" + info.getCoffeeChatId());
 
-		return ResponseEntity.ok().body(CommonResponse.of(response));
-	}
+        return ResponseEntity.created(uri).body(CommonResponse.of(response));
+    }
 
-	@DeleteMapping("/api/v1/coffeechats/{id}")
-	public ResponseEntity<CommonResponse<CoffeeChatDto.DeletedCoffeeChatResponse>> removeCoffeeChat(
-		@PathVariable(name = "id") Long coffeeChatId) {
-		CoffeeChatInfo.DeletedCoffeeChatResponse info = coffeeChatFacade.deleteCoffeeChat(
-			coffeeChatId);
-		CoffeeChatDto.DeletedCoffeeChatResponse response = coffeeChatDtoMapper.of(info);
+    @PutMapping("/api/v1/coffeechats/{id}")
+    public ResponseEntity<CommonResponse<CoffeeChatDto.UpdatedCoffeeChatResponse>> modifyCoffeeChat(
+        @PathVariable(name = "id") Long coffeeChatId,
+        @RequestBody @Valid CoffeeChatDto.UpdateCoffeeChatRequest request
+    ) {
+        CoffeeChatCommand.UpdateCoffeeChatRequest updateCommand = coffeeChatDtoMapper.of(request);
+        CoffeeChatInfo.UpdatedCoffeeChatResponse info = coffeeChatFacade.modifyCoffeeChat(
+            updateCommand, coffeeChatId);
+        CoffeeChatDto.UpdatedCoffeeChatResponse response = coffeeChatDtoMapper.of(info);
 
-		return ResponseEntity.ok().body(CommonResponse.of(response));
-	}
+        return ResponseEntity.ok().body(CommonResponse.of(response));
+    }
 
-	@GetMapping("/api/v1/coffeechats/guest")
-	public ResponseEntity<CommonResponse<CustomPageResponse<CoffeeChatInfo.FindCoffeeChat>>> getGuestCoffeeChatList(
-		@LoginUser SessionUserInfo member,
-		@PageableDefault(size = 12) Pageable pageable
-	) {
-		CustomPageResponse<CoffeeChatInfo.FindCoffeeChat> response = coffeeChatFacade.getGuestCoffeeChatList(
-			member.getId(), pageable);
+    @DeleteMapping("/api/v1/coffeechats/{id}")
+    public ResponseEntity<CommonResponse<CoffeeChatDto.DeletedCoffeeChatResponse>> removeCoffeeChat(
+        @PathVariable(name = "id") Long coffeeChatId) {
+        CoffeeChatInfo.DeletedCoffeeChatResponse info = coffeeChatFacade.deleteCoffeeChat(
+            coffeeChatId);
+        CoffeeChatDto.DeletedCoffeeChatResponse response = coffeeChatDtoMapper.of(info);
 
-		return ResponseEntity.ok().body(CommonResponse.of(response));
-	}
+        return ResponseEntity.ok().body(CommonResponse.of(response));
+    }
 
-	@GetMapping("/api/v1/coffeechats/host")
-	public ResponseEntity<CommonResponse<CustomPageResponse<CoffeeChatInfo.FindCoffeeChat>>> getHostCoffeeChatList(
-		@LoginUser SessionUserInfo member,
-		@PageableDefault(size = 12) Pageable pageable
-	) {
-		CustomPageResponse<CoffeeChatInfo.FindCoffeeChat> response = coffeeChatFacade.getHostCoffeeChatList(
-			member.getId(), pageable);
+    @GetMapping("/api/v1/coffeechats/guest")
+    public ResponseEntity<CommonResponse<CustomPageResponse<CoffeeChatInfo.FindCoffeeChat>>> getGuestCoffeeChatList(
+        @LoginUser SessionUserInfo member,
+        @PageableDefault(size = 12) Pageable pageable
+    ) {
+        CustomPageResponse<CoffeeChatInfo.FindCoffeeChat> response = coffeeChatFacade.getGuestCoffeeChatList(
+            member.getId(), pageable);
 
-		return ResponseEntity.ok().body(CommonResponse.of(response));
-	}
+        return ResponseEntity.ok().body(CommonResponse.of(response));
+    }
+
+    @GetMapping("/api/v1/coffeechats/host")
+    public ResponseEntity<CommonResponse<CustomPageResponse<CoffeeChatInfo.FindCoffeeChat>>> getHostCoffeeChatList(
+        @LoginUser SessionUserInfo member,
+        @PageableDefault(size = 12) Pageable pageable
+    ) {
+        CustomPageResponse<CoffeeChatInfo.FindCoffeeChat> response = coffeeChatFacade.getHostCoffeeChatList(
+            member.getId(), pageable);
+
+        return ResponseEntity.ok().body(CommonResponse.of(response));
+    }
 }

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/coffeechat/presentation/CoffeeChatController.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/coffeechat/presentation/CoffeeChatController.java
@@ -72,62 +72,62 @@ public class CoffeeChatController {
     }
 
     @PostMapping("/api/v1/coffeechats/{id}")
-    public ResponseEntity<CommonResponse<CoffeeChatDto.AppliedCoffeeChatResponse>> applyCoffeeChat(
+    public ResponseEntity<CommonResponse<CoffeeChatDto.ApplyCoffeeChatResponse>> applyCoffeeChat(
         @PathVariable(name = "id") Long coffeeChatId,
         @LoginUser SessionUserInfo member
     ) {
-        CoffeeChatInfo.AppliedCoffeeChatResponse info = coffeeChatFacade.applyCoffeeChat(
+        CoffeeChatInfo.ApplyCoffeeChatResponse info = coffeeChatFacade.applyCoffeeChat(
             coffeeChatId, member.getId());
-        CoffeeChatDto.AppliedCoffeeChatResponse response = coffeeChatDtoMapper.of(info);
+        CoffeeChatDto.ApplyCoffeeChatResponse response = coffeeChatDtoMapper.of(info);
 
         return ResponseEntity.ok().body(CommonResponse.of(response));
     }
 
     @PostMapping("/api/v1/coffeechats/{id}/cancel")
-    public ResponseEntity<CommonResponse<CoffeeChatDto.CanceledCoffeeChatResponse>> cancelCoffeeChat(
+    public ResponseEntity<CommonResponse<CoffeeChatDto.CancelCoffeeChatResponse>> cancelCoffeeChat(
         @PathVariable(name = "id") Long coffeeChatId,
         @LoginUser SessionUserInfo member
     ) {
         CoffeeChatInfo.CanceledCoffeeChatResponse info = coffeeChatFacade.cancelCoffeeChatApplication(
             coffeeChatId, member.getId());
-        CoffeeChatDto.CanceledCoffeeChatResponse response = coffeeChatDtoMapper.of(info);
+        CoffeeChatDto.CancelCoffeeChatResponse response = coffeeChatDtoMapper.of(info);
 
         return ResponseEntity.ok(CommonResponse.of(response));
     }
 
     @PostMapping("/api/v1/coffeechats")
-    public ResponseEntity<CommonResponse<CoffeeChatDto.CreatedCoffeeChatResponse>> createCoffeeChat(
+    public ResponseEntity<CommonResponse<CoffeeChatDto.CreateCoffeeChatResponse>> createCoffeeChat(
         @RequestBody @Valid CoffeeChatDto.CreateCoffeeChatRequest request,
         @LoginUser SessionUserInfo member
     ) {
         CoffeeChatCommand.CreateCoffeeChatRequest createCommand = coffeeChatDtoMapper.of(request);
-        CoffeeChatInfo.CreatedCoffeeChatResponse info = coffeeChatFacade.createCoffeeChat(createCommand,
+        CoffeeChatInfo.CreateCoffeeChatResponse info = coffeeChatFacade.createCoffeeChat(createCommand,
             member.getId());
-        CoffeeChatDto.CreatedCoffeeChatResponse response = coffeeChatDtoMapper.of(info);
+        CoffeeChatDto.CreateCoffeeChatResponse response = coffeeChatDtoMapper.of(info);
         URI uri = URI.create("/v1/coffeechats/" + info.getCoffeeChatId());
 
         return ResponseEntity.created(uri).body(CommonResponse.of(response));
     }
 
     @PutMapping("/api/v1/coffeechats/{id}")
-    public ResponseEntity<CommonResponse<CoffeeChatDto.UpdatedCoffeeChatResponse>> modifyCoffeeChat(
+    public ResponseEntity<CommonResponse<CoffeeChatDto.UpdateCoffeeChatResponse>> modifyCoffeeChat(
         @PathVariable(name = "id") Long coffeeChatId,
         @RequestBody @Valid CoffeeChatDto.UpdateCoffeeChatRequest request
     ) {
         CoffeeChatCommand.UpdateCoffeeChatRequest updateCommand = coffeeChatDtoMapper.of(request);
-        CoffeeChatInfo.UpdatedCoffeeChatResponse info = coffeeChatFacade.modifyCoffeeChat(
+        CoffeeChatInfo.UpdateCoffeeChatResponse info = coffeeChatFacade.modifyCoffeeChat(
             updateCommand, coffeeChatId);
-        CoffeeChatDto.UpdatedCoffeeChatResponse response = coffeeChatDtoMapper.of(info);
+        CoffeeChatDto.UpdateCoffeeChatResponse response = coffeeChatDtoMapper.of(info);
 
         return ResponseEntity.ok().body(CommonResponse.of(response));
     }
 
     @DeleteMapping("/api/v1/coffeechats/{id}")
-    public ResponseEntity<CommonResponse<CoffeeChatDto.DeletedCoffeeChatResponse>> removeCoffeeChat(
+    public ResponseEntity<CommonResponse<CoffeeChatDto.DeleteCoffeeChatResponse>> removeCoffeeChat(
         @PathVariable(name = "id") Long coffeeChatId) {
-        CoffeeChatInfo.DeletedCoffeeChatResponse info = coffeeChatFacade.deleteCoffeeChat(
+        CoffeeChatInfo.DeleteCoffeeChatResponse info = coffeeChatFacade.deleteCoffeeChat(
             coffeeChatId);
-        CoffeeChatDto.DeletedCoffeeChatResponse response = coffeeChatDtoMapper.of(info);
+        CoffeeChatDto.DeleteCoffeeChatResponse response = coffeeChatDtoMapper.of(info);
 
         return ResponseEntity.ok().body(CommonResponse.of(response));
     }

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/coffeechat/presentation/CoffeeChatController.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/coffeechat/presentation/CoffeeChatController.java
@@ -88,7 +88,7 @@ public class CoffeeChatController {
         @PathVariable(name = "id") Long coffeeChatId,
         @LoginUser SessionUserInfo member
     ) {
-        CoffeeChatInfo.CanceledCoffeeChatResponse info = coffeeChatFacade.cancelCoffeeChatApplication(
+        CoffeeChatInfo.CancelCoffeeChatResponse info = coffeeChatFacade.cancelCoffeeChatApplication(
             coffeeChatId, member.getId());
         CoffeeChatDto.CancelCoffeeChatResponse response = coffeeChatDtoMapper.of(info);
 

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/coffeechat/presentation/CoffeeChatDto.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/coffeechat/presentation/CoffeeChatDto.java
@@ -25,6 +25,12 @@ public class CoffeeChatDto {
 
     @Getter
     @Builder
+    public static class CanceledCoffeeChatResponse {
+        private final Long coffeeChatId;
+    }
+
+    @Getter
+    @Builder
     public static class UpdatedCoffeeChatResponse {
         private final Long coffeeChatId;
     }

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/coffeechat/presentation/CoffeeChatDto.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/coffeechat/presentation/CoffeeChatDto.java
@@ -25,31 +25,31 @@ public class CoffeeChatDto {
 
     @Getter
     @Builder
-    public static class CanceledCoffeeChatResponse {
+    public static class CancelCoffeeChatResponse {
         private final Long coffeeChatId;
     }
 
     @Getter
     @Builder
-    public static class UpdatedCoffeeChatResponse {
+    public static class UpdateCoffeeChatResponse {
         private final Long coffeeChatId;
     }
 
     @Getter
     @Builder
-    public static class CreatedCoffeeChatResponse {
+    public static class CreateCoffeeChatResponse {
         private final Long coffeeChatId;
     }
 
     @Getter
     @Builder
-    public static class AppliedCoffeeChatResponse {
+    public static class ApplyCoffeeChatResponse {
         private final Long coffeeChatId;
     }
 
     @Getter
     @Builder
-    public static class DeletedCoffeeChatResponse {
+    public static class DeleteCoffeeChatResponse {
         private final Long coffeeChatId;
     }
 

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/coffeechat/presentation/CoffeeChatDtoMapper.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/coffeechat/presentation/CoffeeChatDtoMapper.java
@@ -14,15 +14,15 @@ import kernel.jdon.moduleapi.domain.coffeechat.core.CoffeeChatInfo;
 )
 public interface CoffeeChatDtoMapper {
 
-    CoffeeChatDto.CanceledCoffeeChatResponse of(CoffeeChatInfo.CanceledCoffeeChatResponse info);
+    CoffeeChatDto.CancelCoffeeChatResponse of(CoffeeChatInfo.CanceledCoffeeChatResponse info);
 
-    CoffeeChatDto.UpdatedCoffeeChatResponse of(CoffeeChatInfo.UpdatedCoffeeChatResponse info);
+    CoffeeChatDto.UpdateCoffeeChatResponse of(CoffeeChatInfo.UpdateCoffeeChatResponse info);
 
-    CoffeeChatDto.CreatedCoffeeChatResponse of(CoffeeChatInfo.CreatedCoffeeChatResponse info);
+    CoffeeChatDto.CreateCoffeeChatResponse of(CoffeeChatInfo.CreateCoffeeChatResponse info);
 
-    CoffeeChatDto.AppliedCoffeeChatResponse of(CoffeeChatInfo.AppliedCoffeeChatResponse info);
+    CoffeeChatDto.ApplyCoffeeChatResponse of(CoffeeChatInfo.ApplyCoffeeChatResponse info);
 
-    CoffeeChatDto.DeletedCoffeeChatResponse of(CoffeeChatInfo.DeletedCoffeeChatResponse info);
+    CoffeeChatDto.DeleteCoffeeChatResponse of(CoffeeChatInfo.DeleteCoffeeChatResponse info);
 
     CoffeeChatDto.FindCoffeeChatResponse of(CoffeeChatInfo.FindCoffeeChatResponse info);
 

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/coffeechat/presentation/CoffeeChatDtoMapper.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/coffeechat/presentation/CoffeeChatDtoMapper.java
@@ -14,7 +14,7 @@ import kernel.jdon.moduleapi.domain.coffeechat.core.CoffeeChatInfo;
 )
 public interface CoffeeChatDtoMapper {
 
-    CoffeeChatDto.CancelCoffeeChatResponse of(CoffeeChatInfo.CanceledCoffeeChatResponse info);
+    CoffeeChatDto.CancelCoffeeChatResponse of(CoffeeChatInfo.CancelCoffeeChatResponse info);
 
     CoffeeChatDto.UpdateCoffeeChatResponse of(CoffeeChatInfo.UpdateCoffeeChatResponse info);
 

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/coffeechat/presentation/CoffeeChatDtoMapper.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/coffeechat/presentation/CoffeeChatDtoMapper.java
@@ -14,6 +14,8 @@ import kernel.jdon.moduleapi.domain.coffeechat.core.CoffeeChatInfo;
 )
 public interface CoffeeChatDtoMapper {
 
+    CoffeeChatDto.CanceledCoffeeChatResponse of(CoffeeChatInfo.CanceledCoffeeChatResponse info);
+
     CoffeeChatDto.UpdatedCoffeeChatResponse of(CoffeeChatInfo.UpdatedCoffeeChatResponse info);
 
     CoffeeChatDto.CreatedCoffeeChatResponse of(CoffeeChatInfo.CreatedCoffeeChatResponse info);

--- a/module-domain/src/main/java/kernel/jdon/moduledomain/coffeechat/domain/CoffeeChat.java
+++ b/module-domain/src/main/java/kernel/jdon/moduledomain/coffeechat/domain/CoffeeChat.java
@@ -103,6 +103,16 @@ public class CoffeeChat extends AbstractEntity {
         this.currentRecruitCount += 1;
     }
 
+    public void removeCoffeeChatMember(CoffeeChatMember coffeeChatMember) {
+        this.coffeeChatMemberList.remove(coffeeChatMember);
+        decreaseCurrentRecruitCount();
+        updateStatusByRecruitCount();
+    }
+
+    private void decreaseCurrentRecruitCount() {
+        this.currentRecruitCount -= 1;
+    }
+
     public void updateCoffeeChat(CoffeeChat request) {
         this.title = request.getTitle();
         this.content = request.getContent();

--- a/module-domain/src/main/java/kernel/jdon/moduledomain/coffeechat/domain/CoffeeChat.java
+++ b/module-domain/src/main/java/kernel/jdon/moduledomain/coffeechat/domain/CoffeeChat.java
@@ -130,10 +130,6 @@ public class CoffeeChat extends AbstractEntity {
         return this.meetDate.isBefore(LocalDateTime.now());
     }
 
-    public boolean isPastDate() {
-        return this.meetDate.isBefore(LocalDateTime.now());
-    }
-
     public boolean isCurrentCountGreaterThan(Long newTotalCount) {
         return this.currentRecruitCount > newTotalCount;
     }


### PR DESCRIPTION
### 요약

JPA변경 감지 활용해서 커피챗 신청 취소 API를 구현했습니다.
- 엔드포인트는 신청 API와 구분위해 아래와 같이 적용했습니다
  - 신청: @PostMapping("/api/v1/coffeechats/{id}")
  - 취소: @PostMapping("/api/v1/coffeechats/{id}/cancel") 

### 변경한 부분

- 취소 성공시 해당 커피챗의 id를 반환하며 관련 dto와 mapper를 작성했습니다.
- 전달받은 coffeeChatId와 memberId로 신청 정보가 확인 안될 시 예외를 반환합니다. 예외에 담을 에러코드 추가했습니다.
- 취소에 대한 책임은 Aggregate Root인 엔터티가 갖도록 했습니다. 취소 로직은 cascade와 orphanRemoval를 이용한 변경감지를 활용합니다. 취소 성공시 현재 모집인원을 감소시키고, 감소된 모집인원 현황에 따라 상태를 업데이트 합니다.

### 변경한 결과
![image](https://github.com/Kernel360/f1-JDON-Backend/assets/111513287/36455f42-3185-4d8f-ac24-95442049a76d)
1번 커피챗은 모집인원이 모두 차서 '모집완료' 상태입니다.

![image](https://github.com/Kernel360/f1-JDON-Backend/assets/111513287/86a7fee4-c953-4d84-be0e-8ea91641039e)
해당 커피챗을 신청한 유저가 취소 요청에 성공하면 해당 커피챗의 식별자를 반환합니다.

![image](https://github.com/Kernel360/f1-JDON-Backend/assets/111513287/97f7ebcc-e67f-4f90-8e34-86ef72ebe603)
취소 성공시 currentRecruitCount를 1 감소시키고 상태를 '모집중'으로 변경합니다.

![image](https://github.com/Kernel360/f1-JDON-Backend/assets/111513287/211dad1b-3de4-4115-a595-b3dda21a9587)
유저가 신청하지 않은 커피챗에 요청시 예외를 반환합니다.

### 이슈

- closes: #397 

---

## PR 유형

어떤 변경 사항이 있나요?

- [X] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경, 주석 변경)
- [ ] 코드 리팩토링
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 파일 혹은 폴더명 수정, 삭제
- [ ] 배포 관련