### PR TITLE
Fix: OAuth2 인증 과정 중 발생할 수 있는 에러 추가

### DIFF
--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/auth/core/CustomOAuth2UserServiceImpl.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/auth/core/CustomOAuth2UserServiceImpl.java
@@ -1,6 +1,7 @@
 package kernel.jdon.moduleapi.domain.auth.core;
 
 import java.util.List;
+import java.util.Objects;
 
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
@@ -12,15 +13,16 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import jakarta.servlet.http.HttpSession;
-import kernel.jdon.moduledomain.member.domain.Member;
-import kernel.jdon.moduledomain.member.domain.MemberRole;
-import kernel.jdon.moduledomain.member.domain.SocialProviderType;
 import kernel.jdon.moduleapi.domain.auth.error.AuthErrorCode;
 import kernel.jdon.moduleapi.domain.member.core.MemberCommand;
 import kernel.jdon.moduleapi.domain.member.core.MemberReader;
 import kernel.jdon.moduleapi.domain.member.core.MemberStore;
 import kernel.jdon.moduleapi.global.dto.SessionUserInfo;
 import kernel.jdon.moduleapi.global.exception.AuthException;
+import kernel.jdon.modulecommon.error.ErrorCode;
+import kernel.jdon.moduledomain.member.domain.Member;
+import kernel.jdon.moduledomain.member.domain.MemberRole;
+import kernel.jdon.moduledomain.member.domain.SocialProviderType;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -29,58 +31,73 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 @RequiredArgsConstructor
 public class CustomOAuth2UserServiceImpl extends DefaultOAuth2UserService implements CustomOAuth2UserService {
-	private final HttpSession httpSession;
-	private final MemberReader memberReader;
-	private final MemberStore memberStore;
-	private final OAuth2ProviderComposite oauth2ProviderComposite;
+    private final HttpSession httpSession;
+    private final MemberReader memberReader;
+    private final MemberStore memberStore;
+    private final OAuth2ProviderComposite oauth2ProviderComposite;
 
-	@Override
-	@Transactional
-	public OAuth2User loadUser(final OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
-		final OAuth2User user = super.loadUser(userRequest);
+    @Override
+    @Transactional
+    public OAuth2User loadUser(final OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+        final OAuth2User user = super.loadUser(userRequest);
 
-		return getOAuth2User(userRequest, user);
-	}
+        return getOAuth2User(userRequest, user);
+    }
 
-	private DefaultOAuth2User getOAuth2User(final OAuth2UserRequest userRequest, final OAuth2User user) {
-		final SessionUserInfo userInfo = oauth2ProviderComposite.getOAuth2Strategy(getSocialProvider(userRequest))
-			.getUserInfo(user);
-		final Member findMember = memberReader.findByEmail(userInfo.getEmail());
-		final List<SimpleGrantedAuthority> authorities = getAuthorities(userInfo, findMember);
+    private DefaultOAuth2User getOAuth2User(final OAuth2UserRequest userRequest, final OAuth2User user) {
+        final SessionUserInfo userInfo = oauth2ProviderComposite.getOAuth2Strategy(getSocialProvider(userRequest))
+            .getUserInfo(user);
+        final Member findMember = memberReader.findByEmail(userInfo.getEmail());
+        final List<SimpleGrantedAuthority> authorities = getAuthorities(userInfo, findMember);
 
-		return new JdonOAuth2User(authorities, user.getAttributes(), getUserNameAttributeName(userRequest),
-			userInfo.getEmail(), userInfo.getSocialProvider());
-	}
+        return new JdonOAuth2User(authorities, user.getAttributes(), getUserNameAttributeName(userRequest),
+            userInfo.getEmail(), userInfo.getSocialProvider());
+    }
 
-	private List<SimpleGrantedAuthority> getAuthorities(final SessionUserInfo userInfo, final Member member) {
-		if (member != null && member.isActiveMember()) {
-			checkRightSocialProvider(member, userInfo.getSocialProvider());
-			httpSession.setAttribute("USER", userInfo.getMemberSession(member));
-			memberStore.updateLastLoginDate(member);
-			return List.of(new SimpleGrantedAuthority(MemberRole.ROLE_USER.name()));
-		} else {
-			return List.of(new SimpleGrantedAuthority(MemberRole.ROLE_GUEST.name()));
-		}
-	}
+    private List<SimpleGrantedAuthority> getAuthorities(final SessionUserInfo userInfo, final Member member) {
+        if (Objects.nonNull(member)) {
+            checkAccountStatusActive(userInfo, member);
+            checkRightSocialProvider(member, userInfo.getSocialProvider(),
+                AuthErrorCode.UNAUTHORIZED_NOT_MATCH_PROVIDER_TYPE);
+            updateMemberLoginData(userInfo, member);
+            return List.of(new SimpleGrantedAuthority(MemberRole.ROLE_USER.name()));
+        }
+        return List.of(new SimpleGrantedAuthority(MemberRole.ROLE_GUEST.name()));
+    }
 
-	private void checkRightSocialProvider(final Member member, final SocialProviderType socialProvider) {
-		if (!member.isRightSocialProvider(socialProvider))
-			throw new AuthException(AuthErrorCode.UNAUTHORIZED_NOT_MATCH_PROVIDER_TYPE);
-	}
+    private void updateMemberLoginData(final SessionUserInfo userInfo, final Member member) {
+        httpSession.setAttribute("USER", userInfo.getMemberSession(member));
+        memberStore.updateLastLoginDate(member);
+    }
 
-	private SocialProviderType getSocialProvider(final OAuth2UserRequest userRequest) {
-		return SocialProviderType.valueOf((userRequest.getClientRegistration().getRegistrationId()).toUpperCase());
-	}
+    private void checkAccountStatusActive(final SessionUserInfo userInfo, final Member member) {
+        if (member.isWithDrawMember()) {
+            checkRightSocialProvider(member, userInfo.getSocialProvider(),
+                AuthErrorCode.CONFLICT_WITHDRAW_BY_OTHER_SOCIAL_PROVIDER);
+            throw new AuthException(AuthErrorCode.CONFLICT_WITHDRAW_ACCOUNT);
+        }
+    }
 
-	private String getUserNameAttributeName(final OAuth2UserRequest userRequest) {
-		return userRequest.getClientRegistration()
-			.getProviderDetails()
-			.getUserInfoEndpoint()
-			.getUserNameAttributeName();
-	}
+    private void checkRightSocialProvider(final Member member, final SocialProviderType socialProvider,
+        final ErrorCode errorCode) {
+        if (!member.isRightSocialProvider(socialProvider)) {
+            throw new AuthException(errorCode);
+        }
+    }
 
-	@Override
-	public boolean sendDeleteRequestToOAuth2(final MemberCommand.WithdrawRequest command) {
-		return oauth2ProviderComposite.getOAuth2Strategy(command.getSocialProvider()).unlinkOAuth2Account(command);
-	}
+    private SocialProviderType getSocialProvider(final OAuth2UserRequest userRequest) {
+        return SocialProviderType.valueOf((userRequest.getClientRegistration().getRegistrationId()).toUpperCase());
+    }
+
+    private String getUserNameAttributeName(final OAuth2UserRequest userRequest) {
+        return userRequest.getClientRegistration()
+            .getProviderDetails()
+            .getUserInfoEndpoint()
+            .getUserNameAttributeName();
+    }
+
+    @Override
+    public boolean sendDeleteRequestToOAuth2(final MemberCommand.WithdrawRequest command) {
+        return oauth2ProviderComposite.getOAuth2Strategy(command.getSocialProvider()).unlinkOAuth2Account(command);
+    }
 }

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/auth/core/CustomOAuth2UserServiceImpl.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/auth/core/CustomOAuth2UserServiceImpl.java
@@ -56,9 +56,7 @@ public class CustomOAuth2UserServiceImpl extends DefaultOAuth2UserService implem
 
     private List<SimpleGrantedAuthority> getAuthorities(final SessionUserInfo userInfo, final Member member) {
         if (Objects.nonNull(member)) {
-            checkAccountStatusActive(userInfo, member);
-            checkRightSocialProvider(member, userInfo.getSocialProvider(),
-                AuthErrorCode.UNAUTHORIZED_NOT_MATCH_PROVIDER_TYPE);
+            validateLoginMember(userInfo, member);
             updateMemberLoginData(userInfo, member);
             return List.of(new SimpleGrantedAuthority(MemberRole.ROLE_USER.name()));
         }
@@ -70,12 +68,14 @@ public class CustomOAuth2UserServiceImpl extends DefaultOAuth2UserService implem
         memberStore.updateLastLoginDate(member);
     }
 
