### PR TITLE
BugFix : scrapingDate 필드 타입 변경

### DIFF
--- a/module-domain/src/main/java/kernel/jdon/moduledomain/wantedjd/domain/WantedJd.java
+++ b/module-domain/src/main/java/kernel/jdon/moduledomain/wantedjd/domain/WantedJd.java
@@ -1,5 +1,6 @@
 package kernel.jdon.moduledomain.wantedjd.domain;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -33,69 +34,69 @@ import lombok.NoArgsConstructor;
 @Table(name = "wanted_jd", uniqueConstraints = @UniqueConstraint(columnNames = {"detail_id", "job_category_id"}))
 public class WantedJd {
 
-	@Id
-	@GeneratedValue(strategy = GenerationType.IDENTITY)
-	private Long id;
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
 
-	@Column(name = "company_name", columnDefinition = "VARCHAR(50)", nullable = false)
-	private String companyName;
+    @Column(name = "company_name", columnDefinition = "VARCHAR(50)", nullable = false)
+    private String companyName;
 
-	@Column(name = "title", columnDefinition = "VARCHAR(255)", nullable = false)
-	private String title;
+    @Column(name = "title", columnDefinition = "VARCHAR(255)", nullable = false)
+    private String title;
 
-	@Column(name = "detail_id", columnDefinition = "BIGINT", nullable = false)
-	private Long detailId;
+    @Column(name = "detail_id", columnDefinition = "BIGINT", nullable = false)
+    private Long detailId;
 
-	@Column(name = "detail_url", columnDefinition = "VARCHAR(255)", nullable = false)
-	private String detailUrl;
+    @Column(name = "detail_url", columnDefinition = "VARCHAR(255)", nullable = false)
+    private String detailUrl;
 
-	@Column(name = "image_url", columnDefinition = "TEXT", nullable = false)
-	private String imageUrl;
+    @Column(name = "image_url", columnDefinition = "TEXT", nullable = false)
+    private String imageUrl;
 
-	@Column(name = "requirements", columnDefinition = "TEXT")
-	private String requirements;
+    @Column(name = "requirements", columnDefinition = "TEXT")
+    private String requirements;
 
-	@Column(name = "main_tasks", columnDefinition = "TEXT")
-	private String mainTasks;
+    @Column(name = "main_tasks", columnDefinition = "TEXT")
+    private String mainTasks;
 
-	@Column(name = "intro", columnDefinition = "TEXT")
-	private String intro;
+    @Column(name = "intro", columnDefinition = "TEXT")
+    private String intro;
 
-	@Column(name = "benefits", columnDefinition = "TEXT")
-	private String benefits;
+    @Column(name = "benefits", columnDefinition = "TEXT")
+    private String benefits;
 
-	@Column(name = "preferredPoints", columnDefinition = "TEXT")
-	private String preferredPoints;
+    @Column(name = "preferredPoints", columnDefinition = "TEXT")
+    private String preferredPoints;
 
-	@CreatedDate
-	@Column(name = "scraping_date", columnDefinition = "TEXT", nullable = false)
-	private String scrapingDate;
+    @CreatedDate
+    @Column(name = "scraping_date", columnDefinition = "DATETIME", nullable = false)
+    private LocalDateTime scrapingDate;
 
-	@ManyToOne(fetch = FetchType.EAGER)
-	@JoinColumn(name = "job_category_id", columnDefinition = "BIGINT")
-	private JobCategory jobCategory;
+    @ManyToOne(fetch = FetchType.EAGER)
+    @JoinColumn(name = "job_category_id", columnDefinition = "BIGINT")
+    private JobCategory jobCategory;
 
-	@OneToMany(mappedBy = "wantedJd")
-	private List<WantedJdSkill> skillList = new ArrayList<>();
+    @OneToMany(mappedBy = "wantedJd")
+    private List<WantedJdSkill> skillList = new ArrayList<>();
 
-	@OneToMany(mappedBy = "wantedJd")
-	private List<Review> reviewList = new ArrayList<>();
+    @OneToMany(mappedBy = "wantedJd")
+    private List<Review> reviewList = new ArrayList<>();
 
-	@Builder
-	public WantedJd(String companyName, String title, Long detailId, String detailUrl, String imageUrl,
-		String requirements, String mainTasks, String intro, String benefits, String preferredPoints,
-		String scrapingDate, JobCategory jobCategory) {
-		this.companyName = companyName;
-		this.title = title;
-		this.detailId = detailId;
-		this.detailUrl = detailUrl;
-		this.imageUrl = imageUrl;
-		this.requirements = requirements;
-		this.mainTasks = mainTasks;
-		this.intro = intro;
-		this.benefits = benefits;
-		this.preferredPoints = preferredPoints;
-		this.scrapingDate = scrapingDate;
-		this.jobCategory = jobCategory;
-	}
+    @Builder
+    public WantedJd(String companyName, String title, Long detailId, String detailUrl, String imageUrl,
+        String requirements, String mainTasks, String intro, String benefits, String preferredPoints,
+        LocalDateTime scrapingDate, JobCategory jobCategory) {
+        this.companyName = companyName;
+        this.title = title;
+        this.detailId = detailId;
+        this.detailUrl = detailUrl;
+        this.imageUrl = imageUrl;
+        this.requirements = requirements;
+        this.mainTasks = mainTasks;
+        this.intro = intro;
+        this.benefits = benefits;
+        this.preferredPoints = preferredPoints;
+        this.scrapingDate = scrapingDate;
+        this.jobCategory = jobCategory;
+    }
 }


### PR DESCRIPTION
## 개요

### 요약
- wanted_jd 테이블 scraping_date 컬럼 타입 변경

### 변경한 부분
- 운영서버, 개발서버의 wanted_jd 테이블의 scraping_date 컬럼 타입을 변경 했습니다.
1. DATE 타입의 TEMP 컬럼을 신규 생성
2. 기존 scraping_date 컬럼 데이터를 DATE 타입으로 형변환하여 TEMP 컬럼에 복사
3. 기존 scraping_date 컬럼을 삭제
4. TEMP 컬럼명을 scraping_date으로 변경

**개인 로컬 DB에서도 직접 DDL을 입력하여 컬럼타입 변경이 필요합니다.**

```
ALTER TABLE wanted_jd
ADD COLUMN temp DATETIME;

UPDATE wanted_jd
SET temp = STR_TO_DATE(scraping_date, '%y. %m. %d. 오후 %h:%i');

ALTER TABLE wanted_jd
DROP COLUMN scraping_date;

ALTER TABLE wanted_jd
CHANGE COLUMN temp scraping_date DATETIME;

ALTER TABLE wanted_jd
MODIFY COLUMN scraping_date DATETIME NOT NULL;
```

- WantedJd 엔티티의 scrapingDate 필드 타입을 변경했습니다.

### 변경한 결과
<img width="612" alt="image" src="https://github.com/Kernel360/f1-JDON-Backend/assets/59242594/b237cf3e-5e2f-4bdc-9d08-fbbfd854dad0">

### 이슈

- closes: #420 

---

## PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경, 주석 변경)
- [ ] 코드 리팩토링
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 파일 혹은 폴더명 수정, 삭제
- [ ] 배포 관련