### PR TITLE
Feature: JD 목록조회 검색기능 구현

### DIFF
--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/coffeechat/core/CoffeeChatCommand.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/coffeechat/core/CoffeeChatCommand.java
@@ -12,13 +12,13 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class CoffeeChatCommand {
 
-    @Getter
-    @Builder
-    public static class FindCoffeeChatListRequest {
-        private final CoffeeChatSortCondition sort;
-        private final String keyword;
-        private final Long jobCategory;
-    }
+	@Getter
+	@Builder
+	public static class FindCoffeeChatListRequest {
+		private final CoffeeChatSortType sort;
+		private final String keyword;
+		private final Long jobCategory;
+	}
 
     @Getter
     @Builder

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/coffeechat/core/CoffeeChatSortType.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/coffeechat/core/CoffeeChatSortType.java
@@ -5,22 +5,22 @@ import static org.springframework.util.StringUtils.*;
 import java.util.Arrays;
 
 public enum CoffeeChatSortType {
-	CREATED_DATE("createdDate"),
-	VIEW_COUNT("viewCount");
+    CREATED_DATE("createdDate"),
+    VIEW_COUNT("viewCount");
 
-	private final String webNaming;
+    private final String webNaming;
 
-	CoffeeChatSortType(String webNaming) {
-		this.webNaming = webNaming;
-	}
+    CoffeeChatSortType(String webNaming) {
+        this.webNaming = webNaming;
+    }
 
-	public static CoffeeChatSortType of(String webNaming) {
-		if (!hasText(webNaming)) {
-			return null;
-		}
-		return Arrays.stream(values())
-			.filter(name -> name.webNaming.equals(webNaming))
-			.findFirst()
-			.orElseThrow();
-	}
+    public static CoffeeChatSortType of(String webNaming) {
+        if (!hasText(webNaming)) {
+            return CREATED_DATE;
+        }
+        return Arrays.stream(values())
+            .filter(name -> name.webNaming.equals(webNaming))
+            .findFirst()
+            .orElse(CREATED_DATE);
+    }
 }

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/coffeechat/core/CoffeeChatSortType.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/coffeechat/core/CoffeeChatSortType.java
@@ -4,19 +4,20 @@ import static org.springframework.util.StringUtils.*;
 
 import java.util.Arrays;
 
-public enum CoffeeChatSortCondition {
+public enum CoffeeChatSortType {
 	CREATED_DATE("createdDate"),
 	VIEW_COUNT("viewCount");
 
 	private final String webNaming;
 
-	CoffeeChatSortCondition(String webNaming) {
+	CoffeeChatSortType(String webNaming) {
 		this.webNaming = webNaming;
 	}
 
-	public static CoffeeChatSortCondition of(String webNaming) {
-		if (!hasText(webNaming))
+	public static CoffeeChatSortType of(String webNaming) {
+		if (!hasText(webNaming)) {
 			return null;
+		}
 		return Arrays.stream(values())
 			.filter(name -> name.webNaming.equals(webNaming))
 			.findFirst()

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/coffeechat/infrastructure/CoffeeChatRepositoryImpl.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/coffeechat/infrastructure/CoffeeChatRepositoryImpl.java
@@ -18,7 +18,7 @@ import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
 import kernel.jdon.moduleapi.domain.coffeechat.core.CoffeeChatCommand;
-import kernel.jdon.moduleapi.domain.coffeechat.core.CoffeeChatSortCondition;
+import kernel.jdon.moduleapi.domain.coffeechat.core.CoffeeChatSortType;
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
@@ -72,9 +72,9 @@ public class CoffeeChatRepositoryImpl implements CustomCoffeeChatRepository {
 		return new PageImpl<>(content, pageable, totalCount);
 	}
 
-	private OrderSpecifier[] coffeeChatSort(CoffeeChatSortCondition sort) {
+	private OrderSpecifier[] coffeeChatSort(CoffeeChatSortType sort) {
 		ArrayList<Object> orderSpecifiers = new ArrayList<>();
-		if (CoffeeChatSortCondition.VIEW_COUNT == sort) {
+		if (CoffeeChatSortType.VIEW_COUNT == sort) {
 			orderSpecifiers.add(new OrderSpecifier<>(Order.DESC, coffeeChat.viewCount));
 		} else {
 			orderSpecifiers.add(new OrderSpecifier<>(Order.DESC, coffeeChat.createdDate));

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/coffeechat/presentation/CoffeeChatCondition.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/coffeechat/presentation/CoffeeChatCondition.java
@@ -1,13 +1,13 @@
 package kernel.jdon.moduleapi.domain.coffeechat.presentation;
 
-import kernel.jdon.moduleapi.domain.coffeechat.core.CoffeeChatSortCondition;
+import kernel.jdon.moduleapi.domain.coffeechat.core.CoffeeChatSortType;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
 @AllArgsConstructor
 public class CoffeeChatCondition {
-	private CoffeeChatSortCondition sort;
+	private CoffeeChatSortType sort;
 	private String keyword;
 	private Long jobCategory;
 }

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/coffeechat/presentation/CoffeeChatController.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/coffeechat/presentation/CoffeeChatController.java
@@ -18,7 +18,7 @@ import jakarta.validation.Valid;
 import kernel.jdon.moduleapi.domain.coffeechat.application.CoffeeChatFacade;
 import kernel.jdon.moduleapi.domain.coffeechat.core.CoffeeChatCommand;
 import kernel.jdon.moduleapi.domain.coffeechat.core.CoffeeChatInfo;
-import kernel.jdon.moduleapi.domain.coffeechat.core.CoffeeChatSortCondition;
+import kernel.jdon.moduleapi.domain.coffeechat.core.CoffeeChatSortType;
 import kernel.jdon.moduleapi.global.annotation.LoginUser;
 import kernel.jdon.moduleapi.global.dto.SessionUserInfo;
 import kernel.jdon.moduleapi.global.page.PageInfoRequest;
@@ -31,80 +31,79 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 public class CoffeeChatController {
 
-    private final CoffeeChatFacade coffeeChatFacade;
-    private final CoffeeChatDtoMapper coffeeChatDtoMapper;
+	private final CoffeeChatFacade coffeeChatFacade;
+	private final CoffeeChatDtoMapper coffeeChatDtoMapper;
 
-    @GetMapping("/api/v1/coffeechats")
-    public ResponseEntity<CommonResponse<CoffeeChatInfo.FindCoffeeChatListResponse>> getCoffeeChatList(
-        @ModelAttribute final PageInfoRequest pageInfoRequest,
-        @RequestParam(value = "sort", defaultValue = "") final CoffeeChatSortCondition sort,
-        @RequestParam(value = "keyword", defaultValue = "") final String keyword,
-        @RequestParam(value = "jobCategory", defaultValue = "") final Long jobCategory) {
-
+	@GetMapping("/api/v1/coffeechats")
+	public ResponseEntity<CommonResponse<CoffeeChatInfo.FindCoffeeChatListResponse>> getCoffeeChatList(
+		@ModelAttribute final PageInfoRequest pageInfoRequest,
+		@RequestParam(value = "sort", defaultValue = "") final CoffeeChatSortType sort,
+		@RequestParam(value = "keyword", defaultValue = "") final String keyword,
+		@RequestParam(value = "jobCategory", defaultValue = "") final Long jobCategory) {
         final CoffeeChatCommand.FindCoffeeChatListRequest request = coffeeChatDtoMapper.of(
             new CoffeeChatCondition(sort, keyword, jobCategory));
         final CoffeeChatInfo.FindCoffeeChatListResponse info = coffeeChatFacade.getCoffeeChatList(
             pageInfoRequest, request);
         final CoffeeChatDto.FindCoffeeChatListResponse response = coffeeChatDtoMapper.of(info);
 
-        return ResponseEntity.ok(CommonResponse.of(response));
-    }
+		return ResponseEntity.ok(CommonResponse.of(response));
+	}
 
-    @GetMapping("/api/v1/coffeechats/{id}")
-    public ResponseEntity<CommonResponse<CoffeeChatDto.FindCoffeeChatResponse>> getCoffeeChat(
-        @PathVariable(name = "id") Long coffeeChatId,
-        @LoginUser SessionUserInfo member
-    ) {
-        Long memberId = getMemberId(member);
-        CoffeeChatInfo.FindCoffeeChatResponse info = coffeeChatFacade.getCoffeeChat(coffeeChatId, memberId);
-        CoffeeChatDto.FindCoffeeChatResponse response = coffeeChatDtoMapper.of(info);
+	@GetMapping("/api/v1/coffeechats/{id}")
+	public ResponseEntity<CommonResponse<CoffeeChatDto.FindCoffeeChatResponse>> getCoffeeChat(
+		@PathVariable(name = "id") Long coffeeChatId,
+		@LoginUser SessionUserInfo member
+	) {
+		Long memberId = getMemberId(member);
+		CoffeeChatInfo.FindCoffeeChatResponse info = coffeeChatFacade.getCoffeeChat(coffeeChatId, memberId);
+		CoffeeChatDto.FindCoffeeChatResponse response = coffeeChatDtoMapper.of(info);
 
-        return ResponseEntity.ok(CommonResponse.of(response));
-    }
+		return ResponseEntity.ok(CommonResponse.of(response));
+	}
 
-    private Long getMemberId(SessionUserInfo member) {
-        return Optional.ofNullable(member)
-            .map(SessionUserInfo::getId)
-            .orElse(null);
-    }
+	private Long getMemberId(SessionUserInfo member) {
+		return Optional.ofNullable(member)
+			.map(SessionUserInfo::getId)
+			.orElse(null);
+	}
 
-    @PostMapping("/api/v1/coffeechats/{id}")
-    public ResponseEntity<CommonResponse<CoffeeChatDto.ApplyCoffeeChatResponse>> applyCoffeeChat(
-        @PathVariable(name = "id") Long coffeeChatId,
-        @LoginUser SessionUserInfo member
-    ) {
-        CoffeeChatInfo.ApplyCoffeeChatResponse info = coffeeChatFacade.applyCoffeeChat(
-            coffeeChatId, member.getId());
-        CoffeeChatDto.ApplyCoffeeChatResponse response = coffeeChatDtoMapper.of(info);
+	@PostMapping("/api/v1/coffeechats/{id}")
+	public ResponseEntity<CommonResponse<CoffeeChatDto.ApplyCoffeeChatResponse>> applyCoffeeChat(
+		@PathVariable(name = "id") Long coffeeChatId,
+		@LoginUser SessionUserInfo member
+	) {
+		CoffeeChatInfo.ApplyCoffeeChatResponse info = coffeeChatFacade.applyCoffeeChat(
+			coffeeChatId, member.getId());
+		CoffeeChatDto.ApplyCoffeeChatResponse response = coffeeChatDtoMapper.of(info);
 
-        return ResponseEntity.ok().body(CommonResponse.of(response));
-    }
+		return ResponseEntity.ok().body(CommonResponse.of(response));
+	}
 
-    @PostMapping("/api/v1/coffeechats/{id}/cancel")
-    public ResponseEntity<CommonResponse<CoffeeChatDto.CancelCoffeeChatResponse>> cancelCoffeeChat(
-        @PathVariable(name = "id") Long coffeeChatId,
-        @LoginUser SessionUserInfo member
-    ) {
-        CoffeeChatInfo.CancelCoffeeChatResponse info = coffeeChatFacade.cancelCoffeeChatApplication(
-            coffeeChatId, member.getId());
-        CoffeeChatDto.CancelCoffeeChatResponse response = coffeeChatDtoMapper.of(info);
+	@PostMapping("/api/v1/coffeechats/{id}/cancel")
+	public ResponseEntity<CommonResponse<CoffeeChatDto.CancelCoffeeChatResponse>> cancelCoffeeChat(
+		@PathVariable(name = "id") Long coffeeChatId,
+		@LoginUser SessionUserInfo member
+	) {
+		CoffeeChatInfo.CancelCoffeeChatResponse info = coffeeChatFacade.cancelCoffeeChatApplication(
+			coffeeChatId, member.getId());
+		CoffeeChatDto.CancelCoffeeChatResponse response = coffeeChatDtoMapper.of(info);
 
-        return ResponseEntity.ok(CommonResponse.of(response));
-    }
+		return ResponseEntity.ok(CommonResponse.of(response));
+	}
 
-    @PostMapping("/api/v1/coffeechats")
-    public ResponseEntity<CommonResponse<CoffeeChatDto.CreateCoffeeChatResponse>> createCoffeeChat(
-        @RequestBody @Valid CoffeeChatDto.CreateCoffeeChatRequest request,
-        @LoginUser SessionUserInfo member
-    ) {
-        CoffeeChatCommand.CreateCoffeeChatRequest createCommand = coffeeChatDtoMapper.of(request);
-        CoffeeChatInfo.CreateCoffeeChatResponse info = coffeeChatFacade.createCoffeeChat(createCommand,
-            member.getId());
-        CoffeeChatDto.CreateCoffeeChatResponse response = coffeeChatDtoMapper.of(info);
-        URI uri = URI.create("/v1/coffeechats/" + info.getCoffeeChatId());
+	@PostMapping("/api/v1/coffeechats")
+	public ResponseEntity<CommonResponse<CoffeeChatDto.CreateCoffeeChatResponse>> createCoffeeChat(
+		@RequestBody @Valid CoffeeChatDto.CreateCoffeeChatRequest request,
+		@LoginUser SessionUserInfo member
+	) {
+		CoffeeChatCommand.CreateCoffeeChatRequest createCommand = coffeeChatDtoMapper.of(request);
+		CoffeeChatInfo.CreateCoffeeChatResponse info = coffeeChatFacade.createCoffeeChat(createCommand,
+			member.getId());
+		CoffeeChatDto.CreateCoffeeChatResponse response = coffeeChatDtoMapper.of(info);
+		URI uri = URI.create("/v1/coffeechats/" + info.getCoffeeChatId());
 
-        return ResponseEntity.created(uri).body(CommonResponse.of(response));
-    }
+		return ResponseEntity.created(uri).body(CommonResponse.of(response));
+	}
 
     @PutMapping("/api/v1/coffeechats/{id}")
     public ResponseEntity<CommonResponse<CoffeeChatDto.UpdateCoffeeChatResponse>> modifyCoffeeChat(

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/jd/application/JdFacade.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/jd/application/JdFacade.java
@@ -4,6 +4,7 @@ import org.springframework.stereotype.Service;
 
 import kernel.jdon.moduleapi.domain.jd.core.JdInfo;
 import kernel.jdon.moduleapi.domain.jd.core.JdService;
+import kernel.jdon.moduleapi.domain.jd.presentation.JdCondition;
 import kernel.jdon.moduleapi.global.page.PageInfoRequest;
 import lombok.RequiredArgsConstructor;
 
@@ -16,7 +17,8 @@ public class JdFacade {
 		return jdService.getJd(jdId);
 	}
 
-	public JdInfo.FindWantedJdListResponse getJdList(final PageInfoRequest pageInfoRequest, final String keyword) {
-		return jdService.getJdList(pageInfoRequest, keyword);
+	public JdInfo.FindWantedJdListResponse getJdList(final PageInfoRequest pageInfoRequest,
+		final JdCondition jdCondition) {
+		return jdService.getJdList(pageInfoRequest, jdCondition);
 	}
 }

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/jd/application/JdFacade.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/jd/application/JdFacade.java
@@ -11,14 +11,14 @@ import lombok.RequiredArgsConstructor;
 @Service
 @RequiredArgsConstructor
 public class JdFacade {
-	private final JdService jdService;
+    private final JdService jdService;
 
-	public JdInfo.FindWantedJdResponse getJd(final Long jdId) {
-		return jdService.getJd(jdId);
-	}
+    public JdInfo.FindWantedJdResponse getJd(final Long jdId) {
+        return jdService.getJd(jdId);
+    }
 
-	public JdInfo.FindWantedJdListResponse getJdList(final PageInfoRequest pageInfoRequest,
-		final JdCondition jdCondition) {
-		return jdService.getJdList(pageInfoRequest, jdCondition);
-	}
+    public JdInfo.FindWantedJdListResponse getJdList(final PageInfoRequest pageInfoRequest,
+        final JdCondition jdCondition) {
+        return jdService.getJdList(pageInfoRequest, jdCondition);
+    }
 }

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/jd/core/JdInfo.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/jd/core/JdInfo.java
@@ -13,51 +13,51 @@ import lombok.NoArgsConstructor;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class JdInfo {
+	
+    @Getter
+    @Builder
+    public static class FindWantedJdResponse {
+        private final Long id;
+        private final String title;
+        private final String company;
+        private final String imageUrl;
+        private final String jdUrl;
+        private final String requirements;
+        private final String mainTasks;
+        private final String intro;
+        private final String benefits;
+        private final String preferredPoints;
+        private final String jobCategoryName;
+        private final int reviewCount;
+        private final List<FindSkill> skillList;
+    }
 
-	@Getter
-	@Builder
-	public static class FindWantedJdResponse {
-		private final Long id;
-		private final String title;
-		private final String company;
-		private final String imageUrl;
-		private final String jdUrl;
-		private final String requirements;
-		private final String mainTasks;
-		private final String intro;
-		private final String benefits;
-		private final String preferredPoints;
-		private final String jobCategoryName;
-		private final int reviewCount;
-		private final List<FindSkill> skillList;
-	}
+    @Getter
+    @EqualsAndHashCode
+    public static class FindSkill {
+        private final Long id;
+        private final String keyword;
 
-	@Getter
-	@EqualsAndHashCode
-	public static class FindSkill {
-		private final Long id;
-		private final String keyword;
+        public FindSkill(Skill skill) {
+            this.id = skill.getId();
+            this.keyword = skill.getKeyword();
+        }
+    }
 
-		public FindSkill(Skill skill) {
-			this.id = skill.getId();
-			this.keyword = skill.getKeyword();
-		}
-	}
+    @Getter
+    @AllArgsConstructor
+    public static class FindWantedJdListResponse {
+        private final List<FindWantedJd> content;
+        private final CustomPageInfo pageInfo;
+    }
 
-	@Getter
-	@AllArgsConstructor
-	public static class FindWantedJdListResponse {
-		private final List<FindWantedJd> content;
-		private final CustomPageInfo pageInfo;
-	}
-
-	@Getter
-	@Builder
-	public static class FindWantedJd {
-		private final Long id;
-		private final String title;
-		private final String company;
-		private final String imageUrl;
-		private final String jobCategoryName;
-	}
+    @Getter
+    @Builder
+    public static class FindWantedJd {
+        private final Long id;
+        private final String title;
+        private final String company;
+        private final String imageUrl;
+        private final String jobCategoryName;
+    }
 }

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/jd/core/JdInfoMapper.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/jd/core/JdInfoMapper.java
@@ -10,23 +10,23 @@ import org.mapstruct.ReportingPolicy;
 import kernel.jdon.moduledomain.wantedjd.domain.WantedJd;
 
 @Mapper(
-	componentModel = "spring",
-	injectionStrategy = InjectionStrategy.CONSTRUCTOR,
-	unmappedSourcePolicy = ReportingPolicy.WARN
+    componentModel = "spring",
+    injectionStrategy = InjectionStrategy.CONSTRUCTOR,
+    unmappedSourcePolicy = ReportingPolicy.WARN
 )
 public interface JdInfoMapper {
-	@Mapping(source = "wantedJd.id", target = "id")
-	@Mapping(source = "wantedJd.title", target = "title")
-	@Mapping(source = "wantedJd.companyName", target = "company")
-	@Mapping(source = "wantedJd.imageUrl", target = "imageUrl")
-	@Mapping(source = "wantedJd.detailUrl", target = "jdUrl")
-	@Mapping(source = "wantedJd.requirements", target = "requirements")
-	@Mapping(source = "wantedJd.mainTasks", target = "mainTasks")
-	@Mapping(source = "wantedJd.intro", target = "intro")
-	@Mapping(source = "wantedJd.benefits", target = "benefits")
-	@Mapping(source = "wantedJd.preferredPoints", target = "preferredPoints")
-	@Mapping(source = "skillList", target = "skillList")
-	@Mapping(expression = "java(wantedJd.getReviewList().size())", target = "reviewCount")
-	@Mapping(expression = "java(wantedJd.getJobCategory().getName())", target = "jobCategoryName")
-	JdInfo.FindWantedJdResponse of(WantedJd wantedJd, List<JdInfo.FindSkill> skillList);
+    @Mapping(source = "wantedJd.id", target = "id")
+    @Mapping(source = "wantedJd.title", target = "title")
+    @Mapping(source = "wantedJd.companyName", target = "company")
+    @Mapping(source = "wantedJd.imageUrl", target = "imageUrl")
+    @Mapping(source = "wantedJd.detailUrl", target = "jdUrl")
+    @Mapping(source = "wantedJd.requirements", target = "requirements")
+    @Mapping(source = "wantedJd.mainTasks", target = "mainTasks")
+    @Mapping(source = "wantedJd.intro", target = "intro")
+    @Mapping(source = "wantedJd.benefits", target = "benefits")
+    @Mapping(source = "wantedJd.preferredPoints", target = "preferredPoints")
+    @Mapping(source = "skillList", target = "skillList")
+    @Mapping(expression = "java(wantedJd.getReviewList().size())", target = "reviewCount")
+    @Mapping(expression = "java(wantedJd.getJobCategory().getName())", target = "jobCategoryName")
+    JdInfo.FindWantedJdResponse of(WantedJd wantedJd, List<JdInfo.FindSkill> skillList);
 }

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/jd/core/JdReader.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/jd/core/JdReader.java
@@ -2,6 +2,7 @@ package kernel.jdon.moduleapi.domain.jd.core;
 
 import java.util.List;
 
+import kernel.jdon.moduleapi.domain.jd.presentation.JdCondition;
 import kernel.jdon.moduleapi.global.page.PageInfoRequest;
 import kernel.jdon.moduledomain.wantedjd.domain.WantedJd;
 
@@ -10,5 +11,5 @@ public interface JdReader {
 
 	List<JdInfo.FindSkill> findSkillListByWantedJd(WantedJd wantedJd);
 
-	JdInfo.FindWantedJdListResponse findWantedJdList(PageInfoRequest pageInfoRequest, String keyword);
+	JdInfo.FindWantedJdListResponse findWantedJdList(PageInfoRequest pageInfoRequest, JdCondition jdCondition);
 }

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/jd/core/JdReader.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/jd/core/JdReader.java
@@ -7,9 +7,9 @@ import kernel.jdon.moduleapi.global.page.PageInfoRequest;
 import kernel.jdon.moduledomain.wantedjd.domain.WantedJd;
 
 public interface JdReader {
-	WantedJd findWantedJd(Long jdId);
+    WantedJd findWantedJd(Long jdId);
 
-	List<JdInfo.FindSkill> findSkillListByWantedJd(WantedJd wantedJd);
+    List<JdInfo.FindSkill> findSkillListByWantedJd(WantedJd wantedJd);
 
-	JdInfo.FindWantedJdListResponse findWantedJdList(PageInfoRequest pageInfoRequest, JdCondition jdCondition);
+    JdInfo.FindWantedJdListResponse findWantedJdList(PageInfoRequest pageInfoRequest, JdCondition jdCondition);
 }

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/jd/core/JdSearchType.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/jd/core/JdSearchType.java
@@ -4,22 +4,23 @@ import static org.springframework.util.StringUtils.*;
 
 import java.util.Arrays;
 
-public enum JdSearchTypeCondition {
+public enum JdSearchType {
 	COMPANY("company"),
 	TITLE("title");
 
 	private final String searchCondition;
 
-	JdSearchTypeCondition(String searchCondition) {
+	JdSearchType(String searchCondition) {
 		this.searchCondition = searchCondition;
 	}
 
-	public static JdSearchTypeCondition of(String searchCondition) {
-		if (!hasText(searchCondition))
+	public static JdSearchType of(String searchCondition) {
+		if (!hasText(searchCondition)) {
 			return TITLE;
+		}
 		return Arrays.stream(values())
 			.filter(name -> name.searchCondition.equals(searchCondition))
 			.findFirst()
-			.orElseThrow();
+			.orElse(TITLE);
 	}
 }

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/jd/core/JdSearchType.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/jd/core/JdSearchType.java
@@ -5,22 +5,22 @@ import static org.springframework.util.StringUtils.*;
 import java.util.Arrays;
 
 public enum JdSearchType {
-	COMPANY("company"),
-	TITLE("title");
+    COMPANY("company"),
+    TITLE("title");
+	
+    private final String searchCondition;
 
-	private final String searchCondition;
+    JdSearchType(String searchCondition) {
+        this.searchCondition = searchCondition;
+    }
 
-	JdSearchType(String searchCondition) {
-		this.searchCondition = searchCondition;
-	}
-
-	public static JdSearchType of(String searchCondition) {
-		if (!hasText(searchCondition)) {
-			return TITLE;
-		}
-		return Arrays.stream(values())
-			.filter(name -> name.searchCondition.equals(searchCondition))
-			.findFirst()
-			.orElse(TITLE);
-	}
+    public static JdSearchType of(String searchCondition) {
+        if (!hasText(searchCondition)) {
+            return TITLE;
+        }
+        return Arrays.stream(values())
+            .filter(name -> name.searchCondition.equals(searchCondition))
+            .findFirst()
+            .orElse(TITLE);
+    }
 }

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/jd/core/JdSearchTypeCondition.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/jd/core/JdSearchTypeCondition.java
@@ -1,0 +1,25 @@
+package kernel.jdon.moduleapi.domain.jd.core;
+
+import static org.springframework.util.StringUtils.*;
+
+import java.util.Arrays;
+
+public enum JdSearchTypeCondition {
+	COMPANY("company"),
+	TITLE("title");
+
+	private final String searchCondition;
+
+	JdSearchTypeCondition(String searchCondition) {
+		this.searchCondition = searchCondition;
+	}
+
+	public static JdSearchTypeCondition of(String searchCondition) {
+		if (!hasText(searchCondition))
+			return null;
+		return Arrays.stream(values())
+			.filter(name -> name.searchCondition.equals(searchCondition))
+			.findFirst()
+			.orElseThrow();
+	}
+}

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/jd/core/JdSearchTypeCondition.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/jd/core/JdSearchTypeCondition.java
@@ -16,7 +16,7 @@ public enum JdSearchTypeCondition {
 
 	public static JdSearchTypeCondition of(String searchCondition) {
 		if (!hasText(searchCondition))
-			return null;
+			return TITLE;
 		return Arrays.stream(values())
 			.filter(name -> name.searchCondition.equals(searchCondition))
 			.findFirst()

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/jd/core/JdService.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/jd/core/JdService.java
@@ -1,9 +1,10 @@
 package kernel.jdon.moduleapi.domain.jd.core;
 
+import kernel.jdon.moduleapi.domain.jd.presentation.JdCondition;
 import kernel.jdon.moduleapi.global.page.PageInfoRequest;
 
 public interface JdService {
 	JdInfo.FindWantedJdResponse getJd(Long jdId);
 
-	JdInfo.FindWantedJdListResponse getJdList(PageInfoRequest pageInfoRequest, String keyword);
+	JdInfo.FindWantedJdListResponse getJdList(PageInfoRequest pageInfoRequest, JdCondition jdCondition);
 }

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/jd/core/JdService.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/jd/core/JdService.java
@@ -4,7 +4,7 @@ import kernel.jdon.moduleapi.domain.jd.presentation.JdCondition;
 import kernel.jdon.moduleapi.global.page.PageInfoRequest;
 
 public interface JdService {
-	JdInfo.FindWantedJdResponse getJd(Long jdId);
+    JdInfo.FindWantedJdResponse getJd(Long jdId);
 
-	JdInfo.FindWantedJdListResponse getJdList(PageInfoRequest pageInfoRequest, JdCondition jdCondition);
+    JdInfo.FindWantedJdListResponse getJdList(PageInfoRequest pageInfoRequest, JdCondition jdCondition);
 }

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/jd/core/JdServiceImpl.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/jd/core/JdServiceImpl.java
@@ -12,21 +12,21 @@ import lombok.RequiredArgsConstructor;
 @Service
 @RequiredArgsConstructor
 public class JdServiceImpl implements JdService {
-	private final JdReader jdReader;
-	private final JdInfoMapper jdInfoMapper;
+    private final JdReader jdReader;
+    private final JdInfoMapper jdInfoMapper;
 
-	@Override
-	public JdInfo.FindWantedJdResponse getJd(final Long jdId) {
-		final WantedJd findWantedJd = jdReader.findWantedJd(jdId);
-		final List<JdInfo.FindSkill> findSkillList = jdReader.findSkillListByWantedJd(findWantedJd);
+    @Override
+    public JdInfo.FindWantedJdResponse getJd(final Long jdId) {
+        final WantedJd findWantedJd = jdReader.findWantedJd(jdId);
+        final List<JdInfo.FindSkill> findSkillList = jdReader.findSkillListByWantedJd(findWantedJd);
 
-		return jdInfoMapper.of(findWantedJd, findSkillList);
-	}
+        return jdInfoMapper.of(findWantedJd, findSkillList);
+    }
 
-	@Override
-	public JdInfo.FindWantedJdListResponse getJdList(final PageInfoRequest pageInfoRequest,
-		final JdCondition jdCondition) {
-		return jdReader.findWantedJdList(pageInfoRequest, jdCondition);
-	}
+    @Override
+    public JdInfo.FindWantedJdListResponse getJdList(final PageInfoRequest pageInfoRequest,
+        final JdCondition jdCondition) {
+        return jdReader.findWantedJdList(pageInfoRequest, jdCondition);
+    }
 
 }

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/jd/core/JdServiceImpl.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/jd/core/JdServiceImpl.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import org.springframework.stereotype.Service;
 
+import kernel.jdon.moduleapi.domain.jd.presentation.JdCondition;
 import kernel.jdon.moduleapi.global.page.PageInfoRequest;
 import kernel.jdon.moduledomain.wantedjd.domain.WantedJd;
 import lombok.RequiredArgsConstructor;
@@ -23,8 +24,9 @@ public class JdServiceImpl implements JdService {
 	}
 
 	@Override
-	public JdInfo.FindWantedJdListResponse getJdList(final PageInfoRequest pageInfoRequest, final String keyword) {
-		return jdReader.findWantedJdList(pageInfoRequest, keyword);
+	public JdInfo.FindWantedJdListResponse getJdList(final PageInfoRequest pageInfoRequest,
+		final JdCondition jdCondition) {
+		return jdReader.findWantedJdList(pageInfoRequest, jdCondition);
 	}
 
 }

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/jd/core/JdSortType.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/jd/core/JdSortType.java
@@ -5,22 +5,22 @@ import static org.springframework.util.StringUtils.*;
 import java.util.Arrays;
 
 public enum JdSortType {
-	LATEST("latest"),
-	REVIEW("review");
+    LATEST("latest"),
+    REVIEW("review");
+	
+    private final String sortCondition;
 
-	private final String sortCondition;
+    JdSortType(String sortCondition) {
+        this.sortCondition = sortCondition;
+    }
 
-	JdSortType(String sortCondition) {
-		this.sortCondition = sortCondition;
-	}
-
-	public static JdSortType of(String sortCondition) {
-		if (!hasText(sortCondition)) {
-			return LATEST;
-		}
-		return Arrays.stream(values())
-			.filter(name -> name.sortCondition.equals(sortCondition))
-			.findFirst()
-			.orElse(LATEST);
-	}
+    public static JdSortType of(String sortCondition) {
+        if (!hasText(sortCondition)) {
+            return LATEST;
+        }
+        return Arrays.stream(values())
+            .filter(name -> name.sortCondition.equals(sortCondition))
+            .findFirst()
+            .orElse(LATEST);
+    }
 }

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/jd/core/JdSortType.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/jd/core/JdSortType.java
@@ -4,22 +4,23 @@ import static org.springframework.util.StringUtils.*;
 
 import java.util.Arrays;
 
-public enum JdSortTypeCondition {
+public enum JdSortType {
 	LATEST("latest"),
 	REVIEW("review");
 
 	private final String sortCondition;
 
-	JdSortTypeCondition(String sortCondition) {
+	JdSortType(String sortCondition) {
 		this.sortCondition = sortCondition;
 	}
 
-	public static JdSortTypeCondition of(String sortCondition) {
-		if (!hasText(sortCondition))
+	public static JdSortType of(String sortCondition) {
+		if (!hasText(sortCondition)) {
 			return LATEST;
+		}
 		return Arrays.stream(values())
 			.filter(name -> name.sortCondition.equals(sortCondition))
 			.findFirst()
-			.orElseThrow();
+			.orElse(LATEST);
 	}
 }

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/jd/core/JdSortTypeCondition.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/jd/core/JdSortTypeCondition.java
@@ -16,7 +16,7 @@ public enum JdSortTypeCondition {
 
 	public static JdSortTypeCondition of(String sortCondition) {
 		if (!hasText(sortCondition))
-			return null;
+			return LATEST;
 		return Arrays.stream(values())
 			.filter(name -> name.sortCondition.equals(sortCondition))
 			.findFirst()

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/jd/core/JdSortTypeCondition.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/jd/core/JdSortTypeCondition.java
@@ -1,0 +1,25 @@
+package kernel.jdon.moduleapi.domain.jd.core;
+
+import static org.springframework.util.StringUtils.*;
+
+import java.util.Arrays;
+
+public enum JdSortTypeCondition {
+	LATEST("latest"),
+	REVIEW("review");
+
+	private final String sortCondition;
+
+	JdSortTypeCondition(String sortCondition) {
+		this.sortCondition = sortCondition;
+	}
+
+	public static JdSortTypeCondition of(String sortCondition) {
+		if (!hasText(sortCondition))
+			return null;
+		return Arrays.stream(values())
+			.filter(name -> name.sortCondition.equals(sortCondition))
+			.findFirst()
+			.orElseThrow();
+	}
+}

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/jd/infrastructure/CustomWantedJdRepository.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/jd/infrastructure/CustomWantedJdRepository.java
@@ -3,6 +3,8 @@ package kernel.jdon.moduleapi.domain.jd.infrastructure;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
+import kernel.jdon.moduleapi.domain.jd.presentation.JdCondition;
+
 public interface CustomWantedJdRepository {
-	Page<JdReaderInfo.FindWantedJd> findWantedJdList(Pageable pageable, String keyword);
+	Page<JdReaderInfo.FindWantedJd> findWantedJdList(Pageable pageable, JdCondition jdCondition);
 }

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/jd/infrastructure/CustomWantedJdRepository.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/jd/infrastructure/CustomWantedJdRepository.java
@@ -6,5 +6,5 @@ import org.springframework.data.domain.Pageable;
 import kernel.jdon.moduleapi.domain.jd.presentation.JdCondition;
 
 public interface CustomWantedJdRepository {
-	Page<JdReaderInfo.FindWantedJd> findWantedJdList(Pageable pageable, JdCondition jdCondition);
+    Page<JdReaderInfo.FindWantedJd> findWantedJdList(Pageable pageable, JdCondition jdCondition);
 }

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/jd/infrastructure/JdReaderImpl.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/jd/infrastructure/JdReaderImpl.java
@@ -10,6 +10,7 @@ import org.springframework.stereotype.Component;
 import kernel.jdon.moduleapi.domain.jd.core.JdInfo;
 import kernel.jdon.moduleapi.domain.jd.core.JdReader;
 import kernel.jdon.moduleapi.domain.jd.error.JdErrorCode;
+import kernel.jdon.moduleapi.domain.jd.presentation.JdCondition;
 import kernel.jdon.moduleapi.global.page.CustomJpaPageInfo;
 import kernel.jdon.moduleapi.global.page.PageInfoRequest;
 import kernel.jdon.moduledomain.wantedjd.domain.WantedJd;
@@ -38,10 +39,10 @@ public class JdReaderImpl implements JdReader {
 
 	@Override
 	public JdInfo.FindWantedJdListResponse findWantedJdList(final PageInfoRequest pageInfoRequest,
-		final String keyword) {
+		final JdCondition jdCondition) {
 		final Pageable pageable = PageRequest.of(pageInfoRequest.getPage(), pageInfoRequest.getSize());
 
-		final Page<JdReaderInfo.FindWantedJd> readerInfo = wantedJdRepository.findWantedJdList(pageable, keyword);
+		final Page<JdReaderInfo.FindWantedJd> readerInfo = wantedJdRepository.findWantedJdList(pageable, jdCondition);
 
 		final List<JdInfo.FindWantedJd> content = readerInfo.stream()
 			.map(jdReaderInfoMapper::of)

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/jd/infrastructure/JdReaderImpl.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/jd/infrastructure/JdReaderImpl.java
@@ -19,35 +19,35 @@ import lombok.RequiredArgsConstructor;
 @Component
 @RequiredArgsConstructor
 public class JdReaderImpl implements JdReader {
-	private final WantedJdRepository wantedJdRepository;
-	private final JdReaderInfoMapper jdReaderInfoMapper;
+    private final WantedJdRepository wantedJdRepository;
+    private final JdReaderInfoMapper jdReaderInfoMapper;
 
-	@Override
-	public WantedJd findWantedJd(final Long jdId) {
-		return wantedJdRepository.findById(jdId)
-			.orElseThrow(JdErrorCode.NOT_FOUND_JD::throwException);
-	}
+    @Override
+    public WantedJd findWantedJd(final Long jdId) {
+        return wantedJdRepository.findById(jdId)
+            .orElseThrow(JdErrorCode.NOT_FOUND_JD::throwException);
+    }
 
-	@Override
-	public List<JdInfo.FindSkill> findSkillListByWantedJd(final WantedJd wantedJd) {
-		return wantedJd.getSkillList().stream()
-			.map(wantedJdSkill -> new JdInfo.FindSkill(
-				wantedJdSkill.getSkill()))
-			.distinct()
-			.toList();
-	}
+    @Override
+    public List<JdInfo.FindSkill> findSkillListByWantedJd(final WantedJd wantedJd) {
+        return wantedJd.getSkillList().stream()
+            .map(wantedJdSkill -> new JdInfo.FindSkill(
+                wantedJdSkill.getSkill()))
+            .distinct()
+            .toList();
+    }
 
-	@Override
-	public JdInfo.FindWantedJdListResponse findWantedJdList(final PageInfoRequest pageInfoRequest,
-		final JdCondition jdCondition) {
-		final Pageable pageable = PageRequest.of(pageInfoRequest.getPage(), pageInfoRequest.getSize());
+    @Override
+    public JdInfo.FindWantedJdListResponse findWantedJdList(final PageInfoRequest pageInfoRequest,
+        final JdCondition jdCondition) {
+        final Pageable pageable = PageRequest.of(pageInfoRequest.getPage(), pageInfoRequest.getSize());
 
-		final Page<JdReaderInfo.FindWantedJd> readerInfo = wantedJdRepository.findWantedJdList(pageable, jdCondition);
+        final Page<JdReaderInfo.FindWantedJd> readerInfo = wantedJdRepository.findWantedJdList(pageable, jdCondition);
 
-		final List<JdInfo.FindWantedJd> content = readerInfo.stream()
-			.map(jdReaderInfoMapper::of)
-			.toList();
+        final List<JdInfo.FindWantedJd> content = readerInfo.stream()
+            .map(jdReaderInfoMapper::of)
+            .toList();
 
-		return new JdInfo.FindWantedJdListResponse(content, new CustomJpaPageInfo(readerInfo));
-	}
+        return new JdInfo.FindWantedJdListResponse(content, new CustomJpaPageInfo(readerInfo));
+    }
 }

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/jd/infrastructure/JdReaderInfo.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/jd/infrastructure/JdReaderInfo.java
@@ -8,22 +8,21 @@ import lombok.NoArgsConstructor;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class JdReaderInfo {
+    @Getter
+    public static class FindWantedJd {
+        private final Long id;
+        private final String title;
+        private final String company;
+        private final String imageUrl;
+        private final String jobCategoryName;
 
-	@Getter
-	public static class FindWantedJd {
-		private final Long id;
-		private final String title;
-		private final String company;
-		private final String imageUrl;
-		private final String jobCategoryName;
-
-		@QueryProjection
-		public FindWantedJd(Long id, String title, String company, String imageUrl, String jobCategoryName) {
-			this.id = id;
-			this.title = title;
-			this.company = company;
-			this.imageUrl = imageUrl;
-			this.jobCategoryName = jobCategoryName;
-		}
-	}
+        @QueryProjection
+        public FindWantedJd(Long id, String title, String company, String imageUrl, String jobCategoryName) {
+            this.id = id;
+            this.title = title;
+            this.company = company;
+            this.imageUrl = imageUrl;
+            this.jobCategoryName = jobCategoryName;
+        }
+    }
 }

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/jd/infrastructure/WantedJdRepositoryImpl.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/jd/infrastructure/WantedJdRepositoryImpl.java
@@ -2,25 +2,34 @@ package kernel.jdon.moduleapi.domain.jd.infrastructure;
 
 import static kernel.jdon.moduledomain.jobcategory.domain.QJobCategory.*;
 import static kernel.jdon.moduledomain.wantedjd.domain.QWantedJd.*;
+import static kernel.jdon.moduledomain.wantedjdskill.domain.QWantedJdSkill.*;
 import static org.springframework.util.StringUtils.*;
 
 import java.util.List;
+import java.util.Objects;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
+import kernel.jdon.moduleapi.domain.jd.core.JdSearchTypeCondition;
+import kernel.jdon.moduleapi.domain.jd.core.JdSortTypeCondition;
+import kernel.jdon.moduleapi.domain.jd.presentation.JdCondition;
+import kernel.jdon.moduleapi.domain.skill.infrastructure.SkillKeywordManager;
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
 public class WantedJdRepositoryImpl implements CustomWantedJdRepository {
 	private final JPAQueryFactory jpaQueryFactory;
+	private final SkillKeywordManager skillKeywordManager;
 
-	@Override
-	public Page<JdReaderInfo.FindWantedJd> findWantedJdList(final Pageable pageable, final String keyword) {
+	public Page<JdReaderInfo.FindWantedJd> findWantedJdList(final Pageable pageable, final JdCondition jdCondition) {
 
 		List<JdReaderInfo.FindWantedJd> content = jpaQueryFactory
 			.select(new QJdReaderInfo_FindWantedJd(
@@ -30,10 +39,12 @@ public class WantedJdRepositoryImpl implements CustomWantedJdRepository {
 				wantedJd.imageUrl,
 				jobCategory.name))
 			.from(wantedJd)
-			.join(jobCategory)
-			.on(wantedJd.jobCategory.eq(jobCategory))
-			.where(wantedJdTitleContains(keyword))
-			.orderBy(wantedJd.scrapingDate.desc())
+			.join(jobCategory).on(wantedJd.jobCategory.eq(jobCategory))
+			.where(wantedJdSkillContains(jdCondition.getSkill()),
+				wantedJdJobCategoryContains(jdCondition.getJobCategory()),
+				wantedJdKeywordContains(jdCondition.getKeywordType(), jdCondition.getKeyword())
+			)
+			.orderBy(createOrderSpecifier(jdCondition.getSort()))
 			.offset(pageable.getOffset())
 			.limit(pageable.getPageSize())
 			.fetch();
@@ -41,13 +52,53 @@ public class WantedJdRepositoryImpl implements CustomWantedJdRepository {
 		Long totalCount = jpaQueryFactory
 			.select(wantedJd.count())
 			.from(wantedJd)
-			.where(wantedJdTitleContains(keyword))
+			.where(wantedJdSkillContains(jdCondition.getSkill()),
+				wantedJdJobCategoryContains(jdCondition.getJobCategory()),
+				wantedJdKeywordContains(jdCondition.getKeywordType(), jdCondition.getKeyword())
+			)
 			.fetchOne();
 
 		return new PageImpl<>(content, pageable, totalCount);
 	}
 
-	private BooleanExpression wantedJdTitleContains(String keyword) {
+	private BooleanExpression wantedJdKeywordContains(final JdSearchTypeCondition keywordType, final String keyword) {
+		return Objects.nonNull(keywordType) ? switch (keywordType) {
+			case COMPANY -> wantedJdCompanyContains(keyword);
+			default -> wantedJdTitleContains(keyword);
+		} : null;
+	}
+
+	private BooleanExpression wantedJdCompanyContains(final String keyword) {
+		return hasText(keyword) ?
+			wantedJd.companyName.contains(keyword)
+			: null;
+	}
+
+	private BooleanExpression wantedJdTitleContains(final String keyword) {
 		return hasText(keyword) ? wantedJd.title.contains(keyword) : null;
+	}
+
+	private BooleanExpression wantedJdJobCategoryContains(final Long jobCategory) {
+		return Objects.nonNull(jobCategory) ?
+			wantedJd.jobCategory.id.eq(jobCategory)
+			: null;
+	}
+
+	private BooleanExpression wantedJdSkillContains(final String skill) {
+		final List<String> allKeywordAssociatedTermList = skillKeywordManager
+			.getAllKeywordAssociatedTermsByKeyword(skill);
+
+		return hasText(skill) ?
+			wantedJd.id.in(JPAExpressions.select(wantedJdSkill.wantedJd.id)
+				.from(wantedJdSkill)
+				.where(wantedJdSkill.skill.keyword.in(allKeywordAssociatedTermList)))
+			: null;
+	}
+
+	private OrderSpecifier createOrderSpecifier(final JdSortTypeCondition sort) {
+		return Objects.nonNull(sort) ? switch (sort) {
+			case REVIEW -> new OrderSpecifier<>(Order.DESC, wantedJd.reviewList.size());
+			default -> new OrderSpecifier<>(Order.DESC, wantedJd.scrapingDate);
+		} : null;
 	}
 }

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/jd/infrastructure/WantedJdRepositoryImpl.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/jd/infrastructure/WantedJdRepositoryImpl.java
@@ -19,8 +19,8 @@ import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
-import kernel.jdon.moduleapi.domain.jd.core.JdSearchTypeCondition;
-import kernel.jdon.moduleapi.domain.jd.core.JdSortTypeCondition;
+import kernel.jdon.moduleapi.domain.jd.core.JdSearchType;
+import kernel.jdon.moduleapi.domain.jd.core.JdSortType;
 import kernel.jdon.moduleapi.domain.jd.presentation.JdCondition;
 import kernel.jdon.moduleapi.domain.skill.infrastructure.SkillKeywordManager;
 import lombok.RequiredArgsConstructor;
@@ -57,17 +57,14 @@ public class WantedJdRepositoryImpl implements CustomWantedJdRepository {
 
 	private BooleanBuilder searchWantedJdList(JdCondition jdCondition) {
 		BooleanBuilder searchCondition = new BooleanBuilder();
-
-		if (jdCondition != null) {
-			searchCondition.and(wantedJdSkillContains(jdCondition.getSkill()));
-			searchCondition.and(wantedJdJobCategoryContains(jdCondition.getJobCategory()));
-			searchCondition.and(wantedJdKeywordContains(jdCondition.getKeywordType(), jdCondition.getKeyword()));
-		}
+		searchCondition.and(wantedJdSkillContains(jdCondition.getSkill()));
+		searchCondition.and(wantedJdJobCategoryContains(jdCondition.getJobCategory()));
+		searchCondition.and(wantedJdKeywordContains(jdCondition.getKeywordType(), jdCondition.getKeyword()));
 
 		return searchCondition;
 	}
 
-	private BooleanExpression wantedJdKeywordContains(final JdSearchTypeCondition keywordType, final String keyword) {
+	private BooleanExpression wantedJdKeywordContains(final JdSearchType keywordType, final String keyword) {
 		return switch (keywordType) {
 			case COMPANY -> wantedJdCompanyContains(keyword);
 			default -> wantedJdTitleContains(keyword);
@@ -101,7 +98,7 @@ public class WantedJdRepositoryImpl implements CustomWantedJdRepository {
 			: null;
 	}
 
-	private OrderSpecifier createOrderSpecifier(final JdSortTypeCondition sort) {
+	private OrderSpecifier createOrderSpecifier(final JdSortType sort) {
 		return switch (sort) {
 			case REVIEW -> new OrderSpecifier<>(Order.DESC, wantedJd.reviewList.size());
 			default -> new OrderSpecifier<>(Order.DESC, wantedJd.scrapingDate);

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/jd/infrastructure/WantedJdRepositoryImpl.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/jd/infrastructure/WantedJdRepositoryImpl.java
@@ -27,81 +27,81 @@ import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
 public class WantedJdRepositoryImpl implements CustomWantedJdRepository {
-	private final JPAQueryFactory jpaQueryFactory;
-	private final SkillKeywordManager skillKeywordManager;
+    private final JPAQueryFactory jpaQueryFactory;
+    private final SkillKeywordManager skillKeywordManager;
 
-	public Page<JdReaderInfo.FindWantedJd> findWantedJdList(final Pageable pageable, final JdCondition jdCondition) {
-		List<JdReaderInfo.FindWantedJd> content = jpaQueryFactory
-			.select(new QJdReaderInfo_FindWantedJd(
-				wantedJd.id,
-				wantedJd.title,
-				wantedJd.companyName,
-				wantedJd.imageUrl,
-				jobCategory.name))
-			.from(wantedJd)
-			.join(jobCategory).on(wantedJd.jobCategory.eq(jobCategory))
-			.where(searchWantedJdList(jdCondition))
-			.orderBy(createOrderSpecifier(jdCondition.getSort()))
-			.offset(pageable.getOffset())
-			.limit(pageable.getPageSize())
-			.fetch();
+    public Page<JdReaderInfo.FindWantedJd> findWantedJdList(final Pageable pageable, final JdCondition jdCondition) {
+        List<JdReaderInfo.FindWantedJd> content = jpaQueryFactory
+            .select(new QJdReaderInfo_FindWantedJd(
+                wantedJd.id,
+                wantedJd.title,
+                wantedJd.companyName,
+                wantedJd.imageUrl,
+                jobCategory.name))
+            .from(wantedJd)
+            .join(jobCategory).on(wantedJd.jobCategory.eq(jobCategory))
+            .where(searchWantedJdList(jdCondition))
+            .orderBy(createOrderSpecifier(jdCondition.getSort()))
+            .offset(pageable.getOffset())
+            .limit(pageable.getPageSize())
+            .fetch();
 
-		Long totalCount = jpaQueryFactory
-			.select(wantedJd.count())
-			.from(wantedJd)
-			.where(searchWantedJdList(jdCondition))
-			.fetchOne();
+        Long totalCount = jpaQueryFactory
+            .select(wantedJd.count())
+            .from(wantedJd)
+            .where(searchWantedJdList(jdCondition))
+            .fetchOne();
 
-		return new PageImpl<>(content, pageable, totalCount);
-	}
+        return new PageImpl<>(content, pageable, totalCount);
+    }
 
-	private BooleanBuilder searchWantedJdList(JdCondition jdCondition) {
-		BooleanBuilder searchCondition = new BooleanBuilder();
-		searchCondition.and(wantedJdSkillContains(jdCondition.getSkill()));
-		searchCondition.and(wantedJdJobCategoryContains(jdCondition.getJobCategory()));
-		searchCondition.and(wantedJdKeywordContains(jdCondition.getKeywordType(), jdCondition.getKeyword()));
+    private BooleanBuilder searchWantedJdList(JdCondition jdCondition) {
+        BooleanBuilder searchCondition = new BooleanBuilder();
+        searchCondition.and(wantedJdSkillContains(jdCondition.getSkill()));
+        searchCondition.and(wantedJdJobCategoryContains(jdCondition.getJobCategory()));
+        searchCondition.and(wantedJdKeywordContains(jdCondition.getKeywordType(), jdCondition.getKeyword()));
 
-		return searchCondition;
-	}
+        return searchCondition;
+    }
 
-	private BooleanExpression wantedJdKeywordContains(final JdSearchType keywordType, final String keyword) {
-		return switch (keywordType) {
-			case COMPANY -> wantedJdCompanyContains(keyword);
-			default -> wantedJdTitleContains(keyword);
-		};
-	}
+    private BooleanExpression wantedJdKeywordContains(final JdSearchType keywordType, final String keyword) {
+        return switch (keywordType) {
+            case COMPANY -> wantedJdCompanyContains(keyword);
+            default -> wantedJdTitleContains(keyword);
+        };
+    }
 
-	private BooleanExpression wantedJdCompanyContains(final String keyword) {
-		return hasText(keyword) ?
-			wantedJd.companyName.contains(keyword)
-			: null;
-	}
+    private BooleanExpression wantedJdCompanyContains(final String keyword) {
+        return hasText(keyword) ?
+            wantedJd.companyName.contains(keyword)
+            : null;
+    }
 
-	private BooleanExpression wantedJdTitleContains(final String keyword) {
-		return hasText(keyword) ? wantedJd.title.contains(keyword) : null;
-	}
+    private BooleanExpression wantedJdTitleContains(final String keyword) {
+        return hasText(keyword) ? wantedJd.title.contains(keyword) : null;
+    }
 
-	private BooleanExpression wantedJdJobCategoryContains(final Long jobCategory) {
-		return Objects.nonNull(jobCategory) ?
-			wantedJd.jobCategory.id.eq(jobCategory)
-			: null;
-	}
+    private BooleanExpression wantedJdJobCategoryContains(final Long jobCategory) {
+        return Objects.nonNull(jobCategory) ?
+            wantedJd.jobCategory.id.eq(jobCategory)
+            : null;
+    }
 
-	private BooleanExpression wantedJdSkillContains(final String skill) {
-		final List<String> allKeywordAssociatedTermList = skillKeywordManager
-			.getAllKeywordAssociatedTermsByKeyword(skill);
+    private BooleanExpression wantedJdSkillContains(final String skill) {
+        final List<String> allKeywordAssociatedTermList = skillKeywordManager
+            .getAllKeywordAssociatedTermsByKeyword(skill);
 
-		return hasText(skill) ?
-			wantedJd.id.in(JPAExpressions.select(wantedJdSkill.wantedJd.id)
-				.from(wantedJdSkill)
-				.where(wantedJdSkill.skill.keyword.in(allKeywordAssociatedTermList)))
-			: null;
-	}
+        return hasText(skill) ?
+            wantedJd.id.in(JPAExpressions.select(wantedJdSkill.wantedJd.id)
+                .from(wantedJdSkill)
+                .where(wantedJdSkill.skill.keyword.in(allKeywordAssociatedTermList)))
+            : null;
+    }
 
-	private OrderSpecifier createOrderSpecifier(final JdSortType sort) {
-		return switch (sort) {
-			case REVIEW -> new OrderSpecifier<>(Order.DESC, wantedJd.reviewList.size());
-			default -> new OrderSpecifier<>(Order.DESC, wantedJd.scrapingDate);
-		};
-	}
+    private OrderSpecifier createOrderSpecifier(final JdSortType sort) {
+        return switch (sort) {
+            case REVIEW -> new OrderSpecifier<>(Order.DESC, wantedJd.reviewList.size());
+            default -> new OrderSpecifier<>(Order.DESC, wantedJd.scrapingDate);
+        };
+    }
 }

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/jd/infrastructure/WantedJdRepositoryImpl.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/jd/infrastructure/WantedJdRepositoryImpl.java
@@ -62,10 +62,10 @@ public class WantedJdRepositoryImpl implements CustomWantedJdRepository {
 	}
 
 	private BooleanExpression wantedJdKeywordContains(final JdSearchTypeCondition keywordType, final String keyword) {
-		return Objects.nonNull(keywordType) ? switch (keywordType) {
+		return switch (keywordType) {
 			case COMPANY -> wantedJdCompanyContains(keyword);
 			default -> wantedJdTitleContains(keyword);
-		} : null;
+		};
 	}
 
 	private BooleanExpression wantedJdCompanyContains(final String keyword) {
@@ -96,9 +96,9 @@ public class WantedJdRepositoryImpl implements CustomWantedJdRepository {
 	}
 
 	private OrderSpecifier createOrderSpecifier(final JdSortTypeCondition sort) {
-		return Objects.nonNull(sort) ? switch (sort) {
+		return switch (sort) {
 			case REVIEW -> new OrderSpecifier<>(Order.DESC, wantedJd.reviewList.size());
 			default -> new OrderSpecifier<>(Order.DESC, wantedJd.scrapingDate);
-		} : null;
+		};
 	}
 }

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/jd/presentation/JdCondition.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/jd/presentation/JdCondition.java
@@ -8,15 +8,15 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public class JdCondition {
-	private final String skill;
-	private final Long jobCategory;
-	private final JdSearchType keywordType;
-	private final String keyword;
-	private final JdSortType sort;
+    private final String skill;
+    private final Long jobCategory;
+    private final JdSearchType keywordType;
+    private final String keyword;
+    private final JdSortType sort;
 
-	public static JdCondition of(final String skill, final Long jobCategory,
-		final JdSearchType keywordType, final String keyword,
-		final JdSortType sort) {
-		return new JdCondition(skill, jobCategory, keywordType, keyword, sort);
-	}
+    public static JdCondition of(final String skill, final Long jobCategory,
+        final JdSearchType keywordType, final String keyword,
+        final JdSortType sort) {
+        return new JdCondition(skill, jobCategory, keywordType, keyword, sort);
+    }
 }

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/jd/presentation/JdCondition.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/jd/presentation/JdCondition.java
@@ -1,0 +1,22 @@
+package kernel.jdon.moduleapi.domain.jd.presentation;
+
+import kernel.jdon.moduleapi.domain.jd.core.JdSearchTypeCondition;
+import kernel.jdon.moduleapi.domain.jd.core.JdSortTypeCondition;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class JdCondition {
+	private final String skill;
+	private final Long jobCategory;
+	private final JdSearchTypeCondition keywordType;
+	private final String keyword;
+	private final JdSortTypeCondition sort;
+
+	public static JdCondition of(final String skill, final Long jobCategory,
+		final JdSearchTypeCondition keywordType, final String keyword,
+		final JdSortTypeCondition sort) {
+		return new JdCondition(skill, jobCategory, keywordType, keyword, sort);
+	}
+}

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/jd/presentation/JdCondition.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/jd/presentation/JdCondition.java
@@ -1,7 +1,7 @@
 package kernel.jdon.moduleapi.domain.jd.presentation;
 
-import kernel.jdon.moduleapi.domain.jd.core.JdSearchTypeCondition;
-import kernel.jdon.moduleapi.domain.jd.core.JdSortTypeCondition;
+import kernel.jdon.moduleapi.domain.jd.core.JdSearchType;
+import kernel.jdon.moduleapi.domain.jd.core.JdSortType;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -10,13 +10,13 @@ import lombok.Getter;
 public class JdCondition {
 	private final String skill;
 	private final Long jobCategory;
-	private final JdSearchTypeCondition keywordType;
+	private final JdSearchType keywordType;
 	private final String keyword;
-	private final JdSortTypeCondition sort;
+	private final JdSortType sort;
 
 	public static JdCondition of(final String skill, final Long jobCategory,
-		final JdSearchTypeCondition keywordType, final String keyword,
-		final JdSortTypeCondition sort) {
+		final JdSearchType keywordType, final String keyword,
+		final JdSortType sort) {
 		return new JdCondition(skill, jobCategory, keywordType, keyword, sort);
 	}
 }

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/jd/presentation/JdController.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/jd/presentation/JdController.java
@@ -34,7 +34,7 @@ public class JdController {
     public ResponseEntity<CommonResponse<JdDto.FindWantedJdListResponse>> getJdList(
         @ModelAttribute final PageInfoRequest pageInfoRequest,
         @RequestParam(value = "skill", defaultValue = "") final String skill,
-        @RequestParam(value = "jobCategory", required = false) final Long jobCategory,
+        @RequestParam(value = "jobCategory", defaultValue = "") final Long jobCategory,
         @RequestParam(value = "keywordType", defaultValue = "") final JdSearchType keywordType,
         @RequestParam(value = "keyword", defaultValue = "") final String keyword,
         @RequestParam(value = "sort", defaultValue = "") final JdSortType sort) {

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/jd/presentation/JdController.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/jd/presentation/JdController.java
@@ -34,7 +34,7 @@ public class JdController {
 	public ResponseEntity<CommonResponse<JdDto.FindWantedJdListResponse>> getJdList(
 		@ModelAttribute final PageInfoRequest pageInfoRequest,
 		@RequestParam(value = "skill", defaultValue = "") final String skill,
-		@RequestParam(value = "jobCategory", defaultValue = "") final Long jobCategory,
+		@RequestParam(value = "jobCategory", required = false) final Long jobCategory,
 		@RequestParam(value = "keywordType", defaultValue = "") final JdSearchTypeCondition keywordType,
 		@RequestParam(value = "keyword", defaultValue = "") final String keyword,
 		@RequestParam(value = "sort", defaultValue = "") final JdSortTypeCondition sort) {

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/jd/presentation/JdController.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/jd/presentation/JdController.java
@@ -9,8 +9,8 @@ import org.springframework.web.bind.annotation.RestController;
 
 import kernel.jdon.moduleapi.domain.jd.application.JdFacade;
 import kernel.jdon.moduleapi.domain.jd.core.JdInfo;
-import kernel.jdon.moduleapi.domain.jd.core.JdSearchTypeCondition;
-import kernel.jdon.moduleapi.domain.jd.core.JdSortTypeCondition;
+import kernel.jdon.moduleapi.domain.jd.core.JdSearchType;
+import kernel.jdon.moduleapi.domain.jd.core.JdSortType;
 import kernel.jdon.moduleapi.global.page.PageInfoRequest;
 import kernel.jdon.modulecommon.dto.response.CommonResponse;
 import lombok.RequiredArgsConstructor;
@@ -35,9 +35,9 @@ public class JdController {
 		@ModelAttribute final PageInfoRequest pageInfoRequest,
 		@RequestParam(value = "skill", defaultValue = "") final String skill,
 		@RequestParam(value = "jobCategory", required = false) final Long jobCategory,
-		@RequestParam(value = "keywordType", defaultValue = "") final JdSearchTypeCondition keywordType,
+		@RequestParam(value = "keywordType", defaultValue = "") final JdSearchType keywordType,
 		@RequestParam(value = "keyword", defaultValue = "") final String keyword,
-		@RequestParam(value = "sort", defaultValue = "") final JdSortTypeCondition sort) {
+		@RequestParam(value = "sort", defaultValue = "") final JdSortType sort) {
 		final JdInfo.FindWantedJdListResponse info = jdFacade.getJdList(pageInfoRequest,
 			JdCondition.of(skill, jobCategory, keywordType, keyword, sort));
 		final JdDto.FindWantedJdListResponse response = jdDtoMapper.of(info);

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/jd/presentation/JdController.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/jd/presentation/JdController.java
@@ -9,6 +9,8 @@ import org.springframework.web.bind.annotation.RestController;
 
 import kernel.jdon.moduleapi.domain.jd.application.JdFacade;
 import kernel.jdon.moduleapi.domain.jd.core.JdInfo;
+import kernel.jdon.moduleapi.domain.jd.core.JdSearchTypeCondition;
+import kernel.jdon.moduleapi.domain.jd.core.JdSortTypeCondition;
 import kernel.jdon.moduleapi.global.page.PageInfoRequest;
 import kernel.jdon.modulecommon.dto.response.CommonResponse;
 import lombok.RequiredArgsConstructor;
@@ -31,8 +33,13 @@ public class JdController {
 	@GetMapping("/api/v1/jds")
 	public ResponseEntity<CommonResponse<JdDto.FindWantedJdListResponse>> getJdList(
 		@ModelAttribute final PageInfoRequest pageInfoRequest,
-		@RequestParam(value = "keyword", defaultValue = "") final String keyword) {
-		final JdInfo.FindWantedJdListResponse info = jdFacade.getJdList(pageInfoRequest, keyword);
+		@RequestParam(value = "skill", defaultValue = "") final String skill,
+		@RequestParam(value = "jobCategory", defaultValue = "") final Long jobCategory,
+		@RequestParam(value = "keywordType", defaultValue = "") final JdSearchTypeCondition keywordType,
+		@RequestParam(value = "keyword", defaultValue = "") final String keyword,
+		@RequestParam(value = "sort", defaultValue = "") final JdSortTypeCondition sort) {
+		final JdInfo.FindWantedJdListResponse info = jdFacade.getJdList(pageInfoRequest,
+			JdCondition.of(skill, jobCategory, keywordType, keyword, sort));
 		final JdDto.FindWantedJdListResponse response = jdDtoMapper.of(info);
 
 		return ResponseEntity.ok().body(CommonResponse.of(response));

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/jd/presentation/JdController.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/jd/presentation/JdController.java
@@ -18,30 +18,30 @@ import lombok.RequiredArgsConstructor;
 @RestController
 @RequiredArgsConstructor
 public class JdController {
-	private final JdFacade jdFacade;
-	private final JdDtoMapper jdDtoMapper;
+    private final JdFacade jdFacade;
+    private final JdDtoMapper jdDtoMapper;
 
-	@GetMapping("/api/v1/jds/{id}")
-	public ResponseEntity<CommonResponse<JdDto.FindWantedJdResponse>> getJd(
-		@PathVariable(name = "id") final Long jdId) {
-		final JdInfo.FindWantedJdResponse info = jdFacade.getJd(jdId);
-		final JdDto.FindWantedJdResponse response = jdDtoMapper.of(info);
+    @GetMapping("/api/v1/jds/{id}")
+    public ResponseEntity<CommonResponse<JdDto.FindWantedJdResponse>> getJd(
+        @PathVariable(name = "id") final Long jdId) {
+        final JdInfo.FindWantedJdResponse info = jdFacade.getJd(jdId);
+        final JdDto.FindWantedJdResponse response = jdDtoMapper.of(info);
 
-		return ResponseEntity.ok().body(CommonResponse.of(response));
-	}
+        return ResponseEntity.ok().body(CommonResponse.of(response));
+    }
 
-	@GetMapping("/api/v1/jds")
-	public ResponseEntity<CommonResponse<JdDto.FindWantedJdListResponse>> getJdList(
-		@ModelAttribute final PageInfoRequest pageInfoRequest,
-		@RequestParam(value = "skill", defaultValue = "") final String skill,
-		@RequestParam(value = "jobCategory", required = false) final Long jobCategory,
-		@RequestParam(value = "keywordType", defaultValue = "") final JdSearchType keywordType,
-		@RequestParam(value = "keyword", defaultValue = "") final String keyword,
-		@RequestParam(value = "sort", defaultValue = "") final JdSortType sort) {
-		final JdInfo.FindWantedJdListResponse info = jdFacade.getJdList(pageInfoRequest,
-			JdCondition.of(skill, jobCategory, keywordType, keyword, sort));
-		final JdDto.FindWantedJdListResponse response = jdDtoMapper.of(info);
+    @GetMapping("/api/v1/jds")
+    public ResponseEntity<CommonResponse<JdDto.FindWantedJdListResponse>> getJdList(
+        @ModelAttribute final PageInfoRequest pageInfoRequest,
+        @RequestParam(value = "skill", defaultValue = "") final String skill,
+        @RequestParam(value = "jobCategory", required = false) final Long jobCategory,
+        @RequestParam(value = "keywordType", defaultValue = "") final JdSearchType keywordType,
+        @RequestParam(value = "keyword", defaultValue = "") final String keyword,
+        @RequestParam(value = "sort", defaultValue = "") final JdSortType sort) {
+        final JdInfo.FindWantedJdListResponse info = jdFacade.getJdList(pageInfoRequest,
+            JdCondition.of(skill, jobCategory, keywordType, keyword, sort));
+        final JdDto.FindWantedJdListResponse response = jdDtoMapper.of(info);
 
-		return ResponseEntity.ok().body(CommonResponse.of(response));
-	}
+        return ResponseEntity.ok().body(CommonResponse.of(response));
+    }
 }

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/jd/presentation/JdDto.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/jd/presentation/JdDto.java
@@ -10,46 +10,45 @@ import lombok.NoArgsConstructor;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class JdDto {
+    @Getter
+    @Builder
+    public static class FindWantedJdResponse {
+        private final Long id;
+        private final String title;
+        private final String company;
+        private final String imageUrl;
+        private final String jdUrl;
+        private final String requirements;
+        private final String mainTasks;
+        private final String intro;
+        private final String benefits;
+        private final String preferredPoints;
+        private final String jobCategoryName;
+        private final int reviewCount;
+        private final List<FindSkill> skillList;
+    }
 
-	@Getter
-	@Builder
-	public static class FindWantedJdResponse {
-		private final Long id;
-		private final String title;
-		private final String company;
-		private final String imageUrl;
-		private final String jdUrl;
-		private final String requirements;
-		private final String mainTasks;
-		private final String intro;
-		private final String benefits;
-		private final String preferredPoints;
-		private final String jobCategoryName;
-		private final int reviewCount;
-		private final List<FindSkill> skillList;
-	}
+    @Getter
+    @Builder
+    public static class FindSkill {
+        private final Long id;
+        private final String keyword;
+    }
 
-	@Getter
-	@Builder
-	public static class FindSkill {
-		private final Long id;
-		private final String keyword;
-	}
+    @Getter
+    @Builder
+    public static class FindWantedJdListResponse {
+        private final List<FindWantedJd> content;
+        private final CustomPageInfo pageInfo;
+    }
 
-	@Getter
-	@Builder
-	public static class FindWantedJdListResponse {
-		private final List<FindWantedJd> content;
-		private final CustomPageInfo pageInfo;
-	}
-
-	@Getter
-	@Builder
-	public static class FindWantedJd {
-		private final Long id;
-		private final String title;
-		private final String company;
-		private final String imageUrl;
-		private final String jobCategoryName;
-	}
+    @Getter
+    @Builder
+    public static class FindWantedJd {
+        private final Long id;
+        private final String title;
+        private final String company;
+        private final String imageUrl;
+        private final String jobCategoryName;
+    }
 }

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/jd/presentation/JdDtoMapper.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/jd/presentation/JdDtoMapper.java
@@ -7,12 +7,12 @@ import org.mapstruct.ReportingPolicy;
 import kernel.jdon.moduleapi.domain.jd.core.JdInfo;
 
 @Mapper(
-	componentModel = "spring",
-	injectionStrategy = InjectionStrategy.CONSTRUCTOR,
-	unmappedTargetPolicy = ReportingPolicy.ERROR
+    componentModel = "spring",
+    injectionStrategy = InjectionStrategy.CONSTRUCTOR,
+    unmappedTargetPolicy = ReportingPolicy.ERROR
 )
 public interface JdDtoMapper {
-	JdDto.FindWantedJdResponse of(JdInfo.FindWantedJdResponse info);
+    JdDto.FindWantedJdResponse of(JdInfo.FindWantedJdResponse info);
 
-	JdDto.FindWantedJdListResponse of(JdInfo.FindWantedJdListResponse info);
+    JdDto.FindWantedJdListResponse of(JdInfo.FindWantedJdListResponse info);
 }

--- a/module-api/src/main/java/kernel/jdon/moduleapi/global/config/web/WebConfig.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/global/config/web/WebConfig.java
@@ -8,9 +8,9 @@ import org.springframework.format.FormatterRegistry;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
-import kernel.jdon.moduleapi.domain.coffeechat.core.CoffeeChatSortCondition;
-import kernel.jdon.moduleapi.domain.jd.core.JdSearchTypeCondition;
-import kernel.jdon.moduleapi.domain.jd.core.JdSortTypeCondition;
+import kernel.jdon.moduleapi.domain.coffeechat.core.CoffeeChatSortType;
+import kernel.jdon.moduleapi.domain.jd.core.JdSearchType;
+import kernel.jdon.moduleapi.domain.jd.core.JdSortType;
 import lombok.RequiredArgsConstructor;
 
 @Configuration
@@ -32,24 +32,24 @@ public class WebConfig implements WebMvcConfigurer {
 		registry.addConverter(new JdSortTypeConverter());
 	}
 
-	private static class CoffeeChatSortConverter implements Converter<String, CoffeeChatSortCondition> {
+	private static class CoffeeChatSortConverter implements Converter<String, CoffeeChatSortType> {
 		@Override
-		public CoffeeChatSortCondition convert(String source) {
-			return CoffeeChatSortCondition.of(source);
+		public CoffeeChatSortType convert(String source) {
+			return CoffeeChatSortType.of(source);
 		}
 	}
 
-	private static class JdSearchTypeConverter implements Converter<String, JdSearchTypeCondition> {
+	private static class JdSearchTypeConverter implements Converter<String, JdSearchType> {
 		@Override
-		public JdSearchTypeCondition convert(String source) {
-			return JdSearchTypeCondition.of(source);
+		public JdSearchType convert(String source) {
+			return JdSearchType.of(source);
 		}
 	}
 
-	private static class JdSortTypeConverter implements Converter<String, JdSortTypeCondition> {
+	private static class JdSortTypeConverter implements Converter<String, JdSortType> {
 		@Override
-		public JdSortTypeCondition convert(String source) {
-			return JdSortTypeCondition.of(source);
+		public JdSortType convert(String source) {
+			return JdSortType.of(source);
 		}
 	}
 }

--- a/module-api/src/main/java/kernel/jdon/moduleapi/global/config/web/WebConfig.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/global/config/web/WebConfig.java
@@ -9,6 +9,8 @@ import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 import kernel.jdon.moduleapi.domain.coffeechat.core.CoffeeChatSortCondition;
+import kernel.jdon.moduleapi.domain.jd.core.JdSearchTypeCondition;
+import kernel.jdon.moduleapi.domain.jd.core.JdSortTypeCondition;
 import lombok.RequiredArgsConstructor;
 
 @Configuration
@@ -24,13 +26,30 @@ public class WebConfig implements WebMvcConfigurer {
 
 	@Override
 	public void addFormatters(FormatterRegistry registry) {
+
 		registry.addConverter(new CoffeeChatSortConverter());
+		registry.addConverter(new JdSearchTypeConverter());
+		registry.addConverter(new JdSortTypeConverter());
 	}
 
 	private static class CoffeeChatSortConverter implements Converter<String, CoffeeChatSortCondition> {
 		@Override
 		public CoffeeChatSortCondition convert(String source) {
 			return CoffeeChatSortCondition.of(source);
+		}
+	}
+
+	private static class JdSearchTypeConverter implements Converter<String, JdSearchTypeCondition> {
+		@Override
+		public JdSearchTypeCondition convert(String source) {
+			return JdSearchTypeCondition.of(source);
+		}
+	}
+
+	private static class JdSortTypeConverter implements Converter<String, JdSortTypeCondition> {
+		@Override
+		public JdSortTypeCondition convert(String source) {
+			return JdSortTypeCondition.of(source);
 		}
 	}
 }

--- a/module-api/src/test/java/kernel/jdon/moduleapi/domain/jd/application/JdFacadeTest.java
+++ b/module-api/src/test/java/kernel/jdon/moduleapi/domain/jd/application/JdFacadeTest.java
@@ -12,6 +12,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import kernel.jdon.moduleapi.domain.jd.core.JdInfo;
 import kernel.jdon.moduleapi.domain.jd.core.JdService;
+import kernel.jdon.moduleapi.domain.jd.presentation.JdCondition;
 import kernel.jdon.moduleapi.global.page.PageInfoRequest;
 
 @DisplayName("JD Facade 테스트")
@@ -39,19 +40,19 @@ class JdFacadeTest {
 	}
 
 	@Test
-	@DisplayName("2: 올바른 keyword가 주어졌을 때 getJdList가 jd 목록을 반환한다.")
-	void givenValidKeyword_whenGetJdList_thenReturnCorrectJdList() throws Exception {
+	@DisplayName("2: 올바른 JdCondition이 주어졌을 때 getJdList가 jd 목록을 반환한다.")
+	void givenValidJdCondition_whenGetJdList_thenReturnCorrectJdList() throws Exception {
 		//given
-		final var keyword = "keyword";
 		final var mockPageInfoRequest = mock(PageInfoRequest.class);
+		final var mockJdCondition = mock(JdCondition.class);
 		final var mockFindWantedJdListInfo = mock(JdInfo.FindWantedJdListResponse.class);
-		given(jdService.getJdList(mockPageInfoRequest, skill, keyword)).willReturn(mockFindWantedJdListInfo);
+		given(jdService.getJdList(mockPageInfoRequest, mockJdCondition)).willReturn(mockFindWantedJdListInfo);
 
 		//when
-		final var response = jdFacade.getJdList(mockPageInfoRequest, skill, keyword);
+		final var response = jdFacade.getJdList(mockPageInfoRequest, mockJdCondition);
 
 		//then
 		assertThat(response).isEqualTo(mockFindWantedJdListInfo);
-		then(jdService).should(times(1)).getJdList(mockPageInfoRequest, skill, keyword);
+		then(jdService).should(times(1)).getJdList(mockPageInfoRequest, mockJdCondition);
 	}
 }

--- a/module-api/src/test/java/kernel/jdon/moduleapi/domain/jd/application/JdFacadeTest.java
+++ b/module-api/src/test/java/kernel/jdon/moduleapi/domain/jd/application/JdFacadeTest.java
@@ -45,13 +45,13 @@ class JdFacadeTest {
 		final var keyword = "keyword";
 		final var mockPageInfoRequest = mock(PageInfoRequest.class);
 		final var mockFindWantedJdListInfo = mock(JdInfo.FindWantedJdListResponse.class);
-		given(jdService.getJdList(mockPageInfoRequest, keyword)).willReturn(mockFindWantedJdListInfo);
+		given(jdService.getJdList(mockPageInfoRequest, skill, keyword)).willReturn(mockFindWantedJdListInfo);
 
 		//when
-		final var response = jdFacade.getJdList(mockPageInfoRequest, keyword);
+		final var response = jdFacade.getJdList(mockPageInfoRequest, skill, keyword);
 
 		//then
 		assertThat(response).isEqualTo(mockFindWantedJdListInfo);
-		then(jdService).should(times(1)).getJdList(mockPageInfoRequest, keyword);
+		then(jdService).should(times(1)).getJdList(mockPageInfoRequest, skill, keyword);
 	}
 }

--- a/module-api/src/test/java/kernel/jdon/moduleapi/domain/jd/core/JdServiceImplTest.java
+++ b/module-api/src/test/java/kernel/jdon/moduleapi/domain/jd/core/JdServiceImplTest.java
@@ -67,15 +67,15 @@ class JdServiceImplTest {
 		final var keyword = "keyword";
 		final var mockPageInfoRequest = mock(PageInfoRequest.class);
 		final var mockFindWantedJdListInfo = mock(JdInfo.FindWantedJdListResponse.class);
-		given(jdReader.findWantedJdList(mockPageInfoRequest, keyword))
+		given(jdReader.findWantedJdList(mockPageInfoRequest, skill, keyword))
 			.willReturn(mockFindWantedJdListInfo);
 
 		//when
-		final var response = jdServiceImpl.getJdList(mockPageInfoRequest, keyword);
+		final var response = jdServiceImpl.getJdList(mockPageInfoRequest, skill, keyword);
 
 		//then
 		assertThat(response).isEqualTo(mockFindWantedJdListInfo);
 		then(jdReader).should(times(1))
-			.findWantedJdList(mockPageInfoRequest, keyword);
+			.findWantedJdList(mockPageInfoRequest, skill, keyword);
 	}
 }

--- a/module-api/src/test/java/kernel/jdon/moduleapi/domain/jd/core/JdServiceImplTest.java
+++ b/module-api/src/test/java/kernel/jdon/moduleapi/domain/jd/core/JdServiceImplTest.java
@@ -12,6 +12,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import kernel.jdon.moduleapi.domain.jd.presentation.JdCondition;
 import kernel.jdon.moduleapi.global.page.PageInfoRequest;
 import kernel.jdon.moduledomain.wantedjd.domain.WantedJd;
 
@@ -61,21 +62,21 @@ class JdServiceImplTest {
 	}
 
 	@Test
-	@DisplayName("2: keyword가 주어졌을 때 getJdList가 jd 목록을 반환한다.")
-	void givenValidKeyword_whenGetJdList_thenReturnCorrectJdList() throws Exception {
+	@DisplayName("2: JdCondition이 주어졌을 때 getJdList가 jd 목록을 반환한다.")
+	void givenValidJdCondition_whenGetJdList_thenReturnCorrectJdList() throws Exception {
 		//given
-		final var keyword = "keyword";
 		final var mockPageInfoRequest = mock(PageInfoRequest.class);
+		final var mockJdCondition = mock(JdCondition.class);
 		final var mockFindWantedJdListInfo = mock(JdInfo.FindWantedJdListResponse.class);
-		given(jdReader.findWantedJdList(mockPageInfoRequest, skill, keyword))
+		given(jdReader.findWantedJdList(mockPageInfoRequest, mockJdCondition))
 			.willReturn(mockFindWantedJdListInfo);
 
 		//when
-		final var response = jdServiceImpl.getJdList(mockPageInfoRequest, skill, keyword);
+		final var response = jdServiceImpl.getJdList(mockPageInfoRequest, mockJdCondition);
 
 		//then
 		assertThat(response).isEqualTo(mockFindWantedJdListInfo);
 		then(jdReader).should(times(1))
-			.findWantedJdList(mockPageInfoRequest, skill, keyword);
+			.findWantedJdList(mockPageInfoRequest, mockJdCondition);
 	}
 }


### PR DESCRIPTION
## 개요

### 요약
JD 목록 조회 API에 검색 조건을 추가했습니다. 
검색 타입이나 정렬 조건은 아무것도 입력하지 않으면 default 값이 존재해야하기에 Condition에서 아무값이 안들어오면 
keyword 타입은 title을, sort는 latest를 반환하도록 했습니다.

### 변경한 부분
### 검색을 위한 param 추가
- `skill`
기술 스킬에 대한 검색을 제공합니다. 

- `jobCategory`
기술 스킬은 프론트엔드-자바스크립트, 백엔드-자바스크립트 와 같이 중복될 수 있어 jobCategory로 검색할 수 있도록 제공합니다. 

- `keywordType`
검색창에 검색하는 키워드의 타입을 받습니다. 
검색할 수 있는 키워드의 종류는 현재 `제목` `회사명` 이 있습니다. 

- `keyword`
검색창에 입력하는 키워드를 받고  이 키워드를 기반으로 jd 목록 조회를 지원합니다. 

- `sort`
스크래밍 날짜 최신순, 리뷰 많은 순으로 정렬하는 기능을 제공합니다. 


### jd 목록 조회에 대한 facade, service test 를 수정했습니다. 
검색을 위한 param을 `JdCondition` 이라는 클래스로 받아서 관리합니다. 

### 변경한 결과
### 검색 조건 추가
- skill 검색
![image](https://github.com/Kernel360/f1-JDON-Backend/assets/68376744/1c2c9a56-8f3e-4c7c-952b-2e203381fcb6)

- jobCategory 검색
![image](https://github.com/Kernel360/f1-JDON-Backend/assets/68376744/8b890f83-d34a-4ee9-bcc6-d0bdacf3ac58)

- keyword 검색
  - 회사명 검색
     ![image](https://github.com/Kernel360/f1-JDON-Backend/assets/68376744/1a05161a-e5c8-490b-bed2-5694c3d3bff5)

  - 제목 검색
     ![image](https://github.com/Kernel360/f1-JDON-Backend/assets/68376744/19190f15-3846-44bd-b74c-034767e222f5)


- sort (스크래핑 최신순, 리뷰 많은 순)
  - 리뷰 많은 순
     ![image](https://github.com/Kernel360/f1-JDON-Backend/assets/68376744/5d7a4dc0-4f58-4f60-bdff-fb1231ee5947)
     ![image](https://github.com/Kernel360/f1-JDON-Backend/assets/68376744/8c5a04d7-3265-4fb9-a573-8e3aed6d0c02)


- 2중 조건 (자바스크립트 스택의 서버 개발자면서 3년이라는 단어가 제목에 들어가도록 검색)
![image](https://github.com/Kernel360/f1-JDON-Backend/assets/68376744/b56660e1-a90f-423c-b703-82f793663f2d)


### jd 관련 test
![image](https://github.com/Kernel360/f1-JDON-Backend/assets/68376744/a8a98d0b-d071-4173-aa95-ef7dacab0ce7)


### 이슈

- closes: #383 

---

## PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경, 주석 변경)
- [ ] 코드 리팩토링
- [ ] 문서 수정
- [x] 테스트 추가, 테스트 리팩토링
- [ ] 파일 혹은 폴더명 수정, 삭제
- [ ] 배포 관련