-    private void checkAccountStatusActive(final SessionUserInfo userInfo, final Member member) {
+    private void validateLoginMember(final SessionUserInfo userInfo, final Member member) {
         if (member.isWithDrawMember()) {
             checkRightSocialProvider(member, userInfo.getSocialProvider(),
                 AuthErrorCode.CONFLICT_WITHDRAW_BY_OTHER_SOCIAL_PROVIDER);
             throw new AuthException(AuthErrorCode.CONFLICT_WITHDRAW_ACCOUNT);
         }
+        checkRightSocialProvider(member, userInfo.getSocialProvider(),
+            AuthErrorCode.UNAUTHORIZED_NOT_MATCH_PROVIDER_TYPE);
     }
 
     private void checkRightSocialProvider(final Member member, final SocialProviderType socialProvider,

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/auth/error/AuthErrorCode.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/auth/error/AuthErrorCode.java
@@ -9,35 +9,36 @@ import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
 public enum AuthErrorCode implements ErrorCode, BaseThrowException<AuthErrorCode.AuthBaseException> {
-	UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "인증되지 않은 사용자입니다."),
-	UNAUTHORIZED_NOT_MATCH_PROVIDER_TYPE(HttpStatus.UNAUTHORIZED, "다른 소셜 로그인으로 가입된 이메일입니다."),
-	UNAUTHORIZED_OAUTH_RETURN_NULL_EMAIL(HttpStatus.UNAUTHORIZED, "소셜 서비스에 이메일을 등록해야 서비스를 이용할 수 있습니다."),
-	FORBIDDEN(HttpStatus.FORBIDDEN, "권한이 없는 사용자입니다."),
-	ERROR_FAIL_TO_UNLINK_OAUTH2(HttpStatus.INTERNAL_SERVER_ERROR, "외부 API 통신 중 에러가 발생했습니다."),
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "인증되지 않은 사용자입니다."),
+    UNAUTHORIZED_NOT_MATCH_PROVIDER_TYPE(HttpStatus.UNAUTHORIZED, "다른 소셜 로그인으로 가입된 이메일입니다."),
+    UNAUTHORIZED_OAUTH_RETURN_NULL_EMAIL(HttpStatus.UNAUTHORIZED, "소셜 서비스에 이메일을 등록해야 서비스를 이용할 수 있습니다."),
+    FORBIDDEN(HttpStatus.FORBIDDEN, "권한이 없는 사용자입니다."),
+    ERROR_FAIL_TO_UNLINK_OAUTH2(HttpStatus.INTERNAL_SERVER_ERROR, "외부 API 통신 중 에러가 발생했습니다."),
+    NOT_FOUND_PROVIDER(HttpStatus.NOT_FOUND, "지원되지 않는 소셜 로그인입니다."),
+    CONFLICT_WITHDRAW_BY_OTHER_SOCIAL_PROVIDER(HttpStatus.CONFLICT, "다른 소셜 로그인으로 탈퇴한 내역이 존재합니다."),
+    CONFLICT_WITHDRAW_ACCOUNT(HttpStatus.CONFLICT, "탈퇴한 계정입니다.");
 
-	NOT_FOUND_PROVIDER(HttpStatus.NOT_FOUND, "지원되지 않는 소셜 로그인입니다.");
+    private final HttpStatus httpStatus;
+    private final String message;
 
-	private final HttpStatus httpStatus;
-	private final String message;
+    @Override
+    public HttpStatus getHttpStatus() {
+        return httpStatus;
+    }
 
-	@Override
-	public HttpStatus getHttpStatus() {
-		return httpStatus;
-	}
+    @Override
+    public String getMessage() {
+        return message;
+    }
 
-	@Override
-	public String getMessage() {
-		return message;
-	}
+    @Override
+    public AuthErrorCode.AuthBaseException throwException() {
+        return new AuthErrorCode.AuthBaseException(this);
+    }
 
-	@Override
-	public AuthErrorCode.AuthBaseException throwException() {
-		return new AuthErrorCode.AuthBaseException(this);
-	}
-
-	public class AuthBaseException extends ApiException {
-		public AuthBaseException(AuthErrorCode authErrorCode) {
-			super(authErrorCode);
-		}
-	}
+    public class AuthBaseException extends ApiException {
+        public AuthBaseException(AuthErrorCode authErrorCode) {
+            super(authErrorCode);
+        }
+    }
 }

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/member/error/MemberErrorCode.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/member/error/MemberErrorCode.java
@@ -9,35 +9,35 @@ import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
 public enum MemberErrorCode implements ErrorCode,
