### PR TITLE
Fix: 리뷰 목록 조회 무한스크롤 페이징 적용

### DIFF
--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/coffeechat/infrastructure/CoffeeChatReaderImpl.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/coffeechat/infrastructure/CoffeeChatReaderImpl.java
@@ -7,6 +7,8 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Component;
 
+import kernel.jdon.moduledomain.coffeechat.domain.CoffeeChat;
+import kernel.jdon.moduledomain.coffeechatmember.domain.CoffeeChatMember;
 import kernel.jdon.moduleapi.domain.coffeechat.core.CoffeeChatCommand;
 import kernel.jdon.moduleapi.domain.coffeechat.core.CoffeeChatInfo;
 import kernel.jdon.moduleapi.domain.coffeechat.core.CoffeeChatInfoMapper;

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/coffeechat/presentation/CoffeeChatController.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/coffeechat/presentation/CoffeeChatController.java
@@ -41,11 +41,11 @@ public class CoffeeChatController {
         @RequestParam(value = "keyword", defaultValue = "") final String keyword,
         @RequestParam(value = "jobCategory", defaultValue = "") final Long jobCategory) {
 
-		final CoffeeChatCommand.FindCoffeeChatListRequest request = coffeeChatDtoMapper.of(
-			new CoffeeChatCondition(sort, keyword, jobCategory));
-		final CoffeeChatInfo.FindCoffeeChatListResponse info = coffeeChatFacade.getCoffeeChatList(
-			pageInfoRequest, request);
-		final CoffeeChatDto.FindCoffeeChatListResponse response = coffeeChatDtoMapper.of(info);
+        final CoffeeChatCommand.FindCoffeeChatListRequest request = coffeeChatDtoMapper.of(
+            new CoffeeChatCondition(sort, keyword, jobCategory));
+        final CoffeeChatInfo.FindCoffeeChatListResponse info = coffeeChatFacade.getCoffeeChatList(
+            pageInfoRequest, request);
+        final CoffeeChatDto.FindCoffeeChatListResponse response = coffeeChatDtoMapper.of(info);
 
         return ResponseEntity.ok(CommonResponse.of(response));
     }

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/coffeechat/presentation/CoffeeChatController.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/coffeechat/presentation/CoffeeChatController.java
@@ -41,11 +41,11 @@ public class CoffeeChatController {
         @RequestParam(value = "keyword", defaultValue = "") final String keyword,
         @RequestParam(value = "jobCategory", defaultValue = "") final Long jobCategory) {
 
-        CoffeeChatCommand.FindCoffeeChatListRequest request = coffeeChatDtoMapper.of(
-            new CoffeeChatCondition(sort, keyword, jobCategory));
-        CoffeeChatInfo.FindCoffeeChatListResponse info = coffeeChatFacade.getCoffeeChatList(
-            pageInfoRequest, request);
-        CoffeeChatDto.FindCoffeeChatListResponse response = coffeeChatDtoMapper.of(info);
+		final CoffeeChatCommand.FindCoffeeChatListRequest request = coffeeChatDtoMapper.of(
+			new CoffeeChatCondition(sort, keyword, jobCategory));
+		final CoffeeChatInfo.FindCoffeeChatListResponse info = coffeeChatFacade.getCoffeeChatList(
+			pageInfoRequest, request);
+		final CoffeeChatDto.FindCoffeeChatListResponse response = coffeeChatDtoMapper.of(info);
 
         return ResponseEntity.ok(CommonResponse.of(response));
     }

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/review/application/ReviewFacade.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/review/application/ReviewFacade.java
@@ -17,8 +17,9 @@ public class ReviewFacade {
 		return reviewService.createReview(command);
 	}
 
