### PR TITLE
Test: 찜하기/취소하기, 찜 조회하기 컨트롤러 통합 테스트 작성

### DIFF
--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/favorite/core/FavoriteServiceImpl.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/favorite/core/FavoriteServiceImpl.java
@@ -19,7 +19,7 @@ public class FavoriteServiceImpl implements FavoriteService {
 	public FavoriteInfo.UpdateResponse create(final Long memberId, final Long lectureId) {
 		final Favorite saveFavorite = favoriteFactory.create(memberId, lectureId);
 
-		return new FavoriteInfo.UpdateResponse(saveFavorite.getId());
+		return new FavoriteInfo.UpdateResponse(saveFavorite.getInflearnCourse().getId());
 	}
 
 	@Override
@@ -27,7 +27,7 @@ public class FavoriteServiceImpl implements FavoriteService {
 	public FavoriteInfo.UpdateResponse remove(final Long memberId, final Long lectureId) {
 		Favorite deleteFavorite = favoriteFactory.delete(memberId, lectureId);
 
-		return new FavoriteInfo.UpdateResponse(deleteFavorite.getId());
+		return new FavoriteInfo.UpdateResponse(deleteFavorite.getInflearnCourse().getId());
 	}
 
 	@Override

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/favorite/presentation/FavoriteDto.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/favorite/presentation/FavoriteDto.java
@@ -6,6 +6,7 @@ import jakarta.validation.constraints.NotNull;
 import kernel.jdon.moduleapi.global.page.CustomPageInfo;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -32,6 +33,7 @@ public class FavoriteDto {
 	}
 
 	@Getter
+	@Builder
 	public static class UpdateRequest {
 		private Long lectureId;
 		@NotNull(message = "isFavorite은 null이 될 수 없습니다.")

--- a/module-api/src/test/java/kernel/jdon/moduleapi/domain/favorite/presentation/FavoriteControllerIntegrationTest.java
+++ b/module-api/src/test/java/kernel/jdon/moduleapi/domain/favorite/presentation/FavoriteControllerIntegrationTest.java
@@ -1,0 +1,195 @@
+package kernel.jdon.moduleapi.domain.favorite.presentation;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.time.LocalDateTime;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockHttpSession;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import jakarta.persistence.EntityManager;
+import kernel.jdon.moduleapi.domain.favorite.error.FavoriteErrorCode;
+import kernel.jdon.moduleapi.domain.inflearncourse.error.InflearncourseErrorCode;
+import kernel.jdon.moduleapi.global.dto.SessionUserInfo;
+import kernel.jdon.moduledomain.favorite.domain.Favorite;
+import kernel.jdon.moduledomain.inflearncourse.domain.InflearnCourse;
+import kernel.jdon.moduledomain.member.domain.Gender;
+import kernel.jdon.moduledomain.member.domain.Member;
+import kernel.jdon.moduledomain.member.domain.MemberAccountStatus;
+import kernel.jdon.moduledomain.member.domain.MemberRole;
+import kernel.jdon.moduledomain.member.domain.SocialProviderType;
+
+@DisplayName("Favorite Controller 통합 테스트")
+@ExtendWith(SpringExtension.class)
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+class FavoriteControllerIntegrationTest {
+	private static final String FAVORITE_URL = "/api/v1/favorites";
+	private static final String USER_ID = "USER";
+	@Autowired
+	private ObjectMapper objectMapper;
+	@Autowired
+	private EntityManager entityManager;
+	@Autowired
+	private MockMvc mockMvc;
+	private MockHttpSession mockSession;
+	private InflearnCourse inflearnCourse;
+	private Favorite favorite;
+
+	@BeforeEach
+	void setUp() {
+		Member member = mockMember();
+		entityManager.persist(member);
+
+		SessionUserInfo mockUserInfo = SessionUserInfo.builder()
+			.id(member.getId())
+			.email(member.getEmail())
+			.oauthId("oauth 아이디")
+			.socialProvider(member.getSocialProvider())
+			.lastLoginDate(member.getLastLoginDate())
+			.role(member.getRole())
+			.build();
+
+		inflearnCourse = mockInflearnCourse(1L);
+		entityManager.persist(inflearnCourse);
+
+		favorite = new Favorite(member, inflearnCourse);
+		entityManager.persist(favorite);
+
+		mockSession = new MockHttpSession();
+		mockSession.setAttribute(USER_ID, mockUserInfo);
+	}
+
+	@WithMockUser
+	@DisplayName("1: 유효한 요청이 주어졌을 때 찜한 강의 목록을 조회하면 찜한 강의 목록을 반환한다.")
+	@Test
+	void givenValidRequest_whenFindfavoriteCourseList_thenReturnFindFavoriteCourseList() throws Exception {
+		// when & then
+		InflearnCourse firstItem = favorite.getInflearnCourse();
+
+		mockMvc.perform(get(FAVORITE_URL)
+				.session(mockSession)
+				.accept(MediaType.APPLICATION_JSON))
+			.andExpect(status().isOk())
+			.andExpect(content().contentType(MediaType.APPLICATION_JSON))
+			.andExpect(jsonPath("$.data.content[0].lectureId").value(firstItem.getId()))
+			.andExpect(jsonPath("$.data.content[0].title").value(firstItem.getTitle()))
+			.andExpect(jsonPath("$.data.content[0].lectureUrl").value(firstItem.getLectureUrl()))
+			.andExpect(jsonPath("$.data.content[0].imageUrl").value(firstItem.getImageUrl()))
+			.andExpect(jsonPath("$.data.content[0].instructor").value(firstItem.getInstructor()))
+			.andExpect(jsonPath("$.data.content[0].studentCount").value(firstItem.getStudentCount()))
+			.andExpect(jsonPath("$.data.content[0].price").value(firstItem.getPrice()))
+			.andExpect(jsonPath("$.data.content.length()").value(1))
+			.andExpect(content().contentType(MediaType.APPLICATION_JSON))
+			.andDo(print());
+	}
+
+	@WithMockUser
+	@DisplayName("2: 유효한 요청으로 찜한 강의 수정 성공 시 수정된 찜한 또는 찜 취소한 강의의 ID를 반환한다.")
+	@Test
+	void givenValidRequest_whenUpdateFavorite_thenReturnUpdatedFavorite() throws Exception {
+		// given
+		boolean isFavorite = false;
+		FavoriteDto.UpdateRequest updateRequest = createUpdateRequest(inflearnCourse.getId(), isFavorite);
+
+		// when & then
+		mockMvc.perform(post(FAVORITE_URL)
+				.session(mockSession)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(updateRequest)))
+			.andExpect(status().isCreated())
+			.andExpect(content().contentType(MediaType.APPLICATION_JSON))
+			.andExpect(jsonPath("$.data.lectureId").value(inflearnCourse.getId()))
+			.andDo(print());
+	}
+
+	@WithMockUser
+	@DisplayName("3: 존재하지 않는 강의 id로 찜 정보 업데이트 시 NOT_FOUND_INFLEARN_COURSE 에러를 반환한다.")
+	@Test
+	void givenInvalidFavoriteId_whenUpdateFavorite_thenThrowError() throws Exception {
+		// given
+		boolean isFavorite = true;
+		FavoriteDto.UpdateRequest updateRequest = createUpdateRequest(inflearnCourse.getId() + 1, isFavorite);
+
+		// when & then
+		mockMvc.perform(post(FAVORITE_URL)
+				.session(mockSession)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(updateRequest)))
+			.andExpect(status().isNotFound())
+			.andExpect(content().contentType(MediaType.APPLICATION_JSON))
+			.andExpect(jsonPath("$.message").value(InflearncourseErrorCode.NOT_FOUND_INFLEARN_COURSE.getMessage()))
+			.andDo(print());
+	}
+
+	@WithMockUser
+	@DisplayName("4: 존재하지만 찜하지 않은 강의를 찜 취소 시 LECTURE_NOT_FAVORITED 에러를 반환한다.")
+	@Test
+	void givenUnfavoritedLecture_whenUnfavorite_thenThrowError() throws Exception {
+		// given
+		InflearnCourse notFavoritedinflearnCourse = mockInflearnCourse(2L);
+		entityManager.persist(notFavoritedinflearnCourse);
+
+		boolean isFavorite = false;
+		FavoriteDto.UpdateRequest updateRequest = createUpdateRequest(notFavoritedinflearnCourse.getId(), isFavorite);
+
+		// when & then
+		mockMvc.perform(post(FAVORITE_URL)
+				.session(mockSession)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(updateRequest)))
+			.andExpect(status().isNotFound())
+			.andExpect(content().contentType(MediaType.APPLICATION_JSON))
+			.andExpect(jsonPath("$.message").value(FavoriteErrorCode.NOT_FOUND_FAVORITE.getMessage()))
+			.andDo(print());
+	}
+
+	private FavoriteDto.UpdateRequest createUpdateRequest(Long lectureId, Boolean isFavorite) {
+		return FavoriteDto.UpdateRequest.builder()
+			.lectureId(lectureId)
+			.isFavorite(isFavorite)
+			.build();
+	}
+
+	private Member mockMember() {
+		return Member.builder()
+			.email("이메일@kakao.com")
+			.nickname("닉네임")
+			.birth("1990-01-01")
+			.gender(Gender.MALE)
+			.joinDate(LocalDateTime.now())
+			.role(MemberRole.ROLE_USER)
+			.accountStatus(MemberAccountStatus.ACTIVE)
+			.socialProvider(SocialProviderType.KAKAO)
+			.build();
+	}
+
+	private InflearnCourse mockInflearnCourse(Long courseId) {
+		return InflearnCourse.builder()
+			.courseId(courseId)
+			.title("강의 제목")
+			.lectureUrl("https://www.inflearn.com/course/강의 제목")
+			.instructor("지식 공유자")
+			.studentCount(500L)
+			.imageUrl(
+				"https://cdn.inflearn.com/public/courses/courseId/cover/picture.png")
+			.price(80000)
+			.build();
+	}
+}