-	BaseThrowException<MemberErrorCode.MemberBaseException> {
-	UNAUTHORIZED_EMAIL_OAUTH2(HttpStatus.UNAUTHORIZED, "이메일 인증에 실패하였습니다."),
-	BAD_REQUEST_INVALID_ENCRYPT_STRING(HttpStatus.BAD_REQUEST, "잘못된 암호값입니다."),
-	BAD_REQUEST_FAIL_PARSE_QUERY_STRING(HttpStatus.BAD_REQUEST, "쿼리스트링 파싱에 실패하였습니다."),
-	NOT_FOUND_MEMBER(HttpStatus.NOT_FOUND, "존재하지 않는 회원입니다."),
-	CONFLICT_DUPLICATE_NICKNAME(HttpStatus.CONFLICT, "이미 존재하는 닉네임입니다."),
-	FORBIDDEN_NOT_MATCH_EMAIL(HttpStatus.FORBIDDEN, "이메일이 일치하지 않습니다.");
+    BaseThrowException<MemberErrorCode.MemberBaseException> {
+    UNAUTHORIZED_EMAIL_OAUTH2(HttpStatus.UNAUTHORIZED, "이메일 인증에 실패하였습니다."),
+    BAD_REQUEST_INVALID_ENCRYPT_STRING(HttpStatus.BAD_REQUEST, "잘못된 암호값입니다."),
+    BAD_REQUEST_FAIL_PARSE_QUERY_STRING(HttpStatus.BAD_REQUEST, "쿼리스트링 파싱에 실패하였습니다."),
+    NOT_FOUND_MEMBER(HttpStatus.NOT_FOUND, "존재하지 않는 회원입니다."),
+    CONFLICT_DUPLICATE_NICKNAME(HttpStatus.CONFLICT, "이미 존재하는 닉네임입니다."),
+    FORBIDDEN_NOT_MATCH_EMAIL(HttpStatus.FORBIDDEN, "이메일이 일치하지 않습니다.");
 
-	private final HttpStatus httpStatus;
-	private final String message;
+    private final HttpStatus httpStatus;
+    private final String message;
 
-	@Override
-	public HttpStatus getHttpStatus() {
-		return httpStatus;
-	}
+    @Override
+    public HttpStatus getHttpStatus() {
+        return httpStatus;
+    }
 
-	@Override
-	public String getMessage() {
-		return message;
-	}
+    @Override
+    public String getMessage() {
+        return message;
+    }
 
-	@Override
-	public MemberErrorCode.MemberBaseException throwException() {
-		return new MemberErrorCode.MemberBaseException(this);
-	}
+    @Override
+    public MemberErrorCode.MemberBaseException throwException() {
+        return new MemberErrorCode.MemberBaseException(this);
+    }
 
-	public class MemberBaseException extends ApiException {
-		public MemberBaseException(MemberErrorCode memberErrorCode) {
-			super(memberErrorCode);
-		}
-	}
+    public class MemberBaseException extends ApiException {
+        public MemberBaseException(MemberErrorCode memberErrorCode) {
+            super(memberErrorCode);
+        }
+    }
 }

--- a/module-api/src/main/java/kernel/jdon/moduleapi/global/config/auth/JdonAuthExceptionHandler.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/global/config/auth/JdonAuthExceptionHandler.java
@@ -51,8 +51,13 @@ public class JdonAuthExceptionHandler
             response.sendRedirect(loginRedirectUrlProperties.getFailureNotMatchProvider());
             return;
         }
