### PR TITLE
BugFix: 커피챗 수정, 삭제시 작성자 여부 Validation 추가

### DIFF
--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/coffeechat/application/CoffeeChatFacade.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/coffeechat/application/CoffeeChatFacade.java
@@ -48,8 +48,8 @@ public class CoffeeChatFacade {
         return coffeeChatService.modifyCoffeeChat(request);
     }
 
-    public CoffeeChatInfo.DeleteCoffeeChatResponse deleteCoffeeChat(Long coffeeChatId) {
-        return coffeeChatService.deleteCoffeeChat(coffeeChatId);
+    public CoffeeChatInfo.DeleteCoffeeChatResponse deleteCoffeeChat(Long coffeeChatId, Long memberId) {
+        return coffeeChatService.deleteCoffeeChat(coffeeChatId, memberId);
     }
 
     public CoffeeChatInfo.FindCoffeeChatListResponse getGuestCoffeeChatList(Long memberId,

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/coffeechat/application/CoffeeChatFacade.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/coffeechat/application/CoffeeChatFacade.java
@@ -44,9 +44,8 @@ public class CoffeeChatFacade {
         return coffeeChatService.createCoffeeChat(request, memberId);
     }
 
-    public CoffeeChatInfo.UpdateCoffeeChatResponse modifyCoffeeChat(CoffeeChatCommand.UpdateCoffeeChatRequest request,
-        Long coffeeChatId) {
-        return coffeeChatService.modifyCoffeeChat(request, coffeeChatId);
+    public CoffeeChatInfo.UpdateCoffeeChatResponse modifyCoffeeChat(CoffeeChatCommand.UpdateCoffeeChatRequest request) {
+        return coffeeChatService.modifyCoffeeChat(request);
     }
 
     public CoffeeChatInfo.DeleteCoffeeChatResponse deleteCoffeeChat(Long coffeeChatId) {

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/coffeechat/core/CoffeeChatCommand.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/coffeechat/core/CoffeeChatCommand.java
@@ -12,54 +12,56 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class CoffeeChatCommand {
 
-	@Getter
-	@Builder
-	public static class FindCoffeeChatListRequest {
-		private final CoffeeChatSortCondition sort;
-		private final String keyword;
-		private final Long jobCategory;
-	}
+    @Getter
+    @Builder
+    public static class FindCoffeeChatListRequest {
+        private final CoffeeChatSortCondition sort;
+        private final String keyword;
+        private final Long jobCategory;
+    }
 
-	@Getter
-	@Builder
-	public static class CreateCoffeeChatRequest {
+    @Getter
+    @Builder
+    public static class CreateCoffeeChatRequest {
 
-		private final String title;
-		private final String content;
-		private final Long totalRecruitCount;
-		private final LocalDateTime meetDate;
-		private final String openChatUrl;
+        private final String title;
+        private final String content;
+        private final Long totalRecruitCount;
+        private final LocalDateTime meetDate;
+        private final String openChatUrl;
 
-		public CoffeeChat toEntity(Member member) {
-			return CoffeeChat.builder()
-				.title(title)
-				.content(content)
-				.totalRecruitCount(totalRecruitCount)
-				.meetDate(meetDate)
-				.openChatUrl(openChatUrl)
-				.member(member)
-				.build();
-		}
+        public CoffeeChat toEntity(Member member) {
+            return CoffeeChat.builder()
+                .title(title)
+                .content(content)
+                .totalRecruitCount(totalRecruitCount)
+                .meetDate(meetDate)
+                .openChatUrl(openChatUrl)
+                .member(member)
+                .build();
+        }
 
-	}
+    }
 
-	@Getter
-	@Builder
-	public static class UpdateCoffeeChatRequest {
-		private final String title;
-		private final String content;
-		private final Long totalRecruitCount;
-		private final LocalDateTime meetDate;
-		private final String openChatUrl;
+    @Getter
+    @Builder
+    public static class UpdateCoffeeChatRequest {
+        private final String title;
+        private final String content;
+        private final Long totalRecruitCount;
+        private final LocalDateTime meetDate;
+        private final String openChatUrl;
+        private final Long coffeeChatId;
+        private final Long memberId;
 
-		public CoffeeChat toEntity() {
-			return CoffeeChat.builder()
-				.title(title)
-				.content(content)
-				.totalRecruitCount(totalRecruitCount)
-				.meetDate(meetDate)
-				.openChatUrl(openChatUrl)
-				.build();
-		}
-	}
+        public CoffeeChat toEntity() {
+            return CoffeeChat.builder()
+                .title(title)
+                .content(content)
+                .totalRecruitCount(totalRecruitCount)
+                .meetDate(meetDate)
+                .openChatUrl(openChatUrl)
+                .build();
+        }
+    }
 }

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/coffeechat/core/CoffeeChatService.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/coffeechat/core/CoffeeChatService.java
@@ -14,8 +14,7 @@ public interface CoffeeChatService {
 
     void increaseViewCount(Long coffeeChatId);
 
-    CoffeeChatInfo.UpdateCoffeeChatResponse modifyCoffeeChat(CoffeeChatCommand.UpdateCoffeeChatRequest request,
-        Long coffeeChatId);
+    CoffeeChatInfo.UpdateCoffeeChatResponse modifyCoffeeChat(CoffeeChatCommand.UpdateCoffeeChatRequest request);
 
     CoffeeChatInfo.DeleteCoffeeChatResponse deleteCoffeeChat(Long coffeeChatId);
 

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/coffeechat/core/CoffeeChatService.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/coffeechat/core/CoffeeChatService.java
@@ -16,7 +16,7 @@ public interface CoffeeChatService {
 
     CoffeeChatInfo.UpdateCoffeeChatResponse modifyCoffeeChat(CoffeeChatCommand.UpdateCoffeeChatRequest request);
 
-    CoffeeChatInfo.DeleteCoffeeChatResponse deleteCoffeeChat(Long coffeeChatId);
+    CoffeeChatInfo.DeleteCoffeeChatResponse deleteCoffeeChat(Long coffeeChatId, Long memberId);
 
     CoffeeChatInfo.FindCoffeeChatListResponse getGuestCoffeeChatList(Long memberId, PageInfoRequest pageInfoRequest);
 

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/coffeechat/core/CoffeeChatServiceImpl.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/coffeechat/core/CoffeeChatServiceImpl.java
@@ -80,11 +80,15 @@ public class CoffeeChatServiceImpl implements CoffeeChatService {
     }
 
     private void validateUpdateRequest(CoffeeChat findCoffeeChat, CoffeeChat updateCoffeeChat, Long memberId) {
+        checkMemberIsHost(findCoffeeChat, memberId);
+        checkMeetDate(findCoffeeChat, updateCoffeeChat);
+        checkTotalRecruitCount(findCoffeeChat, updateCoffeeChat);
+    }
+
+    private void checkMemberIsHost(CoffeeChat findCoffeeChat, Long memberId) {
         if (!isMemberHost(memberId, findCoffeeChat)) {
             throw new ApiException(CoffeeChatErrorCode.FORBIDDEN_COFFEECHAT_UPDATE);
         }
-        checkMeetDate(findCoffeeChat, updateCoffeeChat);
-        checkTotalRecruitCount(findCoffeeChat, updateCoffeeChat);
     }
 
     private void checkMeetDate(CoffeeChat findCoffeeChat, CoffeeChat updateCoffeeChat) {

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/coffeechat/core/CoffeeChatServiceImpl.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/coffeechat/core/CoffeeChatServiceImpl.java
@@ -81,7 +81,7 @@ public class CoffeeChatServiceImpl implements CoffeeChatService {
 
     private void validateUpdateRequest(CoffeeChat findCoffeeChat, CoffeeChat updateCoffeeChat, Long memberId) {
         if (!isMemberHost(memberId, findCoffeeChat)) {
-            throw new ApiException(CoffeeChatErrorCode.UNAUTHORIZED_COFFEECHAT_UPDATE);
+            throw new ApiException(CoffeeChatErrorCode.FORBIDDEN_COFFEECHAT_UPDATE);
         }
         checkMeetDate(findCoffeeChat, updateCoffeeChat);
         checkTotalRecruitCount(findCoffeeChat, updateCoffeeChat);
@@ -114,7 +114,7 @@ public class CoffeeChatServiceImpl implements CoffeeChatService {
 
     private void validateDeleteRequest(Long memberId, CoffeeChat findCoffeeChat) {
         if (!isMemberHost(memberId, findCoffeeChat)) {
-            throw new ApiException(CoffeeChatErrorCode.UNAUTHORIZED_COFFEECHAT_DELETE);
+            throw new ApiException(CoffeeChatErrorCode.FORBIDDEN_COFFEECHAT_DELETE);
         }
     }
 

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/coffeechat/core/CoffeeChatServiceImpl.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/coffeechat/core/CoffeeChatServiceImpl.java
@@ -49,12 +49,12 @@ public class CoffeeChatServiceImpl implements CoffeeChatService {
     @Override
     public CoffeeChatInfo.FindCoffeeChatResponse getCoffeeChat(Long coffeeChatId, Long memberId) {
         CoffeeChat findCoffeeChat = coffeeChatReader.findExistCoffeeChat(coffeeChatId);
-        boolean isParticipant = checkIfMemberParticipated(coffeeChatId, memberId);
+        boolean isParticipant = isParticipant(coffeeChatId, memberId);
 
         return coffeeChatInfoMapper.of(findCoffeeChat, isParticipant);
     }
 
-    private boolean checkIfMemberParticipated(Long coffeeChatId, Long memberId) {
+    private boolean isParticipant(Long coffeeChatId, Long memberId) {
         return Optional.ofNullable(memberId)
             .map(id -> coffeeChatReader.existsByCoffeeChatIdAndMemberId(coffeeChatId, id))
             .orElse(false);
@@ -150,12 +150,12 @@ public class CoffeeChatServiceImpl implements CoffeeChatService {
         if (isMemberHost(findMember.getId(), findCoffeeChat)) {
             throw new ApiException(CoffeeChatErrorCode.CANNOT_JOIN_OWN_COFFEECHAT);
         }
-        checkIfAlreadyJoined(findMember, findCoffeeChat);
+        checkDuplicateApply(findMember, findCoffeeChat);
     }
 
-    private void checkIfAlreadyJoined(Member findMember, CoffeeChat findCoffeeChat) {
+    private void checkDuplicateApply(Member findMember, CoffeeChat findCoffeeChat) {
         if (coffeeChatReader.existsByCoffeeChatIdAndMemberId(findCoffeeChat.getId(), findMember.getId())) {
-            throw new ApiException(CoffeeChatErrorCode.ALREADY_JOINED_COFFEECHAT);
+            throw new ApiException(CoffeeChatErrorCode.DUPLICATE_COFFEECHAT_APPLY);
         }
     }
 

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/coffeechat/core/CoffeeChatServiceImpl.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/coffeechat/core/CoffeeChatServiceImpl.java
@@ -69,20 +69,26 @@ public class CoffeeChatServiceImpl implements CoffeeChatService {
 
     @Override
     @Transactional
-    public CoffeeChatInfo.UpdateCoffeeChatResponse modifyCoffeeChat(CoffeeChatCommand.UpdateCoffeeChatRequest request,
-        Long coffeeChatId) {
-        CoffeeChat findCoffeeChat = coffeeChatReader.findExistCoffeeChat(coffeeChatId);
+    public CoffeeChatInfo.UpdateCoffeeChatResponse modifyCoffeeChat(CoffeeChatCommand.UpdateCoffeeChatRequest request) {
+        CoffeeChat findCoffeeChat = coffeeChatReader.findExistCoffeeChat(request.getCoffeeChatId());
         CoffeeChat updateCoffeeChat = request.toEntity();
 
-        validateUpdateRequest(findCoffeeChat, updateCoffeeChat);
+        validateUpdateRequest(findCoffeeChat, updateCoffeeChat, request.getMemberId());
         coffeeChatStore.update(findCoffeeChat, updateCoffeeChat);
 
         return new CoffeeChatInfo.UpdateCoffeeChatResponse(findCoffeeChat.getId());
     }
 
-    private void validateUpdateRequest(CoffeeChat findCoffeeChat, CoffeeChat updateCoffeeChat) {
+    private void validateUpdateRequest(CoffeeChat findCoffeeChat, CoffeeChat updateCoffeeChat, Long memberId) {
+        checkMemberIsAuthor(findCoffeeChat, memberId);
         checkMeetDate(findCoffeeChat, updateCoffeeChat);
         checkTotalRecruitCount(findCoffeeChat, updateCoffeeChat);
+    }
+
+    private void checkMemberIsAuthor(CoffeeChat findCoffeeChat, Long memberId) {
+        if (!memberId.equals(findCoffeeChat.getMember().getId())) {
+            throw new ApiException(CoffeeChatErrorCode.UNAUTHORIZED_COFFEECHAT_UPDATE);
+        }
     }
 
     private void checkMeetDate(CoffeeChat findCoffeeChat, CoffeeChat updateCoffeeChat) {

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/coffeechat/core/CoffeeChatServiceImpl.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/coffeechat/core/CoffeeChatServiceImpl.java
@@ -80,14 +80,14 @@ public class CoffeeChatServiceImpl implements CoffeeChatService {
     }
 
     private void validateUpdateRequest(CoffeeChat findCoffeeChat, CoffeeChat updateCoffeeChat, Long memberId) {
-        checkMemberIsHost(findCoffeeChat, memberId);
+        checkMemberIsNotHost(findCoffeeChat, memberId);
         checkMeetDate(findCoffeeChat, updateCoffeeChat);
         checkTotalRecruitCount(findCoffeeChat, updateCoffeeChat);
     }
 
-    private void checkMemberIsHost(CoffeeChat findCoffeeChat, Long memberId) {
+    private void checkMemberIsNotHost(CoffeeChat findCoffeeChat, Long memberId) {
         if (!isMemberHost(memberId, findCoffeeChat)) {
-            throw new ApiException(CoffeeChatErrorCode.FORBIDDEN_COFFEECHAT_UPDATE);
+            throw new ApiException(CoffeeChatErrorCode.FORBIDDEN_COFFEECHAT_ACCESS);
         }
     }
 
@@ -117,9 +117,7 @@ public class CoffeeChatServiceImpl implements CoffeeChatService {
     }
 
     private void validateDeleteRequest(Long memberId, CoffeeChat findCoffeeChat) {
-        if (!isMemberHost(memberId, findCoffeeChat)) {
-            throw new ApiException(CoffeeChatErrorCode.FORBIDDEN_COFFEECHAT_DELETE);
-        }
+        checkMemberIsNotHost(findCoffeeChat, memberId);
     }
 
     @Override
@@ -151,6 +149,7 @@ public class CoffeeChatServiceImpl implements CoffeeChatService {
     }
 
     private void validateApplyRequest(Member findMember, CoffeeChat findCoffeeChat) {
+
         if (isMemberHost(findMember.getId(), findCoffeeChat)) {
             throw new ApiException(CoffeeChatErrorCode.CANNOT_JOIN_OWN_COFFEECHAT);
         }

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/coffeechat/core/CoffeeChatServiceImpl.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/coffeechat/core/CoffeeChatServiceImpl.java
@@ -80,12 +80,12 @@ public class CoffeeChatServiceImpl implements CoffeeChatService {
     }
 
     private void validateUpdateRequest(CoffeeChat findCoffeeChat, CoffeeChat updateCoffeeChat, Long memberId) {
-        checkMemberIsNotHost(findCoffeeChat, memberId);
+        assertMemberIsHost(findCoffeeChat, memberId);
         checkMeetDate(findCoffeeChat, updateCoffeeChat);
         checkTotalRecruitCount(findCoffeeChat, updateCoffeeChat);
     }
 
-    private void checkMemberIsNotHost(CoffeeChat findCoffeeChat, Long memberId) {
+    private void assertMemberIsHost(CoffeeChat findCoffeeChat, Long memberId) {
         if (!isMemberHost(memberId, findCoffeeChat)) {
             throw new ApiException(CoffeeChatErrorCode.FORBIDDEN_COFFEECHAT_ACCESS);
         }
@@ -117,7 +117,7 @@ public class CoffeeChatServiceImpl implements CoffeeChatService {
     }
 
     private void validateDeleteRequest(Long memberId, CoffeeChat findCoffeeChat) {
-        checkMemberIsNotHost(findCoffeeChat, memberId);
+        assertMemberIsHost(findCoffeeChat, memberId);
     }
 
     @Override
@@ -149,11 +149,14 @@ public class CoffeeChatServiceImpl implements CoffeeChatService {
     }
 
     private void validateApplyRequest(Member findMember, CoffeeChat findCoffeeChat) {
+        assertMemberIsNotHost(findMember, findCoffeeChat);
+        checkDuplicateApply(findMember, findCoffeeChat);
+    }
 
+    private void assertMemberIsNotHost(Member findMember, CoffeeChat findCoffeeChat) {
         if (isMemberHost(findMember.getId(), findCoffeeChat)) {
             throw new ApiException(CoffeeChatErrorCode.CANNOT_JOIN_OWN_COFFEECHAT);
         }
-        checkDuplicateApply(findMember, findCoffeeChat);
     }
 
     private void checkDuplicateApply(Member findMember, CoffeeChat findCoffeeChat) {

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/coffeechat/core/CoffeeChatServiceImpl.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/coffeechat/core/CoffeeChatServiceImpl.java
@@ -28,8 +28,10 @@ public class CoffeeChatServiceImpl implements CoffeeChatService {
 
     @Override
     @Transactional
-    public CoffeeChatInfo.CreateCoffeeChatResponse createCoffeeChat(CoffeeChatCommand.CreateCoffeeChatRequest request,
-        Long memberId) {
+    public CoffeeChatInfo.CreateCoffeeChatResponse createCoffeeChat(
+        CoffeeChatCommand.CreateCoffeeChatRequest request,
+        Long memberId
+    ) {
         Member findMember = memberReader.findById(memberId);
         CoffeeChat savedCoffeeChat = coffeeChatStore.save(request.toEntity(findMember));
 
@@ -39,11 +41,9 @@ public class CoffeeChatServiceImpl implements CoffeeChatService {
     @Override
     public CoffeeChatInfo.FindCoffeeChatListResponse getCoffeeChatList(
         final PageInfoRequest pageInfoRequest,
-        final CoffeeChatCommand.FindCoffeeChatListRequest command) {
-        final CoffeeChatInfo.FindCoffeeChatListResponse coffeeChatList = coffeeChatReader.findCoffeeChatList(
-            pageInfoRequest, command);
-
-        return coffeeChatList;
+        final CoffeeChatCommand.FindCoffeeChatListRequest command
+    ) {
+        return coffeeChatReader.findCoffeeChatList(pageInfoRequest, command);
     }
 
     @Override
@@ -119,14 +119,18 @@ public class CoffeeChatServiceImpl implements CoffeeChatService {
     }
 
     @Override
-    public CoffeeChatInfo.FindCoffeeChatListResponse getGuestCoffeeChatList(Long memberId,
-        PageInfoRequest pageInfoRequest) {
+    public CoffeeChatInfo.FindCoffeeChatListResponse getGuestCoffeeChatList(
+        Long memberId,
+        PageInfoRequest pageInfoRequest
+    ) {
         return coffeeChatReader.findGuestCoffeeChatList(memberId, pageInfoRequest);
     }
 
     @Override
-    public CoffeeChatInfo.FindCoffeeChatListResponse getHostCoffeeChatList(Long memberId,
-        PageInfoRequest pageInfoRequest) {
+    public CoffeeChatInfo.FindCoffeeChatListResponse getHostCoffeeChatList(
+        Long memberId,
+        PageInfoRequest pageInfoRequest
+    ) {
         return coffeeChatReader.findHostCoffeeChatList(memberId, pageInfoRequest);
     }
 

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/coffeechat/error/CoffeeChatErrorCode.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/coffeechat/error/CoffeeChatErrorCode.java
@@ -17,7 +17,7 @@ public enum CoffeeChatErrorCode implements ErrorCode, BaseThrowException<CoffeeC
     MEET_DATE_ISBEFORE_NOW(HttpStatus.BAD_REQUEST, "지금보다 이전 시점으로 설정할 수 없습니다."),
     LOCK_ACQUISITION_FAILURE(HttpStatus.SERVICE_UNAVAILABLE, "현재 많은 요청으로 인해 처리가 지연되고 있습니다. 잠시 후 다시 시도해주세요."),
     THREAD_INTERRUPTED(HttpStatus.SERVICE_UNAVAILABLE, "처리 중 문제가 발생했습니다. 잠시 후 다시 시도해주세요."),
-    ALREADY_JOINED_COFFEECHAT(HttpStatus.CONFLICT, "이미 참여한 커피챗 입니다."),
+    DUPLICATE_COFFEECHAT_APPLY(HttpStatus.CONFLICT, "이미 참여한 커피챗 입니다."),
     NOT_FOUND_APPLICATION(HttpStatus.NOT_FOUND, "해당 커피챗을 신청한 정보가 없습니다."),
     UNAUTHORIZED_COFFEECHAT_UPDATE(HttpStatus.UNAUTHORIZED, "본인이 작성하지 않은 커피챗을 수정할 수 없습니다."),
     UNAUTHORIZED_COFFEECHAT_DELETE(HttpStatus.UNAUTHORIZED, "본인이 작성하지 않은 커피챗을 삭제할 수 없습니다.");

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/coffeechat/error/CoffeeChatErrorCode.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/coffeechat/error/CoffeeChatErrorCode.java
@@ -19,8 +19,8 @@ public enum CoffeeChatErrorCode implements ErrorCode, BaseThrowException<CoffeeC
     THREAD_INTERRUPTED(HttpStatus.SERVICE_UNAVAILABLE, "처리 중 문제가 발생했습니다. 잠시 후 다시 시도해주세요."),
     DUPLICATE_COFFEECHAT_APPLY(HttpStatus.CONFLICT, "이미 참여한 커피챗 입니다."),
     NOT_FOUND_APPLICATION(HttpStatus.NOT_FOUND, "해당 커피챗을 신청한 정보가 없습니다."),
-    UNAUTHORIZED_COFFEECHAT_UPDATE(HttpStatus.UNAUTHORIZED, "본인이 작성하지 않은 커피챗을 수정할 수 없습니다."),
-    UNAUTHORIZED_COFFEECHAT_DELETE(HttpStatus.UNAUTHORIZED, "본인이 작성하지 않은 커피챗을 삭제할 수 없습니다.");
+    UNAUTHORIZED_COFFEECHAT_UPDATE(HttpStatus.FORBIDDEN, "본인이 작성하지 않은 커피챗을 수정할 수 없습니다."),
+    UNAUTHORIZED_COFFEECHAT_DELETE(HttpStatus.FORBIDDEN, "본인이 작성하지 않은 커피챗을 삭제할 수 없습니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/coffeechat/error/CoffeeChatErrorCode.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/coffeechat/error/CoffeeChatErrorCode.java
@@ -19,8 +19,8 @@ public enum CoffeeChatErrorCode implements ErrorCode, BaseThrowException<CoffeeC
     THREAD_INTERRUPTED(HttpStatus.SERVICE_UNAVAILABLE, "처리 중 문제가 발생했습니다. 잠시 후 다시 시도해주세요."),
     DUPLICATE_COFFEECHAT_APPLY(HttpStatus.CONFLICT, "이미 참여한 커피챗 입니다."),
     NOT_FOUND_APPLICATION(HttpStatus.NOT_FOUND, "해당 커피챗을 신청한 정보가 없습니다."),
-    UNAUTHORIZED_COFFEECHAT_UPDATE(HttpStatus.FORBIDDEN, "본인이 작성하지 않은 커피챗을 수정할 수 없습니다."),
-    UNAUTHORIZED_COFFEECHAT_DELETE(HttpStatus.FORBIDDEN, "본인이 작성하지 않은 커피챗을 삭제할 수 없습니다.");
+    FORBIDDEN_COFFEECHAT_UPDATE(HttpStatus.FORBIDDEN, "본인이 작성하지 않은 커피챗을 수정할 수 없습니다."),
+    FORBIDDEN_COFFEECHAT_DELETE(HttpStatus.FORBIDDEN, "본인이 작성하지 않은 커피챗을 삭제할 수 없습니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/coffeechat/error/CoffeeChatErrorCode.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/coffeechat/error/CoffeeChatErrorCode.java
@@ -18,7 +18,9 @@ public enum CoffeeChatErrorCode implements ErrorCode, BaseThrowException<CoffeeC
     LOCK_ACQUISITION_FAILURE(HttpStatus.SERVICE_UNAVAILABLE, "현재 많은 요청으로 인해 처리가 지연되고 있습니다. 잠시 후 다시 시도해주세요."),
     THREAD_INTERRUPTED(HttpStatus.SERVICE_UNAVAILABLE, "처리 중 문제가 발생했습니다. 잠시 후 다시 시도해주세요."),
     ALREADY_JOINED_COFFEECHAT(HttpStatus.CONFLICT, "이미 참여한 커피챗 입니다."),
-    NOT_FOUND_APPLICATION(HttpStatus.NOT_FOUND, "해당 커피챗을 신청한 정보가 없습니다.");
+    NOT_FOUND_APPLICATION(HttpStatus.NOT_FOUND, "해당 커피챗을 신청한 정보가 없습니다."),
+    UNAUTHORIZED_COFFEECHAT_UPDATE(HttpStatus.UNAUTHORIZED, "본인이 작성하지 않은 커피챗을 수정할 수 없습니다."),
+    UNAUTHORIZED_COFFEECHAT_DELETE(HttpStatus.UNAUTHORIZED, "본인이 작성하지 않은 커피챗을 삭제할 수 없습니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/coffeechat/error/CoffeeChatErrorCode.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/coffeechat/error/CoffeeChatErrorCode.java
@@ -19,8 +19,7 @@ public enum CoffeeChatErrorCode implements ErrorCode, BaseThrowException<CoffeeC
     THREAD_INTERRUPTED(HttpStatus.SERVICE_UNAVAILABLE, "처리 중 문제가 발생했습니다. 잠시 후 다시 시도해주세요."),
     DUPLICATE_COFFEECHAT_APPLY(HttpStatus.CONFLICT, "이미 참여한 커피챗 입니다."),
     NOT_FOUND_APPLICATION(HttpStatus.NOT_FOUND, "해당 커피챗을 신청한 정보가 없습니다."),
-    FORBIDDEN_COFFEECHAT_UPDATE(HttpStatus.FORBIDDEN, "본인이 작성하지 않은 커피챗을 수정할 수 없습니다."),
-    FORBIDDEN_COFFEECHAT_DELETE(HttpStatus.FORBIDDEN, "본인이 작성하지 않은 커피챗을 삭제할 수 없습니다.");
+    FORBIDDEN_COFFEECHAT_ACCESS(HttpStatus.FORBIDDEN, "본인이 작성하지 않은 커피챗의 상태를 변경할 수 없습니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/coffeechat/presentation/CoffeeChatController.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/coffeechat/presentation/CoffeeChatController.java
@@ -108,12 +108,13 @@ public class CoffeeChatController {
 
     @PutMapping("/api/v1/coffeechats/{id}")
     public ResponseEntity<CommonResponse<CoffeeChatDto.UpdateCoffeeChatResponse>> modifyCoffeeChat(
+        @RequestBody @Valid CoffeeChatDto.UpdateCoffeeChatRequest request,
         @PathVariable(name = "id") Long coffeeChatId,
-        @RequestBody @Valid CoffeeChatDto.UpdateCoffeeChatRequest request
+        @LoginUser SessionUserInfo member
     ) {
-        CoffeeChatCommand.UpdateCoffeeChatRequest updateCommand = coffeeChatDtoMapper.of(request);
-        CoffeeChatInfo.UpdateCoffeeChatResponse info = coffeeChatFacade.modifyCoffeeChat(
-            updateCommand, coffeeChatId);
+        CoffeeChatCommand.UpdateCoffeeChatRequest updateCommand = coffeeChatDtoMapper.of(request, coffeeChatId,
+            member.getId());
+        CoffeeChatInfo.UpdateCoffeeChatResponse info = coffeeChatFacade.modifyCoffeeChat(updateCommand);
         CoffeeChatDto.UpdateCoffeeChatResponse response = coffeeChatDtoMapper.of(info);
 
         return ResponseEntity.ok().body(CommonResponse.of(response));

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/coffeechat/presentation/CoffeeChatController.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/coffeechat/presentation/CoffeeChatController.java
@@ -122,9 +122,11 @@ public class CoffeeChatController {
 
     @DeleteMapping("/api/v1/coffeechats/{id}")
     public ResponseEntity<CommonResponse<CoffeeChatDto.DeleteCoffeeChatResponse>> removeCoffeeChat(
-        @PathVariable(name = "id") Long coffeeChatId) {
+        @PathVariable(name = "id") Long coffeeChatId,
+        @LoginUser SessionUserInfo member
+    ) {
         CoffeeChatInfo.DeleteCoffeeChatResponse info = coffeeChatFacade.deleteCoffeeChat(
-            coffeeChatId);
+            coffeeChatId, member.getId());
         CoffeeChatDto.DeleteCoffeeChatResponse response = coffeeChatDtoMapper.of(info);
 
         return ResponseEntity.ok().body(CommonResponse.of(response));

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/coffeechat/presentation/CoffeeChatDtoMapper.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/coffeechat/presentation/CoffeeChatDtoMapper.java
@@ -28,7 +28,8 @@ public interface CoffeeChatDtoMapper {
 
     CoffeeChatCommand.CreateCoffeeChatRequest of(CoffeeChatDto.CreateCoffeeChatRequest request);
 
-    CoffeeChatCommand.UpdateCoffeeChatRequest of(CoffeeChatDto.UpdateCoffeeChatRequest request);
+    CoffeeChatCommand.UpdateCoffeeChatRequest of(CoffeeChatDto.UpdateCoffeeChatRequest request, Long coffeeChatId,
+        Long memberId);
 
     CoffeeChatCommand.FindCoffeeChatListRequest of(CoffeeChatCondition request);
 


### PR DESCRIPTION
## 개요

- 커피챗 수정, 삭제시 로그인 유저가 작성자가 아니면 예외처리 하도록 변경했습니다.

### 변경한 부분

- 각 API 컨트롤러에서 이제 로그인 유저 정보를 받습니다
  - 수정 API의 경우 전달하는 파라미터가 3개가 되어서 Command DTO로 감쌌습니다.
- 본인이 작성하지 않은 커피챗을 수정,삭제하려고 할때 예외에 담을 ErrorCode를 생성했습니다.

- 그 외
  - 가독성을 위한 개행 구분 및 getCoffeeChatList 메서드에서 inline variable을 바로 반환하도록 했습니다.
  - 에러코드와 메서드명 네이밍을 개선했습니다.
    - 에러코드: ~ALREADY_JOINED-COFFEECHAT~ -> DUPLICATE_COFFEECHAT_APPLY
    - 메서드명: ~checkIfAlreadyJoined~ -> checkDuplicateApply
    - 메서드명: ~checkIfMemberParticipated~ -> isParticipant

### 변경한 결과

> 작성하지 않은 커피챗 수정 요청시
![image](https://github.com/Kernel360/f1-JDON-Backend/assets/111513287/ead14941-ff10-401b-be0f-fe40e412e033)

> 작성하지 않은 커피챗 삭제요청시
![image](https://github.com/Kernel360/f1-JDON-Backend/assets/111513287/3b7df202-c6d0-46cf-9bda-8c64c682739a)


### 이슈

- closes: #431 

---

## PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [X] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경, 주석 변경)
- [X] 코드 리팩토링
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 파일 혹은 폴더명 수정, 삭제
- [ ] 배포 관련