-	public ReviewInfo.FindReviewListResponse getReviewList(final Long jdId, final PageInfoRequest pageInfoRequest) {
-		return reviewService.getReviewList(jdId, pageInfoRequest);
+	public ReviewInfo.FindReviewListResponse getReviewList(final Long jdId, final PageInfoRequest pageInfoRequest,
+		final Long reviewId) {
+		return reviewService.getReviewList(jdId, pageInfoRequest, reviewId);
 	}
 
 	public void removeReview(final ReviewCommand.DeleteReviewRequest command) {

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/review/core/ReviewInfo.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/review/core/ReviewInfo.java
@@ -3,7 +3,7 @@ package kernel.jdon.moduleapi.domain.review.core;
 import java.time.LocalDateTime;
 import java.util.List;
 
-import kernel.jdon.moduleapi.global.page.CustomPageInfo;
+import kernel.jdon.moduleapi.global.page.CustomSliceInfo;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -23,7 +23,7 @@ public class ReviewInfo {
 	@AllArgsConstructor
 	public static class FindReviewListResponse {
 		private final List<FindReview> content;
-		private final CustomPageInfo pageInfo;
+		private final CustomSliceInfo pageInfo;
 	}
 
 	@Getter

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/review/core/ReviewReader.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/review/core/ReviewReader.java
@@ -4,7 +4,7 @@ import kernel.jdon.moduleapi.global.page.PageInfoRequest;
 import kernel.jdon.moduledomain.review.domain.Review;
 
 public interface ReviewReader {
-	ReviewInfo.FindReviewListResponse findReviewList(Long jdId, PageInfoRequest pageInfoRequest);
+	ReviewInfo.FindReviewListResponse findReviewList(Long jdId, PageInfoRequest pageInfoRequest, Long reviewId);
 
 	Review findById(Long id);
 }

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/review/core/ReviewService.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/review/core/ReviewService.java
@@ -5,7 +5,7 @@ import kernel.jdon.moduleapi.global.page.PageInfoRequest;
 public interface ReviewService {
 	ReviewInfo.CreateReviewResponse createReview(ReviewCommand.CreateReviewRequest command);
 
-	ReviewInfo.FindReviewListResponse getReviewList(Long jdId, PageInfoRequest pageInfoRequest);
+	ReviewInfo.FindReviewListResponse getReviewList(Long jdId, PageInfoRequest pageInfoRequest, Long reviewId);
 
 	void removeReview(ReviewCommand.DeleteReviewRequest command);
 }

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/review/core/ReviewServiceImpl.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/review/core/ReviewServiceImpl.java
@@ -26,8 +26,9 @@ public class ReviewServiceImpl implements ReviewService {
 	}
 
 	@Override
-	public ReviewInfo.FindReviewListResponse getReviewList(final Long jdId, final PageInfoRequest pageInfoRequest) {
-		return reviewReader.findReviewList(jdId, pageInfoRequest);
+	public ReviewInfo.FindReviewListResponse getReviewList(final Long jdId, final PageInfoRequest pageInfoRequest,
+		final Long reviewId) {
+		return reviewReader.findReviewList(jdId, pageInfoRequest, reviewId);
 	}
 
 	@Override

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/review/infrastructure/CustomReviewRepository.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/review/infrastructure/CustomReviewRepository.java
@@ -1,8 +1,8 @@
 package kernel.jdon.moduleapi.domain.review.infrastructure;
 
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 
 public interface CustomReviewRepository {
-	Page<ReviewReaderInfo.FindReview> findReviewList(Long jdId, Pageable pageable);
+	Slice<ReviewReaderInfo.FindReview> findReviewList(Long jdId, Pageable pageable, Long reviewId);
 }

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/review/infrastructure/ReviewReaderImpl.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/review/infrastructure/ReviewReaderImpl.java
@@ -2,15 +2,15 @@ package kernel.jdon.moduleapi.domain.review.infrastructure;
 
 import java.util.List;
 
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Component;
 
 import kernel.jdon.moduleapi.domain.review.core.ReviewInfo;
 import kernel.jdon.moduleapi.domain.review.core.ReviewReader;
 import kernel.jdon.moduleapi.domain.review.error.ReviewErrorCode;
-import kernel.jdon.moduleapi.global.page.CustomJpaPageInfo;
+import kernel.jdon.moduleapi.global.page.CustomJpaSliceInfo;
 import kernel.jdon.moduleapi.global.page.PageInfoRequest;
 import kernel.jdon.moduledomain.review.domain.Review;
 import lombok.RequiredArgsConstructor;
@@ -22,16 +22,18 @@ public class ReviewReaderImpl implements ReviewReader {
 	private final ReviewReaderInfoMapper reviewReaderInfoMapper;
 
 	@Override
-	public ReviewInfo.FindReviewListResponse findReviewList(final Long jdId, final PageInfoRequest pageInfoRequest) {
+	public ReviewInfo.FindReviewListResponse findReviewList(final Long jdId, final PageInfoRequest pageInfoRequest,
+		final Long reviewId) {
 		final Pageable pageable = PageRequest.of(pageInfoRequest.getPage(), pageInfoRequest.getSize());
 
-		final Page<ReviewReaderInfo.FindReview> findReviewList = reviewRepository.findReviewList(jdId, pageable);
+		final Slice<ReviewReaderInfo.FindReview> findReviewList = reviewRepository.findReviewList(jdId, pageable,
+			reviewId);
 
 		final List<ReviewInfo.FindReview> content = findReviewList.stream()
 			.map(reviewReaderInfoMapper::of)
 			.toList();
 
-		return new ReviewInfo.FindReviewListResponse(content, new CustomJpaPageInfo(findReviewList));
+		return new ReviewInfo.FindReviewListResponse(content, new CustomJpaSliceInfo(findReviewList));
 	}
 
 	@Override

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/review/infrastructure/ReviewRepositoryImpl.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/review/infrastructure/ReviewRepositoryImpl.java
@@ -36,7 +36,7 @@ public class ReviewRepositoryImpl implements CustomReviewRepository {
                 reviewIdLt(reviewId),
                 review.wantedJd.id.eq(jdId)
             )
-            .limit(pageable.getPageSize())
+            .limit(pageable.getPageSize() + 1)
             .orderBy(review.createdDate.desc())
             .fetch();
 
@@ -44,7 +44,11 @@ public class ReviewRepositoryImpl implements CustomReviewRepository {
     }
 
     private boolean hasNextPage(final List<ReviewReaderInfo.FindReview> content, final int pageSize) {
-        return content.size() > pageSize - 1;
+        if (content.size() > pageSize) {
+            content.remove(pageSize);
+            return true;
+        }
+        return false;
     }
 
     private BooleanExpression reviewIdLt(final Long reviewId) {

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/review/infrastructure/ReviewRepositoryImpl.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/review/infrastructure/ReviewRepositoryImpl.java
@@ -16,41 +16,41 @@ import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
 public class ReviewRepositoryImpl implements CustomReviewRepository {
-	private final JPAQueryFactory jpaQueryFactory;
+    private final JPAQueryFactory jpaQueryFactory;
 
-	@Override
-	public Slice<ReviewReaderInfo.FindReview> findReviewList(final Long jdId, final Pageable pageable,
-		final Long reviewId) {
-		final List<ReviewReaderInfo.FindReview> content = jpaQueryFactory
-			.select(new QReviewReaderInfo_FindReview(
-				review.id,
-				review.content,
-				member.nickname,
-				review.createdDate,
-				member.id
-			))
-			.from(review)
-			.join(member)
-			.on(review.member.eq(member))
-			.where(
-				reviewIdIt(reviewId),
-				review.wantedJd.id.eq(jdId)
-			)
-			.limit(pageable.getPageSize())
-			.orderBy(review.createdDate.desc())
-			.fetch();
+    @Override
+    public Slice<ReviewReaderInfo.FindReview> findReviewList(final Long jdId, final Pageable pageable,
+        final Long reviewId) {
+        final List<ReviewReaderInfo.FindReview> content = jpaQueryFactory
+            .select(new QReviewReaderInfo_FindReview(
+                review.id,
+                review.content,
+                member.nickname,
+                review.createdDate,
+                member.id
+            ))
+            .from(review)
+            .join(member)
+            .on(review.member.eq(member))
+            .where(
+                reviewIdLt(reviewId),
+                review.wantedJd.id.eq(jdId)
+            )
+            .limit(pageable.getPageSize())
+            .orderBy(review.createdDate.desc())
+            .fetch();
 
-		return new SliceImpl<>(content, pageable, hasNextPage(content, pageable.getPageSize()));
-	}
+        return new SliceImpl<>(content, pageable, hasNextPage(content, pageable.getPageSize()));
+    }
 
-	private boolean hasNextPage(final List<ReviewReaderInfo.FindReview> content, final int pageSize) {
-		return content.size() > pageSize - 1;
-	}
+    private boolean hasNextPage(final List<ReviewReaderInfo.FindReview> content, final int pageSize) {
+        return content.size() > pageSize - 1;
+    }
 
-	private BooleanExpression reviewIdIt(final Long reviewId) {
-		if (reviewId == null) {
-			return null;
-		}
-		return review.id.lt(reviewId);
-	}
+    private BooleanExpression reviewIdLt(final Long reviewId) {
+        if (reviewId == null) {
+            return null;
+        }
+        return review.id.lt(reviewId);
+    }
 }

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/review/presentation/ReviewController.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/review/presentation/ReviewController.java
@@ -9,6 +9,7 @@ import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import jakarta.validation.Valid;
@@ -42,9 +43,10 @@ public class ReviewController {
 	@GetMapping("/api/v1/reviews/{jdId}")
 	public ResponseEntity<CommonResponse<ReviewDto.CreateReviewResponse>> findReviewList(
 		@PathVariable(name = "jdId") final Long jdId,
+		@RequestParam(name = "reviewId", defaultValue = "") final Long reviewId,
 		@ModelAttribute final PageInfoRequest pageInfoRequest) {
 		final ReviewInfo.FindReviewListResponse info = reviewFacade.getReviewList(jdId,
-			pageInfoRequest);
+			pageInfoRequest, reviewId);
 		final ReviewDto.FindReviewListResponse response = reviewDtoMapper.of(info);
 
 		return ResponseEntity.ok().body(CommonResponse.of(response));

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/review/presentation/ReviewDto.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/review/presentation/ReviewDto.java
@@ -16,39 +16,38 @@ import lombok.NoArgsConstructor;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class ReviewDto {
+    @Getter
+    @Builder
+    public static class CreateReviewRequest {
+        @NotNull(message = "jd 식별자가 없습니다.")
+        private final Long jdId;
+        @NotBlank(message = "내용은 필수 입력 항목 입니다.")
+        @Size(min = 10, max = 500, message = "내용은 10자 이상 500자 이하로 작성해주세요.")
+        private final String content;
+    }
 
-	@Getter
-	@Builder
-	public static class CreateReviewRequest {
-		@NotNull(message = "jd 식별자가 없습니다.")
-		private final Long jdId;
-		@NotBlank(message = "내용은 필수 입력 항목 입니다.")
-		@Size(min = 10, max = 500, message = "내용은 10자 이상 500자 이하로 작성해주세요.")
-		private final String content;
-	}
+    @Getter
+    @Builder
+    public static class CreateReviewResponse {
+        private final Long reviewId;
+    }
 
-	@Getter
-	@Builder
-	public static class CreateReviewResponse {
-		private final Long reviewId;
-	}
+    @Getter
+    @Builder
+    public static class FindReviewListResponse {
+        private final List<FindReview> content;
+        private final CustomSliceInfo pageInfo;
+    }
 
-	@Getter
-	@Builder
-	public static class FindReviewListResponse {
-		private final List<FindReview> content;
-		private final CustomSliceInfo pageInfo;
-	}
-
-	@Getter
-	@Builder
-	public static class FindReview {
-		private final Long id;
-		private final String content;
-		private final String nickname;
-		@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm", timezone = "Asia/Seoul")
-		private final LocalDateTime createdDate;
-		private final Long memberId;
-	}
+    @Getter
+    @Builder
+    public static class FindReview {
+        private final Long id;
+        private final String content;
+        private final String nickname;
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm", timezone = "Asia/Seoul")
+        private final LocalDateTime createdDate;
+        private final Long memberId;
+    }
 
 }

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/review/presentation/ReviewDto.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/review/presentation/ReviewDto.java
@@ -8,7 +8,7 @@ import com.fasterxml.jackson.annotation.JsonFormat;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
-import kernel.jdon.moduleapi.global.page.CustomPageInfo;
+import kernel.jdon.moduleapi.global.page.CustomSliceInfo;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -17,38 +17,38 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class ReviewDto {
 
-    @Getter
-    @Builder
-    public static class CreateReviewRequest {
-        @NotNull(message = "jd 식별자가 없습니다.")
-        private final Long jdId;
-        @NotBlank(message = "내용은 필수 입력 항목 입니다.")
-        @Size(min = 10, max = 500, message = "내용은 10자 이상 500자 이하로 작성해주세요.")
-        private final String content;
-    }
+	@Getter
+	@Builder
+	public static class CreateReviewRequest {
+		@NotNull(message = "jd 식별자가 없습니다.")
+		private final Long jdId;
+		@NotBlank(message = "내용은 필수 입력 항목 입니다.")
+		@Size(min = 10, max = 500, message = "내용은 10자 이상 500자 이하로 작성해주세요.")
+		private final String content;
+	}
 
-    @Getter
-    @Builder
-    public static class CreateReviewResponse {
-        private final Long reviewId;
-    }
+	@Getter
+	@Builder
+	public static class CreateReviewResponse {
+		private final Long reviewId;
+	}
 
-    @Getter
-    @Builder
-    public static class FindReviewListResponse {
-        private final List<FindReview> content;
-        private final CustomPageInfo pageInfo;
-    }
+	@Getter
+	@Builder
+	public static class FindReviewListResponse {
+		private final List<FindReview> content;
+		private final CustomSliceInfo pageInfo;
+	}
 
-    @Getter
-    @Builder
-    public static class FindReview {
-        private final Long id;
-        private final String content;
-        private final String nickname;
-        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm", timezone = "Asia/Seoul")
-        private final LocalDateTime createdDate;
-        private final Long memberId;
-    }
+	@Getter
+	@Builder
+	public static class FindReview {
+		private final Long id;
+		private final String content;
+		private final String nickname;
+		@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm", timezone = "Asia/Seoul")
+		private final LocalDateTime createdDate;
+		private final Long memberId;
+	}
 
 }

--- a/module-api/src/main/java/kernel/jdon/moduleapi/global/page/CustomJpaSliceInfo.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/global/page/CustomJpaSliceInfo.java
@@ -6,10 +6,10 @@ import lombok.Getter;
 
 @Getter
 public class CustomJpaSliceInfo extends CustomSliceInfo {
-	public CustomJpaSliceInfo(Slice<?> page) {
-		super(page.getPageable().getPageNumber(),
-			page.getPageable().getPageSize(),
-			page.isLast(),
-			page.isEmpty());
+	public CustomJpaSliceInfo(Slice<?> slice) {
+		super(slice.getPageable().getPageNumber(),
+			slice.getPageable().getPageSize(),
+			slice.isLast(),
+			slice.isEmpty());
 	}
 }

--- a/module-api/src/main/java/kernel/jdon/moduleapi/global/page/CustomJpaSliceInfo.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/global/page/CustomJpaSliceInfo.java
@@ -1,0 +1,15 @@
+package kernel.jdon.moduleapi.global.page;
+
+import org.springframework.data.domain.Slice;
+
+import lombok.Getter;
+
+@Getter
+public class CustomJpaSliceInfo extends CustomSliceInfo {
+	public CustomJpaSliceInfo(Slice<?> page) {
+		super(page.getPageable().getPageNumber(),
+			page.getPageable().getPageSize(),
+			page.isLast(),
+			page.isEmpty());
+	}
+}

--- a/module-api/src/main/java/kernel/jdon/moduleapi/global/page/CustomPageInfo.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/global/page/CustomPageInfo.java
@@ -1,15 +1,15 @@
 package kernel.jdon.moduleapi.global.page;
 
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
-@AllArgsConstructor
-public abstract class CustomPageInfo {
-	private long pageNumber;
-	private long pageSize;
-	private long totalPages;
+public class CustomPageInfo extends CustomPagingInfo {
 	private boolean first;
-	private boolean last;
-	private boolean empty;
+	private long totalPages;
+
+	public CustomPageInfo(long pageNumber, long pageSize, long totalPages, boolean first, boolean last, boolean empty) {
+		super(pageNumber, pageSize, last, empty);
+		this.first = first;
+		this.totalPages = totalPages;
+	}
 }

--- a/module-api/src/main/java/kernel/jdon/moduleapi/global/page/CustomPageInfo.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/global/page/CustomPageInfo.java
@@ -4,12 +4,12 @@ import lombok.Getter;
 
 @Getter
 public class CustomPageInfo extends CustomPagingInfo {
-	private boolean first;
-	private long totalPages;
+    private final boolean first;
+    private final long totalPages;
 
-	public CustomPageInfo(long pageNumber, long pageSize, long totalPages, boolean first, boolean last, boolean empty) {
-		super(pageNumber, pageSize, last, empty);
-		this.first = first;
-		this.totalPages = totalPages;
-	}
+    public CustomPageInfo(long pageNumber, long pageSize, long totalPages, boolean first, boolean last, boolean empty) {
+        super(pageNumber, pageSize, last, empty);
+        this.first = first;
+        this.totalPages = totalPages;
+    }
 }

--- a/module-api/src/main/java/kernel/jdon/moduleapi/global/page/CustomPagingInfo.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/global/page/CustomPagingInfo.java
@@ -1,0 +1,13 @@
+package kernel.jdon.moduleapi.global.page;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public abstract class CustomPagingInfo {
+	private long pageNumber;
+	private long pageSize;
+	private boolean last;
+	private boolean empty;
+}

--- a/module-api/src/main/java/kernel/jdon/moduleapi/global/page/CustomPagingInfo.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/global/page/CustomPagingInfo.java
@@ -6,8 +6,8 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public abstract class CustomPagingInfo {
-	private long pageNumber;
-	private long pageSize;
-	private boolean last;
-	private boolean empty;
+    private final long pageNumber;
+    private final long pageSize;
+    private final boolean last;
+    private final boolean empty;
 }

--- a/module-api/src/main/java/kernel/jdon/moduleapi/global/page/CustomSliceInfo.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/global/page/CustomSliceInfo.java
@@ -1,0 +1,11 @@
+package kernel.jdon.moduleapi.global.page;
+
+import lombok.Getter;
+
+@Getter
+public class CustomSliceInfo extends CustomPagingInfo {
+
+	public CustomSliceInfo(long pageNumber, long pageSize, boolean last, boolean empty) {
+		super(pageNumber, pageSize, last, empty);
+	}
+}

--- a/module-api/src/test/java/kernel/jdon/moduleapi/domain/review/application/ReviewFacadeTest.java
+++ b/module-api/src/test/java/kernel/jdon/moduleapi/domain/review/application/ReviewFacadeTest.java
@@ -15,7 +15,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import kernel.jdon.moduleapi.domain.review.core.ReviewCommand;
 import kernel.jdon.moduleapi.domain.review.core.ReviewInfo;
 import kernel.jdon.moduleapi.domain.review.core.ReviewService;
-import kernel.jdon.moduleapi.global.page.CustomPageInfo;
+import kernel.jdon.moduleapi.global.page.CustomSliceInfo;
 import kernel.jdon.moduleapi.global.page.PageInfoRequest;
 
 @DisplayName("Review Facade 테스트")
@@ -51,20 +51,21 @@ class ReviewFacadeTest {
 	void givenJdIdAndPageInfoRequest_whenGetReviewList_thenCollectFindReviewListInfo() throws Exception {
 		//given
 		final var jdId = 1L;
+		final var reviewId = 30L;
 		final var mockPageInfoRequest = mock(PageInfoRequest.class);
 		final var mockFindReviewListInfo = new ReviewInfo.FindReviewListResponse(
 			List.of(
 				mock(ReviewInfo.FindReview.class),
 				mock(ReviewInfo.FindReview.class)),
-			mock(CustomPageInfo.class));
-		given(reviewService.getReviewList(jdId, mockPageInfoRequest)).willReturn(mockFindReviewListInfo);
+			mock(CustomSliceInfo.class));
+		given(reviewService.getReviewList(jdId, mockPageInfoRequest, reviewId)).willReturn(mockFindReviewListInfo);
 
 		//when
-		var response = reviewFacade.getReviewList(jdId, mockPageInfoRequest);
+		var response = reviewFacade.getReviewList(jdId, mockPageInfoRequest, reviewId);
 
 		//then
 		assertThat(response.getContent()).hasSize(2);
-		then(reviewService).should(times(1)).getReviewList(jdId, mockPageInfoRequest);
+		then(reviewService).should(times(1)).getReviewList(jdId, mockPageInfoRequest, reviewId);
 	}
 
 	@Test

--- a/module-api/src/test/java/kernel/jdon/moduleapi/domain/review/core/ReviewServiceImplTest.java
+++ b/module-api/src/test/java/kernel/jdon/moduleapi/domain/review/core/ReviewServiceImplTest.java
@@ -17,7 +17,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import kernel.jdon.moduleapi.domain.review.error.ReviewErrorCode;
 import kernel.jdon.moduleapi.global.exception.ApiException;
-import kernel.jdon.moduleapi.global.page.CustomPageInfo;
+import kernel.jdon.moduleapi.global.page.CustomSliceInfo;
 import kernel.jdon.moduleapi.global.page.PageInfoRequest;
 import kernel.jdon.moduledomain.review.domain.Review;
 import kernel.jdon.util.JsonFileReader;
@@ -64,20 +64,21 @@ class ReviewServiceImplTest {
 	void givenJdIdAndPageInfoRequest_whenGetReviewList_thenCollectFindReviewListInfo() throws Exception {
 		//given
 		final var jdId = 1L;
+		final var reviewId = 30L;
 		final var mockPageInfoRequest = mock(PageInfoRequest.class);
 		final var mockFindReviewListInfo = new ReviewInfo.FindReviewListResponse(
 			List.of(
 				mock(ReviewInfo.FindReview.class),
 				mock(ReviewInfo.FindReview.class)),
-			mock(CustomPageInfo.class));
-		given(reviewReader.findReviewList(jdId, mockPageInfoRequest)).willReturn(mockFindReviewListInfo);
+			mock(CustomSliceInfo.class));
+		given(reviewReader.findReviewList(jdId, mockPageInfoRequest, reviewId)).willReturn(mockFindReviewListInfo);
 
 		//when
-		var response = reviewServiceImpl.getReviewList(jdId, mockPageInfoRequest);
+		var response = reviewServiceImpl.getReviewList(jdId, mockPageInfoRequest, reviewId);
 
 		//then
 		Assertions.assertThat(response.getContent()).hasSize(2);
-		then(reviewReader).should(times(1)).findReviewList(jdId, mockPageInfoRequest);
+		then(reviewReader).should(times(1)).findReviewList(jdId, mockPageInfoRequest, reviewId);
 	}
 
 	@Test


### PR DESCRIPTION
## 개요

### 요약

리뷰 목록 조회에 no-offset 무한스크롤 페이징 방식을 적용했습니다.

### 변경한 부분

### 추상클래스 CustomPagingInfo 생성 및 자식 클래스 CustomPageInfo, CustomSliceInfo, CustomJpaPageInfo, CustomJpaSliceInfo 생성

무한스크롤 방식 페이징시 프론트엔드에서 필요한 항목은 `pageNumber`,`pageSize`,`last`,`empty` 네 가지 항목
페이지네이션 방식 페이징시 프론트엔드에서 필요한 항목은`pageNumber`,`pageSize`,`last`,`empty`,`totalPages`,` first` 여섯 가지 항목 입니다. (제가 퇴근 전 설명드렸던 것 처럼 무한스크롤 페이징 방식은 페이지로 이동하는 것이 아니기 때문에 첫번째 페이지 유무, 전체 페이지수가 필요하지 않습니다.)

따라서 공통된 `pageNumber`,`pageSize`,`last`,`empty` 항목을 추상클래스(CustomPagingInfo)에 정의했습니다.
**페이지네이션 방식**으로 처리하는 클래스는  `totalPages`,` first`를 필드로 갖도록 구현하고 CustomPagingInfo를 상속받아 생성자에서 모든 필드를 초기화 하도록 구현했습니다. 클래스명은 Page 객체를 사용하여 페이지네이션 방식을 처리하기 때문에 CustomPageInfo로 명명 했습니다.

**무한스크롤 방식**으로 처리하는 클래스는 CustomPagingInfo를 상속받아 생성자에서 모든 필드를 초기화 하도록 구현했으며 클래스명은 Slice 객체를 사용하여 무한스크롤 방식을 처리하기 때문에 CustomSliceInfo로 명명했습니다.

이전처럼 infrastructor 계층에서 Spring Data에 라이브러리의 Page, Slice 객체를 사용하고 있기 때문에 CustomJpaPageInfo, CustomJpaSliceInfo 클래스를 생성하고 해당 클래스를 사용하여 구현체 부분에서 페이징 객체들을 생성할 수 있도록 구현했습니다.

> 클래스명을 결정하면서 Spring Data에서 사용하는 Slice 및 Page 객체명을 따라서 CustomJpaPageInfo, CustomJpaSliceInfo로 구현했으나 각각의 부모클래스 CustomPageInfo, CustomSliceInfo 까지 Spring Data 의 객체명으로 만들어야하나? 라는 고민이 있었습니다.(이 클래스들은 DB 커넥션 기술이 바뀌더라도 그대로 사용하기 때문)리뷰시 해당 클래스명을 그대로 사용할지, 아니면 다른 이름으로 변경해서 사용할지 의견을 달아주세요~


### 무한스크롤 방식 반영
해당 부분은 구두로 회의 때 설명드려서 간단하게 정리하자면 각 내림차순으로 pageSize수 만큼 조회한 review의 마지막 번호(id)를 query파라미터로 전달받아 해당 리뷰 번호(id)보다 작은 항목부터 pageSize 만큼 조회하는 방식입니다.

더 정확하게 짚고 넘어가셨으면 좋겠어서 개발 시 참고한 블로그 링크 첨부드리니 확인해보시면 좋을 것 같습니다.
- https://velog.io/@da_na/Infinite-Scroll-Slice%EC%99%80-Page-%EC%B0%A8%EC%9D%B4%EC%A0%90-%EB%B6%84%EC%84%9D%ED%95%98%EC%97%AC-%EB%AC%B4%ED%95%9C-%EC%8A%A4%ED%81%AC%EB%A1%A4-%EC%A0%81%EC%9A%A9%ED%95%98%EA%B8%B0#4-2-slice-%EC%82%AC%EC%9A%A9%ED%95%98%EA%B8%B0
- https://devjem.tistory.com/74

> Controller부터 Facade, Service, Reader까지 `jdId`, `reviewId`, `pageInfoRequest` 세가지 항목을 전달하고 있는데 이 부분을 Command에 감싸서 전달할지 그대로 전달할지 고민했었습니다.  파라미터수가 4개가 안넘어서 따로 전달하도록 구현했습니다.

> 무한스크롤 방식으로 변경되면서 리뷰목록조회 API에서 더이상 `page`를 query파라미터로 받지 않지만 PageInfoRequest 내부에 `size`를 포함하고 있어 컨트롤러에서 PageInfoRequest를 그대로 사용했습니다.


### 테스트 코드 수정
무한스크롤 방식 반영에 따라 query파라미터로 reviewId가 추가되어 테스트코드를 수정했습니다.


### 변경한 결과
- 무한스크롤 적용 후 테스트코드 실행 결과 정상 동작을 확인했습니다.
<img width="792" alt="image" src="https://github.com/Kernel360/f1-JDON-Backend/assets/59242594/3eeec465-1447-4115-87fd-358a96e4b876">

- 리뷰ID를 전달하지 않았을 때 가장 높은 리뷰ID부터 반환하는것을 확인
![image](https://github.com/Kernel360/f1-JDON-Backend/assets/59242594/935b14b5-d482-4f25-9b05-040517e25181)

- 리뷰 id 27을 query파라미터로 전달할 때 id 26부터 조회되는 것을 확인
<img width="636" alt="image" src="https://github.com/Kernel360/f1-JDON-Backend/assets/59242594/bd8d42a9-5a59-4811-8fda-88310ee2287a">

- 이전 결과의 마지막 리뷰id인 24를 query파라미터로 전달할 때 id 23부터 조회되는 것을 확인
<img width="540" alt="image" src="https://github.com/Kernel360/f1-JDON-Backend/assets/59242594/5b72ea5e-3fdd-47bf-a2e8-e8b8c25c154a">

- 마지막 페이지일 때 pageInfo의 last가 true인 것을 확인
<img width="557" alt="image" src="https://github.com/Kernel360/f1-JDON-Backend/assets/59242594/3cffb82e-3b10-4c2f-8451-18a6bf184049">

- 빈 페이지일 때 pageInfo의 empty가 true인 것을 확인
<img width="528" alt="image" src="https://github.com/Kernel360/f1-JDON-Backend/assets/59242594/7e8228bb-0112-42dc-8ad3-dbccc5382774">






### 이슈

- closes: #400

---

## PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경, 주석 변경)
- [ ] 코드 리팩토링
- [ ] 문서 수정
- [x] 테스트 추가, 테스트 리팩토링
- [ ] 파일 혹은 폴더명 수정, 삭제
- [ ] 배포 관련