-        resolver.resolveException(request, response, null,
-            new AuthException(((AuthException)exception).getErrorCode()));
+        if (AuthErrorCode.CONFLICT_WITHDRAW_BY_OTHER_SOCIAL_PROVIDER == ((AuthException)exception).getErrorCode()) {
+            response.sendRedirect(loginRedirectUrlProperties.getFailureAnotherWithdrawAccount());
+            return;
+        }
+        if (AuthErrorCode.CONFLICT_WITHDRAW_ACCOUNT == ((AuthException)exception).getErrorCode()) {
+            response.sendRedirect(loginRedirectUrlProperties.getFailureAlreadyWithdrawAccount());
+        }
     }
 
 }

--- a/module-api/src/main/java/kernel/jdon/moduleapi/global/config/auth/JdonAuthExceptionHandler.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/global/config/auth/JdonAuthExceptionHandler.java
@@ -18,36 +18,41 @@ import kernel.jdon.moduleapi.global.exception.AuthException;
 
 @Component
 public class JdonAuthExceptionHandler
-	implements AuthenticationEntryPoint, AccessDeniedHandler, AuthenticationFailureHandler {
-	private final HandlerExceptionResolver resolver;
-	private final LoginRedirectUrlProperties loginRedirectUrlProperties;
+    implements AuthenticationEntryPoint, AccessDeniedHandler, AuthenticationFailureHandler {
+    private final HandlerExceptionResolver resolver;
+    private final LoginRedirectUrlProperties loginRedirectUrlProperties;
 
-	public JdonAuthExceptionHandler(@Qualifier("handlerExceptionResolver") HandlerExceptionResolver resolver,
-		LoginRedirectUrlProperties loginRedirectUrlProperties) {
-		this.resolver = resolver;
-		this.loginRedirectUrlProperties = loginRedirectUrlProperties;
-	}
+    public JdonAuthExceptionHandler(@Qualifier("handlerExceptionResolver") HandlerExceptionResolver resolver,
+        LoginRedirectUrlProperties loginRedirectUrlProperties) {
+        this.resolver = resolver;
+        this.loginRedirectUrlProperties = loginRedirectUrlProperties;
+    }
 
-	@Override
-	public void commence(HttpServletRequest request, HttpServletResponse response,
-		AuthenticationException authException) {
-		resolver.resolveException(request, response, null, new AuthException(AuthErrorCode.UNAUTHORIZED));
-	}
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response,
+        AuthenticationException authException) {
+        resolver.resolveException(request, response, null, new AuthException(AuthErrorCode.UNAUTHORIZED));
+    }
 
-	@Override
-	public void handle(HttpServletRequest request, HttpServletResponse response,
-		AccessDeniedException accessDeniedException) {
-		resolver.resolveException(request, response, null, new AuthException(AuthErrorCode.FORBIDDEN));
-	}
+    @Override
+    public void handle(HttpServletRequest request, HttpServletResponse response,
+        AccessDeniedException accessDeniedException) {
+        resolver.resolveException(request, response, null, new AuthException(AuthErrorCode.FORBIDDEN));
+    }
 
-	@Override
-	public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response,
-		AuthenticationException exception) throws IOException {
-		if (AuthErrorCode.UNAUTHORIZED_OAUTH_RETURN_NULL_EMAIL == ((AuthException)exception).getErrorCode()) {
-			response.sendRedirect(loginRedirectUrlProperties.getFailureNotFoundEmail());
-		}
-		if (AuthErrorCode.UNAUTHORIZED_NOT_MATCH_PROVIDER_TYPE == ((AuthException)exception).getErrorCode()) {
-			response.sendRedirect(loginRedirectUrlProperties.getFailureNotMatchProvider());
-		}
-	}
+    @Override
+    public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response,
+        AuthenticationException exception) throws IOException {
+        if (AuthErrorCode.UNAUTHORIZED_OAUTH_RETURN_NULL_EMAIL == ((AuthException)exception).getErrorCode()) {
+            response.sendRedirect(loginRedirectUrlProperties.getFailureNotFoundEmail());
+            return;
+        }
+        if (AuthErrorCode.UNAUTHORIZED_NOT_MATCH_PROVIDER_TYPE == ((AuthException)exception).getErrorCode()) {
+            response.sendRedirect(loginRedirectUrlProperties.getFailureNotMatchProvider());
+            return;
+        }
+        resolver.resolveException(request, response, null,
+            new AuthException(((AuthException)exception).getErrorCode()));
+    }
+
 }

