### PR TITLE
Test: Skill 도메인 테스트코드 리팩토링

### DIFF
--- a/module-api/src/test/java/kernel/jdon/moduleapi/domain/skill/application/SkillFacadeTest.java
+++ b/module-api/src/test/java/kernel/jdon/moduleapi/domain/skill/application/SkillFacadeTest.java
@@ -40,12 +40,12 @@ class SkillFacadeTest {
     @DisplayName("2: getMemberSkillList 메서드가 존재하는 memberSkill 목록 데이터를 응답한다.")
     void givenValidMemberSkillList_whenFindList_thenReturnCorrectHotSkillList() {
         // given
-        var memberId = 1L;
-        var mockMemberSkillListInfo = mock(SkillInfo.FindMemberSkillListResponse.class);
+        final var memberId = 1L;
+        final var mockMemberSkillListInfo = mock(SkillInfo.FindMemberSkillListResponse.class);
         given(skillService.getMemberSkillList(memberId)).willReturn(mockMemberSkillListInfo);
 
         // when
-        var response = skillFacade.getMemberSkillList(memberId);
+        final var response = skillFacade.getMemberSkillList(memberId);
 
         // then
         assertThat(response).isEqualTo(mockMemberSkillListInfo);
@@ -78,7 +78,7 @@ class SkillFacadeTest {
         given(skillService.getDataListBySkill(keyword, memberId)).willReturn(mockDataListBySkillInfo);
 
         //when
-        var response = skillFacade.getDataListBySkill(keyword, memberId);
+        final var response = skillFacade.getDataListBySkill(keyword, memberId);
 
         //then
         assertThat(response).isEqualTo(mockDataListBySkillInfo);

--- a/module-api/src/test/java/kernel/jdon/moduleapi/domain/skill/application/SkillFacadeTest.java
+++ b/module-api/src/test/java/kernel/jdon/moduleapi/domain/skill/application/SkillFacadeTest.java
@@ -1,11 +1,7 @@
 package kernel.jdon.moduleapi.domain.skill.application;
 
 import static org.assertj.core.api.Assertions.*;
-import static org.mockito.Mockito.*;
-
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
+import static org.mockito.BDDMockito.*;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -20,120 +16,72 @@ import kernel.jdon.moduleapi.domain.skill.core.SkillService;
 @DisplayName("Skill Facade 테스트")
 @ExtendWith(MockitoExtension.class)
 class SkillFacadeTest {
-	@Mock
-	private SkillService skillService;
-	@InjectMocks
-	private SkillFacade skillFacade;
+    @Mock
+    private SkillService skillService;
+    @InjectMocks
+    private SkillFacade skillFacade;
 
-	@Test
-	@DisplayName("1: getHotSkillList 메서드가 존재하는 HotSkill 개수 만큼 데이터를 응답한다.")
-	void givenValidHotSkillList_whenFindList_thenReturnCorrectHotSkillList() {
-		// given
-		var hotSkillList = Collections.singletonList(toHotSkill(1L, "hot_skill_keyword"));
-		var hotSkillListResponse = toHotSkillList(hotSkillList);
+    @Test
+    @DisplayName("1: getHotSkillList 메서드가 존재하는 HotSkill 목록 데이터를 응답한다.")
+    void givenValidHotSkillList_whenFindList_thenReturnCorrectHotSkillList() {
+        // given
+        final var mockHotSkillListInfo = mock(SkillInfo.FindHotSkillListResponse.class);
+        given(skillService.getHotSkillList()).willReturn(mockHotSkillListInfo);
 
-		// when
-		when(skillService.getHotSkillList()).thenReturn(hotSkillListResponse);
-		var response = skillFacade.getHotSkillList();
+        // when
+        final var response = skillFacade.getHotSkillList();
 
-		// then
-		assertThat(response.getSkillList()).hasSize(1);
-		verify(skillService, times(1)).getHotSkillList();
-	}
+        // then
+        assertThat(response).isEqualTo(mockHotSkillListInfo);
+        then(skillService).should(times(1)).getHotSkillList();
+    }
 
-	private SkillInfo.FindHotSkillListResponse toHotSkillList(List<SkillInfo.FindHotSkill> skillList) {
-		return SkillInfo.FindHotSkillListResponse.builder().skillList(skillList).build();
-	}
+    @Test
+    @DisplayName("2: getMemberSkillList 메서드가 존재하는 memberSkill 목록 데이터를 응답한다.")
+    void givenValidMemberSkillList_whenFindList_thenReturnCorrectHotSkillList() {
+        // given
+        var memberId = 1L;
+        var mockMemberSkillListInfo = mock(SkillInfo.FindMemberSkillListResponse.class);
+        given(skillService.getMemberSkillList(memberId)).willReturn(mockMemberSkillListInfo);
 
-	private SkillInfo.FindHotSkill toHotSkill(Long id, String keyword) {
-		return SkillInfo.FindHotSkill.builder().id(id).keyword(keyword).build();
-	}
+        // when
+        var response = skillFacade.getMemberSkillList(memberId);
 
-	@Test
-	@DisplayName("2: getMemberSkillList 메서드가 존재하는 memberSkill 개수 만큼 데이터를 응답한다.")
-	void givenValidMemberSkillList_whenFindList_thenReturnCorrectHotSkillList() {
-		// given
-		var memberSkillList = Arrays.asList(
-			toMemberSkill(1L, "member_skill_keyword_1"),
-			toMemberSkill(2L, "member_skill_keyword_2"),
-			toMemberSkill(3L, "member_skill_keyword_3"));
-		var memberSkillListResponse = toMemberSkillList(memberSkillList);
-		var memberId = 1L;
+        // then
+        assertThat(response).isEqualTo(mockMemberSkillListInfo);
+        then(skillService).should(times(1)).getMemberSkillList(memberId);
+    }
 
-		// when
-		when(skillService.getMemberSkillList(memberId)).thenReturn(memberSkillListResponse);
-		var response = skillFacade.getMemberSkillList(memberId);
+    @Test
+    @DisplayName("3: 올바른 직군 ID가 주어졌을 때, getJobCategorySkillList 메서드가 직군별 기술스택 목록 데이터를 응답한다.")
+    void givenValidJobCategoryId_whenFindList_thenReturnCorrectJobCategorySkillList() throws Exception {
+        //given
+        final var jobCategoryId = 1L;
+        final var mockJobCategorySkillListInfo = mock(SkillInfo.FindJobCategorySkillListResponse.class);
+        given(skillService.getJobCategorySkillList(jobCategoryId)).willReturn(mockJobCategorySkillListInfo);
 
-		// then
-		assertThat(response.getSkillList()).hasSize(3);
-		verify(skillService, times(1)).getMemberSkillList(memberId);
-	}
+        //when
+        final var response = skillFacade.getJobCategorySkillList(jobCategoryId);
 
-	private SkillInfo.FindMemberSkillListResponse toMemberSkillList(List<SkillInfo.FindMemberSkill> skillList) {
-		return SkillInfo.FindMemberSkillListResponse.builder().skillList(skillList).build();
-	}
+        //then
+        assertThat(response).isEqualTo(mockJobCategorySkillListInfo);
+        then(skillService).should(times(1)).getJobCategorySkillList(jobCategoryId);
+    }
 
-	private SkillInfo.FindMemberSkill toMemberSkill(Long id, String keyword) {
-		return SkillInfo.FindMemberSkill.builder().id(id).keyword(keyword).build();
-	}
+    @Test
+    @DisplayName("4: keyword, memberId가 주어졌을 때, getDataListBySkill 메서드가 기술스택 기반 강의, JD 목록 데이터를 응답한다.")
+    void givenValidKeyword_whenFindList_thenReturnCorrectDataListBySkill() throws Exception {
+        //given
+        final String keyword = "AWS";
+        final var memberId = 1L;
+        final var mockDataListBySkillInfo = mock(SkillInfo.FindDataListBySkillResponse.class);
+        given(skillService.getDataListBySkill(keyword, memberId)).willReturn(mockDataListBySkillInfo);
 
-	@Test
-	@DisplayName("3: 올바른 직군 ID가 주어졌을 때 getJobCategorySkillList 메서드가 직군별 기술스택 데이터 개수 만큼 데이터를 응답한다.")
-	void givenValidJobCategoryId_whenFindList_thenReturnCorrectJobCategorySkillList() throws Exception {
-		//given
-		Long jobCategoryId = 1L;
-		var jobCategorySkillListResponse = toJobCategorySkillList(Arrays.asList(
-			toJobCategorySkill(1L, "JAVA"),
-			toJobCategorySkill(2L, "GO"),
-			toJobCategorySkill(3L, "Python")));
+        //when
+        var response = skillFacade.getDataListBySkill(keyword, memberId);
 
-		//when
-		when(skillService.getJobCategorySkillList(jobCategoryId)).thenReturn(jobCategorySkillListResponse);
-		var response = skillFacade.getJobCategorySkillList(jobCategoryId);
-
-		//then
-		assertThat(response.getSkillList()).hasSize(3);
-		verify(skillService, times(1)).getJobCategorySkillList(jobCategoryId);
-	}
-
-	private SkillInfo.FindJobCategorySkillListResponse toJobCategorySkillList(
-		List<SkillInfo.FindJobCategorySkill> skillList) {
-		return SkillInfo.FindJobCategorySkillListResponse.builder().skillList(skillList).build();
-	}
-
-	private SkillInfo.FindJobCategorySkill toJobCategorySkill(Long id, String keyword) {
-		return SkillInfo.FindJobCategorySkill.builder().skillId(id).keyword(keyword).build();
-	}
-
-	@Test
-	@DisplayName("4: keyword가 주어졌을 때 getDataListBySkill 메서드가 keyword 기반의 JD 및 강의 데이터 개수 만큼 데이터를 응답한다.")
-	void givenValidKeyword_whenFindList_thenReturnCorrectDataListBySkill() throws Exception {
-		//given
-		final Long memberId = 1L;
-		final String keyword = "AWS";
-		final int jdCount = 1;
-		final int lectureCount = 1;
-		var dataListBySkillResponse = getMockDataListBySkillResponse(keyword);
-
-		//when
-		when(skillService.getDataListBySkill(keyword, memberId)).thenReturn(dataListBySkillResponse);
-		var response = skillFacade.getDataListBySkill(keyword, memberId);
-
-		//then
-		assertThat(response.getJdList()).hasSize(jdCount);
-		assertThat(response.getLectureList()).hasSize(lectureCount);
-		assertThat(response.getKeyword()).isEqualTo(keyword);
-		verify(skillService, times(1)).getDataListBySkill(keyword, memberId);
-	}
-
-	private SkillInfo.FindDataListBySkillResponse getMockDataListBySkillResponse(String keyword) {
-		var findJdList = Collections.singletonList(mock(SkillInfo.FindJd.class));
-		var findLectureList = Collections.singletonList(mock(SkillInfo.FindLecture.class));
-		var dataListBySkillResponse = SkillInfo.FindDataListBySkillResponse.builder()
-			.keyword(keyword)
-			.jdList(findJdList)
-			.lectureList(findLectureList)
-			.build();
-		return dataListBySkillResponse;
-	}
+        //then
+        assertThat(response).isEqualTo(mockDataListBySkillInfo);
+        then(skillService).should(times(1)).getDataListBySkill(keyword, memberId);
+    }
 }

--- a/module-api/src/test/java/kernel/jdon/moduleapi/domain/skill/core/SkillServiceImplTest.java
+++ b/module-api/src/test/java/kernel/jdon/moduleapi/domain/skill/core/SkillServiceImplTest.java
@@ -1,7 +1,7 @@
 package kernel.jdon.moduleapi.domain.skill.core;
 
 import static org.assertj.core.api.Assertions.*;
-import static org.mockito.Mockito.*;
+import static org.mockito.BDDMockito.*;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -16,97 +16,98 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import kernel.jdon.moduledomain.jobcategory.domain.JobCategory;
 import kernel.jdon.moduleapi.domain.jobcategory.core.JobCategoryReader;
 import kernel.jdon.moduleapi.domain.skill.core.inflearnjd.InflearnJdSkillReader;
 import kernel.jdon.moduleapi.domain.skill.core.wantedjd.WantedJdSkillReader;
+import kernel.jdon.moduledomain.jobcategory.domain.JobCategory;
 import kernel.jdon.util.JsonFileReader;
 
 @DisplayName("Skill Service Impl 테스트")
 @ExtendWith(MockitoExtension.class)
 class SkillServiceImplTest {
-	@Mock
-	private SkillReader skillReader;
-	@Mock
-	private JobCategoryReader jobCategoryReader;
-	@Mock
-	private WantedJdSkillReader wantedJdSkillReader;
-	@Mock
-	private InflearnJdSkillReader inflearnJdSkillReader;
-	@InjectMocks
-	private SkillServiceImpl skillServiceImpl;
+    @Mock
+    private SkillReader skillReader;
+    @Mock
+    private JobCategoryReader jobCategoryReader;
+    @Mock
+    private WantedJdSkillReader wantedJdSkillReader;
+    @Mock
+    private InflearnJdSkillReader inflearnJdSkillReader;
+    @InjectMocks
+    private SkillServiceImpl skillServiceImpl;
 
-	@Test
-	@DisplayName("1: getHotSkillList 메서드가 존재하는 HotSkill 개수 만큼 데이터를 응답한다.")
-	void givenValidHotSkillList_whenFindList_thenReturnCorrectHotSkillList() {
-		// given
-		var hotSkillList = Collections.singletonList(new SkillInfo.FindHotSkill(1L, "hotSkill_keyword"));
+    @Test
+    @DisplayName("1: getHotSkillList 메서드가 존재하는 HotSkill 개수 만큼 데이터를 응답한다.")
+    void givenValidHotSkillList_whenFindList_thenReturnCorrectHotSkillList() {
+        // given
+        final var mockHotSkillList = Collections.singletonList(mock(SkillInfo.FindHotSkill.class));
+        given(skillReader.findHotSkillList()).willReturn(mockHotSkillList);
 
-		// when
-		when(skillReader.findHotSkillList()).thenReturn(hotSkillList);
-		var response = skillServiceImpl.getHotSkillList();
+        // when
+        final var response = skillServiceImpl.getHotSkillList();
 
-		// then
-		assertThat(response.getSkillList()).hasSize(1);
-		verify(skillReader, times(1)).findHotSkillList();
-	}
+        // then
+        assertThat(response.getSkillList()).hasSize(1);
+        then(skillReader).should(times(1)).findHotSkillList();
+    }
 
-	@Test
-	@DisplayName("2: getMemberSkillList 메서드가 존재하는 memberSkill 개수 만큼 데이터를 응답한다.")
-	void givenValidMemberSkillList_whenFindList_thenReturnCorrectHotSkillList() {
-		// given
-		var memberSkillList = Arrays.asList(
-			new SkillInfo.FindMemberSkill(1L, "member_skill_keyword_1"),
-			new SkillInfo.FindMemberSkill(2L, "member_skill_keyword_2"),
-			new SkillInfo.FindMemberSkill(3L, "member_skill_keyword_3"));
-		Long memberId = 1L;
+    @Test
+    @DisplayName("2: getMemberSkillList 메서드가 존재하는 memberSkill 개수 만큼 데이터를 응답한다.")
+    void givenValidMemberSkillList_whenFindList_thenReturnCorrectHotSkillList() {
+        // given
+        final var memberSkillList = Arrays.asList(
+            mock(SkillInfo.FindMemberSkill.class),
+            mock(SkillInfo.FindMemberSkill.class),
+            mock(SkillInfo.FindMemberSkill.class)
+        );
+        final var memberId = 1L;
+        given(skillReader.findMemberSkillList(memberId)).willReturn(memberSkillList);
 
-		// when
-		when(skillReader.findMemberSkillList(memberId)).thenReturn(memberSkillList);
-		var response = skillServiceImpl.getMemberSkillList(memberId);
+        // when
+        final var response = skillServiceImpl.getMemberSkillList(memberId);
 
-		// then
-		assertThat(response.getSkillList()).hasSize(3);
-		verify(skillReader, times(1)).findMemberSkillList(memberId);
-	}
+        // then
+        assertThat(response.getSkillList()).hasSize(3);
+        then(skillReader).should(times(1)).findMemberSkillList(memberId);
+    }
 
-	@Test
-	@DisplayName("3: 올바른 직군 ID가 주어졌을 때 getJobCategorySkillList 메서드가 직군별 기술스택에서 '기타' 키워드를 제외한 데이터 개수 만큼 데이터를 응답한다.")
-	void givenValidJobCategoryId_whenFindList_thenReturnCorrectJobCategorySkillList() throws Exception {
-		//given
-		String filePath = "giventest/skill/serviceimpl/3_jobCategorySkillList.json";
-		JobCategory jobCategory = JsonFileReader.readJsonFileToObject(filePath, JobCategory.class);
-		final Long jobCategoryId = 1L;
+    @Test
+    @DisplayName("3: 올바른 직군 ID가 주어졌을 때 getJobCategorySkillList 메서드가 직군별 기술스택에서 '기타' 키워드를 제외한 데이터 개수 만큼 데이터를 응답한다.")
+    void givenValidJobCategoryId_whenFindList_thenReturnCorrectJobCategorySkillList() throws Exception {
+        //given
+        final var filePath = "giventest/skill/serviceimpl/3_jobCategorySkillList.json";
+        final var jobCategory = JsonFileReader.readJsonFileToObject(filePath, JobCategory.class);
+        final var jobCategoryId = 1L;
+        given(jobCategoryReader.findById(jobCategoryId)).willReturn(jobCategory);
 
-		//when
-		when(jobCategoryReader.findById(jobCategoryId)).thenReturn(jobCategory);
-		var response = skillServiceImpl.getJobCategorySkillList(jobCategoryId);
+        //when
+        final var response = skillServiceImpl.getJobCategorySkillList(jobCategoryId);
 
-		//then
-		assertThat(response.getSkillList()).hasSize(2);
-		verify(jobCategoryReader, times(1)).findById(jobCategoryId);
-	}
+        //then
+        assertThat(response.getSkillList()).hasSize(2);
+        then(jobCategoryReader).should(times(1)).findById(jobCategoryId);
+    }
 
-	@ParameterizedTest
-	@NullSource
-	@ValueSource(strings = {""})
-	@DisplayName("4: keyword가 존재하지 않을 때 getDataListBySkill 메서드가 인기있는 keyword 기반으로 데이터를 응답한다.")
-	void givenEmptyKeyword_whenFindList_thenReturnCorrectDataListByHotSkill(final String keyword) throws
-		Exception {
-		//given
-		final String hotSkillKeyword = "hotSkill_keyword";
-		final var hotSkillList = Collections.singletonList(new SkillInfo.FindHotSkill(1L, hotSkillKeyword));
-		final Long memberId = 1L;
+    @ParameterizedTest
+    @NullSource
+    @ValueSource(strings = {""})
+    @DisplayName("4: keyword가 존재하지 않을 때 getDataListBySkill 메서드가 인기있는 keyword 기반으로 데이터를 응답한다.")
+    void givenEmptyKeyword_whenFindList_thenReturnCorrectDataListByHotSkill(final String keyword) throws
+        Exception {
+        //given
+        final var hotSkillKeyword = "hotSkill_keyword";
+        final var hotSkillList = Collections.singletonList(new SkillInfo.FindHotSkill(1L, hotSkillKeyword));
+        final var memberId = 1L;
+        given(skillReader.findHotSkillList()).willReturn(hotSkillList);
+        given(wantedJdSkillReader.findWantedJdListBySkill(hotSkillKeyword)).willReturn(null);
+        given(inflearnJdSkillReader.findInflearnLectureListBySkill(hotSkillKeyword, memberId)).willReturn(null);
 
-		//when
-		when(wantedJdSkillReader.findWantedJdListBySkill(hotSkillKeyword)).thenReturn(null);
-		when(inflearnJdSkillReader.findInflearnLectureListBySkill(hotSkillKeyword, memberId)).thenReturn(null);
-		when(skillReader.findHotSkillList()).thenReturn(hotSkillList);
-		var response = skillServiceImpl.getDataListBySkill(keyword, memberId);
+        //when
+        final var response = skillServiceImpl.getDataListBySkill(keyword, memberId);
 
-		//then
-		assertThat(response.getKeyword()).isEqualTo(hotSkillKeyword);
-		verify(wantedJdSkillReader, times(1)).findWantedJdListBySkill(hotSkillKeyword);
-		verify(inflearnJdSkillReader, times(1)).findInflearnLectureListBySkill(hotSkillKeyword, memberId);
-	}
+        //then
+        assertThat(response.getKeyword()).isEqualTo(hotSkillKeyword);
+        then(wantedJdSkillReader).should(times(1)).findWantedJdListBySkill(hotSkillKeyword);
+        then(inflearnJdSkillReader).should(times(1)).findInflearnLectureListBySkill(hotSkillKeyword, memberId);
+    }
 }


### PR DESCRIPTION
## 개요

### 요약
Skill 도메인의 테스트코드를 리팩토링 했습니다.

### 변경한 부분
- BDDMockito를 통해 검증하도록 수정했습니다.
- 테스트 코드 변수 반환 타입을 var 키워드로 변경했습니다.
- 읽기전용 변수에 final 키워드를 추가 했습니다.
- 실 객체가 아닌 mock 객체로로 검증하도록 검증방식을 변경했습니다.

### 변경한 결과
테스트 정상 동작 확인했습니다.
![image](https://github.com/Kernel360/f1-JDON-Backend/assets/59242594/fce1e52b-1e7e-4ad6-b675-f35b3954d995)


### 이슈

- closes: #427 

---

## PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경, 주석 변경)
- [ ] 코드 리팩토링
- [ ] 문서 수정
- [x] 테스트 추가, 테스트 리팩토링
- [ ] 파일 혹은 폴더명 수정, 삭제
- [ ] 배포 관련