--- a/module-api/src/test/resources/application.yml
+++ b/module-api/src/test/resources/application.yml
@@ -57,3 +57,6 @@ redis:
     coffee-chat:
       wait-time: 5
       lease-time: 1
+
+allowed-origins:
+  origin: http://localhost:3000/


### PR DESCRIPTION
## 개요
- 컨트롤러 단위 테스트는 외부 요소가 많은 데에 비해 비즈니스 로직이 담겨있지 않습니다.
그렇기 때문에 단위테스트를 작성하는 의미가 적어 통합 테스트를 작성했습니다.
- 통합 테스트를 작성함으로써 API들이 제대로 작성하는지 확인하는 작업을 자동화합니다.

### 요약
- 찜하기/취소하기, 찜 조회하기 컨트롤러 통합 테스트를 작성했습니다.

### 변경한 부분
- `FavoriteServiceImpl`
  - **favorite의 id**를 반환하는게 아니라 **찜한 강의 id**를 반환해야하므로 수정했습니다.
-  `application.yml`
  - @WithMockUser를 사용하기 위해선, logoutUrl이 유효한 url형식이어야 합니다.
  - 따라서, 테스트 환경에서 OAuth2SecurityConfig에서 참조하고 있는 주소를 application.yml에 추가했습니다.
  - `FavoriteControllerIntegrationTest`
    -  찜하기/취소하기, 찜 조회하기 컨트롤러 통합 테스트입니다.
    - 유효한 요청으로 유효한 응답이 반환되는 경우: 1, 2
    - 에러가 날 수 있는 경우: 3, 4
    - 회원이 로그인했을 경우에만 찜하기/취소하기, 찜 조회하기 기능에 접근 가능하므로 NOT_FOUND_MEMBER에 대한 상황은 테스트하지 않았습니다.

### 변경한 결과
![image](https://github.com/Kernel360/f1-JDON-Backend/assets/86637372/a9478d11-234d-40a6-8688-5de9f743ff64)


### 이슈

- closes: #391 

---

## PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경, 주석 변경)
- [ ] 코드 리팩토링
- [ ] 문서 수정
- [x] 테스트 추가, 테스트 리팩토링
- [ ] 파일 혹은 폴더명 수정, 삭제
- [ ] 배포 관련