--- a/module-api/src/main/java/kernel/jdon/moduleapi/global/config/auth/JdonAuthExceptionHandler.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/global/config/auth/JdonAuthExceptionHandler.java
@@ -43,21 +43,19 @@ public class JdonAuthExceptionHandler
     @Override
     public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response,
         AuthenticationException exception) throws IOException {
+        String redirectUrl = null;
         if (AuthErrorCode.UNAUTHORIZED_OAUTH_RETURN_NULL_EMAIL == ((AuthException)exception).getErrorCode()) {
-            response.sendRedirect(loginRedirectUrlProperties.getFailureNotFoundEmail());
-            return;
+            redirectUrl = loginRedirectUrlProperties.getFailureNotFoundEmail();
         }
         if (AuthErrorCode.UNAUTHORIZED_NOT_MATCH_PROVIDER_TYPE == ((AuthException)exception).getErrorCode()) {
-            response.sendRedirect(loginRedirectUrlProperties.getFailureNotMatchProvider());
-            return;
+            redirectUrl = loginRedirectUrlProperties.getFailureNotMatchProvider();
         }
         if (AuthErrorCode.CONFLICT_WITHDRAW_BY_OTHER_SOCIAL_PROVIDER == ((AuthException)exception).getErrorCode()) {
-            response.sendRedirect(loginRedirectUrlProperties.getFailureAnotherWithdrawAccount());
-            return;
+            redirectUrl = loginRedirectUrlProperties.getFailureAnotherWithdrawAccount();
         }
         if (AuthErrorCode.CONFLICT_WITHDRAW_ACCOUNT == ((AuthException)exception).getErrorCode()) {
-            response.sendRedirect(loginRedirectUrlProperties.getFailureAlreadyWithdrawAccount());
+            redirectUrl = loginRedirectUrlProperties.getFailureAlreadyWithdrawAccount();
         }
+        response.sendRedirect(redirectUrl);
     }
-
 }

--- a/module-api/src/main/java/kernel/jdon/moduleapi/global/config/auth/LoginRedirectUrlProperties.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/global/config/auth/LoginRedirectUrlProperties.java
@@ -28,6 +28,14 @@ public class LoginRedirectUrlProperties {
         return this.failure.getNotMatchProvider();
     }
 
+    public String getFailureAnotherWithdrawAccount() {
+        return this.failure.getAnotherWithdrawAccount();
+    }
+
+    public String getFailureAlreadyWithdrawAccount() {
+        return this.failure.getAlreadyWithdrawAccount();
+    }
+
     @Getter
     @RequiredArgsConstructor
     public static class Success {
@@ -40,5 +48,7 @@ public class LoginRedirectUrlProperties {
     public static class Failure {
         private final String notFoundEmail;
         private final String notMatchProvider;
+        private final String anotherWithdrawAccount;
+        private final String alreadyWithdrawAccount;
     }
 }

--- a/module-api/src/main/java/kernel/jdon/moduleapi/global/config/auth/LoginRedirectUrlProperties.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/global/config/auth/LoginRedirectUrlProperties.java
@@ -9,36 +9,36 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 @ConfigurationProperties(prefix = "redirect-url.login")
 public class LoginRedirectUrlProperties {
-	private final Success success;
-	private final Failure failure;
+    private final Success success;
+    private final Failure failure;
 
-	public String getSuccessMember() {
-		return this.success.getMember();
-	}
+    public String getSuccessMember() {
+        return this.success.getMember();
+    }
 
-	public String getSuccessGuest() {
-		return this.success.getGuest();
-	}
+    public String getSuccessGuest() {
+        return this.success.getGuest();
+    }
 
-	public String getFailureNotFoundEmail() {
-		return this.failure.getNotFoundEmail();
-	}
+    public String getFailureNotFoundEmail() {
+        return this.failure.getNotFoundEmail();
+    }
 
-	public String getFailureNotMatchProvider() {
-		return this.failure.getNotMatchProvider();
-	}
+    public String getFailureNotMatchProvider() {
+        return this.failure.getNotMatchProvider();
+    }
 
-	@Getter
-	@RequiredArgsConstructor
-	public static class Success {
-		private final String member;
-		private final String guest;
-	}
+    @Getter
+    @RequiredArgsConstructor
+    public static class Success {
+        private final String member;
+        private final String guest;
+    }
 
-	@Getter
-	@RequiredArgsConstructor
-	public static class Failure {
-		private final String notFoundEmail;
-		private final String notMatchProvider;
-	}
+    @Getter
+    @RequiredArgsConstructor
+    public static class Failure {
+        private final String notFoundEmail;
+        private final String notMatchProvider;
+    }
 }

--- a/module-api/src/main/resources/application-dev.yml
+++ b/module-api/src/main/resources/application-dev.yml
@@ -86,6 +86,8 @@ redirect-url:
     failure:
       not-found-email: https://localhost:3000/oauth/login/fail/not-found-email
       not-match-provider: https://localhost:3000/oauth/login/fail/not-match-provider
+      another-withdraw-account: https://localhost:3000/oauth/login/fail/another-withdraw-account
+      already-withdraw-account: https://localhost:3000/oauth/login/fail/already-withdraw-account
 
 redis:
   lock:

--- a/module-api/src/main/resources/application-local.yml
+++ b/module-api/src/main/resources/application-local.yml
@@ -81,6 +81,8 @@ redirect-url:
     failure:
       not-found-email: http://localhost:3000/oauth/login/fail/not-found-email
       not-match-provider: http://localhost:3000/oauth/login/fail/not-match-provider
+      another-withdraw-account: http://localhost:3000/oauth/login/fail/another-withdraw-account
+      already-withdraw-account: http://localhost:3000/oauth/login/fail/already-withdraw-account
 
 redis:
   lock:

--- a/module-api/src/main/resources/application-prod.yml
+++ b/module-api/src/main/resources/application-prod.yml
@@ -85,7 +85,8 @@ redirect-url:
     failure:
       not-found-email: https://jdon.kr/oauth/login/fail/not-found-email
       not-match-provider: https://jdon.kr/oauth/login/fail/not-match-provider
-
+      another-withdraw-account: https://jdon.kr/oauth/login/fail/another-withdraw-account
+      already-withdraw-account: https://jdon.kr/oauth/login/fail/already-withdraw-account
 
 redis:
   lock:

--- a/module-domain/src/main/java/kernel/jdon/moduledomain/member/domain/Member.java
+++ b/module-domain/src/main/java/kernel/jdon/moduledomain/member/domain/Member.java
@@ -21,9 +21,9 @@ import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import kernel.jdon.moduledomain.coffeechat.domain.CoffeeChat;
 import kernel.jdon.moduledomain.coffeechatmember.domain.CoffeeChatMember;
+import kernel.jdon.moduledomain.favorite.domain.Favorite;
 import kernel.jdon.moduledomain.jobcategory.domain.JobCategory;
 import kernel.jdon.moduledomain.memberskill.domain.MemberSkill;
-import kernel.jdon.moduledomain.favorite.domain.Favorite;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -35,112 +35,117 @@ import lombok.NoArgsConstructor;
 @Table(name = "member")
 public class Member {
 
-	@OneToMany(mappedBy = "member")
-	private List<CoffeeChat> hostChatList = new ArrayList<>();
+    @OneToMany(mappedBy = "member")
+    private List<CoffeeChat> hostChatList = new ArrayList<>();
 
-	@OneToMany(mappedBy = "member")
-	private List<CoffeeChatMember> guestChatList = new ArrayList<>();
+    @OneToMany(mappedBy = "member")
+    private List<CoffeeChatMember> guestChatList = new ArrayList<>();
 
-	@OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
-	private List<MemberSkill> memberSkillList = new ArrayList<>();
+    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<MemberSkill> memberSkillList = new ArrayList<>();
 
-	@OneToMany(mappedBy = "member")
-	private List<Favorite> favoriteList = new ArrayList<>();
+    @OneToMany(mappedBy = "member")
+    private List<Favorite> favoriteList = new ArrayList<>();
 
-	@Id
-	@GeneratedValue(strategy = GenerationType.IDENTITY)
-	private Long id;
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
 
-	@Column(name = "email", columnDefinition = "VARCHAR(255)", nullable = false, unique = true)
-	private String email;
+    @Column(name = "email", columnDefinition = "VARCHAR(255)", nullable = false, unique = true)
+    private String email;
 
-	@Column(name = "nickname", columnDefinition = "VARCHAR(255)", nullable = false, unique = true)
-	private String nickname;
+    @Column(name = "nickname", columnDefinition = "VARCHAR(255)", nullable = false, unique = true)
+    private String nickname;
 
-	@Column(name = "birth", columnDefinition = "VARCHAR(11)", nullable = false)
-	private String birth;
+    @Column(name = "birth", columnDefinition = "VARCHAR(11)", nullable = false)
+    private String birth;
 
-	@Enumerated(EnumType.STRING)
-	@Column(name = "gender", columnDefinition = "VARCHAR(11)", nullable = false)
-	private Gender gender;
+    @Enumerated(EnumType.STRING)
+    @Column(name = "gender", columnDefinition = "VARCHAR(11)", nullable = false)
+    private Gender gender;
 
-	@CreatedDate
-	@Column(name = "join_date", columnDefinition = "DATETIME", nullable = false)
-	private LocalDateTime joinDate;
+    @CreatedDate
+    @Column(name = "join_date", columnDefinition = "DATETIME", nullable = false)
+    private LocalDateTime joinDate;
 
-	@Column(name = "last_login_date", columnDefinition = "DATETIME")
-	private LocalDateTime lastLoginDate;
+    @Column(name = "last_login_date", columnDefinition = "DATETIME")
+    private LocalDateTime lastLoginDate;
 
-	@Enumerated(EnumType.STRING)
-	@Column(name = "role", columnDefinition = "VARCHAR(10)", nullable = false)
-	private MemberRole role;
+    @Enumerated(EnumType.STRING)
+    @Column(name = "role", columnDefinition = "VARCHAR(10)", nullable = false)
+    private MemberRole role;
 
-	@Enumerated(EnumType.STRING)
-	@Column(name = "account_status", columnDefinition = "VARCHAR(10)", nullable = false)
-	private MemberAccountStatus accountStatus;
+    @Enumerated(EnumType.STRING)
+    @Column(name = "account_status", columnDefinition = "VARCHAR(10)", nullable = false)
+    private MemberAccountStatus accountStatus;
 
-	@Column(name = "withdraw_date", columnDefinition = "DATETIME")
-	private LocalDateTime withdrawDate;
+    @Column(name = "withdraw_date", columnDefinition = "DATETIME")
+    private LocalDateTime withdrawDate;
 
-	@Enumerated(EnumType.STRING)
-	@Column(name = "social_provider", columnDefinition = "VARCHAR(20)", nullable = false)
-	private SocialProviderType socialProvider;
+    @Enumerated(EnumType.STRING)
+    @Column(name = "social_provider", columnDefinition = "VARCHAR(20)", nullable = false)
+    private SocialProviderType socialProvider;
 
-	@ManyToOne(fetch = FetchType.LAZY)
-	@JoinColumn(name = "job_category_id", columnDefinition = "BIGINT")
-	private JobCategory jobCategory;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "job_category_id", columnDefinition = "BIGINT")
+    private JobCategory jobCategory;
 
-	@Builder
-	public Member(Long id, String email, String nickname, String birth, Gender gender, LocalDateTime joinDate,
-		LocalDateTime lastLoginDate, MemberRole role, MemberAccountStatus accountStatus, LocalDateTime withdrawDate,
-		SocialProviderType socialProvider, JobCategory jobCategory) {
-		this.id = id;
-		this.email = email;
-		this.nickname = nickname;
-		this.birth = birth;
-		this.gender = gender;
-		this.joinDate = joinDate;
-		this.lastLoginDate = lastLoginDate;
-		this.role = role;
-		this.accountStatus = accountStatus;
-		this.withdrawDate = withdrawDate;
-		this.socialProvider = socialProvider;
-		this.jobCategory = jobCategory;
-	}
+    @Builder
+    public Member(Long id, String email, String nickname, String birth, Gender gender, LocalDateTime joinDate,
+        LocalDateTime lastLoginDate, MemberRole role, MemberAccountStatus accountStatus, LocalDateTime withdrawDate,
+        SocialProviderType socialProvider, JobCategory jobCategory) {
+        this.id = id;
+        this.email = email;
+        this.nickname = nickname;
+        this.birth = birth;
+        this.gender = gender;
+        this.joinDate = joinDate;
+        this.lastLoginDate = lastLoginDate;
+        this.role = role;
+        this.accountStatus = accountStatus;
+        this.withdrawDate = withdrawDate;
+        this.socialProvider = socialProvider;
+        this.jobCategory = jobCategory;
+    }
 
-	public boolean isActiveMember() {
-		return this.accountStatus != MemberAccountStatus.WITHDRAW;
-	}
+    public boolean isActiveMember() {
+        return this.accountStatus != MemberAccountStatus.WITHDRAW;
+    }
 
-	public boolean isRightSocialProvider(SocialProviderType socialProvider) {
-		return this.socialProvider == socialProvider;
-	}
+    public boolean isWithDrawMember() {
+        return this.accountStatus == MemberAccountStatus.WITHDRAW;
+    }
 
-	public void update(Member updateMember) {
-		this.nickname = updateMember.nickname;
-		this.birth = updateMember.birth;
-		this.gender = updateMember.getGender();
-		this.jobCategory = updateMember.jobCategory;
-		updateMemberSkillList(updateMember.getMemberSkillList());
-	}
+    public boolean isRightSocialProvider(SocialProviderType socialProvider) {
+        return this.socialProvider == socialProvider;
+    }
 
-	public void updateMemberSkillList(List<MemberSkill> memberSkillList) {
-		this.clearMemberSkillList();
-		this.memberSkillList.addAll(memberSkillList);
-	}
+    public void update(Member updateMember) {
+        this.nickname = updateMember.nickname;
+        this.birth = updateMember.birth;
+        this.gender = updateMember.getGender();
+        this.jobCategory = updateMember.jobCategory;
+        updateMemberSkillList(updateMember.getMemberSkillList());
+    }
 
-	private void clearMemberSkillList() {
-		if (!this.memberSkillList.isEmpty()) {
-			this.memberSkillList.clear();
-		}
-	}
+    public void updateMemberSkillList(List<MemberSkill> memberSkillList) {
+        this.clearMemberSkillList();
+        this.memberSkillList.addAll(memberSkillList);
+    }
 
-	public void withdrawMemberAccount() {
-		this.accountStatus = MemberAccountStatus.WITHDRAW;
-		this.withdrawDate = LocalDateTime.now();
-	}
+    private void clearMemberSkillList() {
+        if (!this.memberSkillList.isEmpty()) {
+            this.memberSkillList.clear();
+        }
+    }
 
-	public void updateLastLoginDate() {
-		this.lastLoginDate = LocalDateTime.now();
-	}
+    public void withdrawMemberAccount() {
+        this.accountStatus = MemberAccountStatus.WITHDRAW;
+        this.withdrawDate = LocalDateTime.now();
+    }
+
+    public void updateLastLoginDate() {
+        this.lastLoginDate = LocalDateTime.now();
+    }
+
 }


### PR DESCRIPTION
## 개요

### 요약

### 변경한 부분

1. 카카오로 회원가입 후 로그인
2. 깃허브(카카오와 같은 이메일)로 회원가입 -> 다른 소셜 로그인으로 가입한 내역 존재한다 에러.
3. 카카오 탈퇴
4. 카카오로 로그인 -> 탈퇴한 계정이다. 에러
5. 깃허브로 회원가입 -> 다른 소셜 계정으로 탈퇴한 내역이 존재한다 에러

라는 4, 5 번의 에러 상황이 있어서 error를 추가했습니다. 

다만 oauth2의 과정 중 발생하는 에러에 대해서 response가 backend의 주소(api.jdon.kr, localhost:1221 같은)로 오기 때문에 직접 redirect 해주고 있었습니다. 따라서 이 에러를 프론트에서 처리하기 위한 페이지가 존재해야합니다. 
-> 프론트와 이야기 후 redirect 주소를 추가적으로 설정, 에러에 대한 페이지 제작이 선행되어야합니다. 

### 변경한 결과

<img width="900" alt="image" src="https://github.com/Kernel360/f1-JDON-Backend/assets/68376744/14d261c2-4865-4e83-876f-b1f48bfb1000">

<img width="592" alt="image" src="https://github.com/Kernel360/f1-JDON-Backend/assets/68376744/132c1ff0-c79b-45b8-b91d-fcf7646ed6b1">

### 이슈

- closes: #441 

---

## PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경, 주석 변경)
- [ ] 코드 리팩토링
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 파일 혹은 폴더명 수정, 삭제
- [ ] 배포 관련