### PR TITLE
Feature: actuator를 위한 spring security 설정 

### DIFF
--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/auth/util/CryptoManager.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/auth/util/CryptoManager.java
@@ -22,82 +22,82 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class CryptoManager {
 
-	private final String iv = SecretKeyConstants.AES_PRIVATE_KEY;
-	private final String secretKey = SecretKeyConstants.HMAC_PRIVATE_KEY;
+    private final CryptoProperties cryptoProperties;
 
-	public String encryptAESCBC(String message) throws Exception {
-		Cipher cipher = getCipher(Cipher.ENCRYPT_MODE);
-		byte[] encrypted = cipher.doFinal(message.getBytes(StandardCharsets.UTF_8));
+    public String encryptAESCBC(String message) throws Exception {
+        Cipher cipher = getCipher(Cipher.ENCRYPT_MODE);
+        byte[] encrypted = cipher.doFinal(message.getBytes(StandardCharsets.UTF_8));
 
-		return Base64.getEncoder().encodeToString(encrypted);
-	}
+        return Base64.getEncoder().encodeToString(encrypted);
+    }
 
-	public String decryptAESCBC(String message) throws Exception {
-		Cipher cipher = getCipher(Cipher.DECRYPT_MODE);
-		byte[] decrypted = cipher.doFinal(Base64.getDecoder().decode(message));
+    public String decryptAESCBC(String message) throws Exception {
+        Cipher cipher = getCipher(Cipher.DECRYPT_MODE);
+        byte[] decrypted = cipher.doFinal(Base64.getDecoder().decode(message));
 
-		return new String(decrypted);
-	}
+        return new String(decrypted);
+    }
 
-	private Cipher getCipher(int mode) throws Exception {
-		SecretKeySpec secretKey = new SecretKeySpec(iv.getBytes(StandardCharsets.UTF_8), "AES");
-		IvParameterSpec IV = new IvParameterSpec(iv.substring(0, 16).getBytes());
+    private Cipher getCipher(int mode) throws Exception {
+        SecretKeySpec secretKey = new SecretKeySpec(
+            cryptoProperties.getAesPrivateKey().getBytes(StandardCharsets.UTF_8), "AES");
+        IvParameterSpec IV = new IvParameterSpec(cryptoProperties.getAesPrivateKey().substring(0, 16).getBytes());
 
-		Cipher cipher = Cipher.getInstance("AES/CBC/PKCS5Padding");
-		cipher.init(mode, secretKey, IV);
+        Cipher cipher = Cipher.getInstance("AES/CBC/PKCS5Padding");
+        cipher.init(mode, secretKey, IV);
 
-		return cipher;
-	}
+        return cipher;
+    }
 
-	public String generateHMAC(String data) throws Exception {
-		Mac hmac = Mac.getInstance("HmacSHA256");
-		SecretKeySpec secretKeySpec = new SecretKeySpec(secretKey.getBytes(StandardCharsets.UTF_8),
-			"HmacSHA256");
-		hmac.init(secretKeySpec);
-		byte[] hmacBytes = hmac.doFinal(data.getBytes(StandardCharsets.UTF_8));
+    public String generateHMAC(String data) throws Exception {
+        Mac hmac = Mac.getInstance("HmacSHA256");
+        SecretKeySpec secretKeySpec = new SecretKeySpec(
+            cryptoProperties.getHmacPrivateKey().getBytes(StandardCharsets.UTF_8), "HmacSHA256");
+        hmac.init(secretKeySpec);
+        byte[] hmacBytes = hmac.doFinal(data.getBytes(StandardCharsets.UTF_8));
 
-		return Base64.getEncoder().encodeToString(hmacBytes);
-	}
+        return Base64.getEncoder().encodeToString(hmacBytes);
+    }
 
-	public boolean isValidHMAC(String receivedHMAC, String data) throws Exception {
-		String calculatedHMAC = generateHMAC(data);
+    public boolean isValidHMAC(String receivedHMAC, String data) throws Exception {
+        String calculatedHMAC = generateHMAC(data);
 
-		return receivedHMAC.equals(calculatedHMAC);
-	}
+        return receivedHMAC.equals(calculatedHMAC);
+    }
 
-	public Map<String, String> getUserInfoFromAuthProvider(final String hmac, final String encrypted) {
-		final String emailAndProvider = getEmailAndProviderString(hmac, encrypted);
+    public Map<String, String> getUserInfoFromAuthProvider(final String hmac, final String encrypted) {
+        final String emailAndProvider = getEmailAndProviderString(hmac, encrypted);
 
-		return parseQueryString(emailAndProvider);
-	}
+        return parseQueryString(emailAndProvider);
+    }
 
-	private String getEmailAndProviderString(final String hmac, final String encrypted) {
-		String emailAndProvider = null;
-		try {
-			if (isValidHMAC(hmac, encrypted)) {
-				emailAndProvider = decryptAESCBC(encrypted);
-			} else {
-				throw new ApiException(MemberErrorCode.UNAUTHORIZED_EMAIL_OAUTH2);
-			}
-		} catch (Exception e) {
-			throw new ApiException(MemberErrorCode.BAD_REQUEST_INVALID_ENCRYPT_STRING);
-		}
-		return emailAndProvider;
-	}
+    private String getEmailAndProviderString(final String hmac, final String encrypted) {
+        String emailAndProvider = null;
+        try {
+            if (isValidHMAC(hmac, encrypted)) {
+                emailAndProvider = decryptAESCBC(encrypted);
+            } else {
+                throw new ApiException(MemberErrorCode.UNAUTHORIZED_EMAIL_OAUTH2);
+            }
+        } catch (Exception e) {
+            throw new ApiException(MemberErrorCode.BAD_REQUEST_INVALID_ENCRYPT_STRING);
+        }
+        return emailAndProvider;
+    }
 
-	private Map<String, String> parseQueryString(final String queryString) {
-		final Map<String, String> params = new HashMap<>();
-		final String[] pairs = queryString.split("&");
-		try {
-			for (String pair : pairs) {
-				String[] keyValue = pair.split("=");
-				String key = URLDecoder.decode(keyValue[0], "UTF-8");
-				String value = URLDecoder.decode(keyValue[1], "UTF-8");
-				params.put(key, value);
-			}
-		} catch (UnsupportedEncodingException e) {
-			throw new ApiException(MemberErrorCode.BAD_REQUEST_FAIL_PARSE_QUERY_STRING);
-		}
-		return params;
-	}
+    private Map<String, String> parseQueryString(final String queryString) {
+        final Map<String, String> params = new HashMap<>();
+        final String[] pairs = queryString.split("&");
+        try {
+            for (String pair : pairs) {
+                String[] keyValue = pair.split("=");
+                String key = URLDecoder.decode(keyValue[0], "UTF-8");
+                String value = URLDecoder.decode(keyValue[1], "UTF-8");
+                params.put(key, value);
+            }
+        } catch (UnsupportedEncodingException e) {
+            throw new ApiException(MemberErrorCode.BAD_REQUEST_FAIL_PARSE_QUERY_STRING);
+        }
+        return params;
+    }
 }

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/auth/util/CryptoManager.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/auth/util/CryptoManager.java
@@ -1,6 +1,5 @@
 package kernel.jdon.moduleapi.domain.auth.util;
 
-import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
@@ -24,43 +23,42 @@ public class CryptoManager {
 
     private final CryptoProperties cryptoProperties;
 
-    public String encryptAESCBC(String message) throws Exception {
-        Cipher cipher = getCipher(Cipher.ENCRYPT_MODE);
-        byte[] encrypted = cipher.doFinal(message.getBytes(StandardCharsets.UTF_8));
+    public String encryptAESCBC(final String message) throws Exception {
+        final Cipher cipher = getCipher(Cipher.ENCRYPT_MODE);
+        final byte[] encrypted = cipher.doFinal(message.getBytes(StandardCharsets.UTF_8));
 
         return Base64.getEncoder().encodeToString(encrypted);
     }
 
-    public String decryptAESCBC(String message) throws Exception {
-        Cipher cipher = getCipher(Cipher.DECRYPT_MODE);
-        byte[] decrypted = cipher.doFinal(Base64.getDecoder().decode(message));
+    public String decryptAESCBC(final String message) throws Exception {
+        final Cipher cipher = getCipher(Cipher.DECRYPT_MODE);
+        final byte[] decrypted = cipher.doFinal(Base64.getDecoder().decode(message));
 
         return new String(decrypted);
     }
 
-    private Cipher getCipher(int mode) throws Exception {
-        SecretKeySpec secretKey = new SecretKeySpec(
-            cryptoProperties.getAesPrivateKey().getBytes(StandardCharsets.UTF_8), "AES");
-        IvParameterSpec IV = new IvParameterSpec(cryptoProperties.getAesPrivateKey().substring(0, 16).getBytes());
-
-        Cipher cipher = Cipher.getInstance("AES/CBC/PKCS5Padding");
+    private Cipher getCipher(final int mode) throws Exception {
+        final SecretKeySpec secretKey = new SecretKeySpec(
+            cryptoProperties.getAesPrivateKeyByByte(), cryptoProperties.getCryptoAlgorithm());
+        final IvParameterSpec IV = new IvParameterSpec(cryptoProperties.getAesPrivateKeyByByte());
+        final Cipher cipher = Cipher.getInstance(cryptoProperties.getCryptoTransformation());
         cipher.init(mode, secretKey, IV);
 
         return cipher;
     }
 
-    public String generateHMAC(String data) throws Exception {
-        Mac hmac = Mac.getInstance("HmacSHA256");
-        SecretKeySpec secretKeySpec = new SecretKeySpec(
-            cryptoProperties.getHmacPrivateKey().getBytes(StandardCharsets.UTF_8), "HmacSHA256");
+    public String generateHMAC(final String data) throws Exception {
+        final Mac hmac = Mac.getInstance(cryptoProperties.getMacAlgorithm());
+        final SecretKeySpec secretKeySpec = new SecretKeySpec(
+            cryptoProperties.getHmacPrivateKeyByByte(), cryptoProperties.getMacAlgorithm());
         hmac.init(secretKeySpec);
-        byte[] hmacBytes = hmac.doFinal(data.getBytes(StandardCharsets.UTF_8));
+        final byte[] hmacBytes = hmac.doFinal(data.getBytes(StandardCharsets.UTF_8));
 
         return Base64.getEncoder().encodeToString(hmacBytes);
     }
 
-    public boolean isValidHMAC(String receivedHMAC, String data) throws Exception {
-        String calculatedHMAC = generateHMAC(data);
+    public boolean isValidHMAC(final String receivedHMAC, final String data) throws Exception {
+        final String calculatedHMAC = generateHMAC(data);
 
         return receivedHMAC.equals(calculatedHMAC);
     }
@@ -88,15 +86,11 @@ public class CryptoManager {
     private Map<String, String> parseQueryString(final String queryString) {
         final Map<String, String> params = new HashMap<>();
         final String[] pairs = queryString.split("&");
-        try {
-            for (String pair : pairs) {
-                String[] keyValue = pair.split("=");
-                String key = URLDecoder.decode(keyValue[0], "UTF-8");
-                String value = URLDecoder.decode(keyValue[1], "UTF-8");
-                params.put(key, value);
-            }
-        } catch (UnsupportedEncodingException e) {
-            throw new ApiException(MemberErrorCode.BAD_REQUEST_FAIL_PARSE_QUERY_STRING);
+        for (String pair : pairs) {
+            String[] keyValue = pair.split("=");
+            String key = URLDecoder.decode(keyValue[0], StandardCharsets.UTF_8);
+            String value = URLDecoder.decode(keyValue[1], StandardCharsets.UTF_8);
+            params.put(key, value);
         }
         return params;
     }

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/auth/util/CryptoProperties.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/auth/util/CryptoProperties.java
@@ -1,0 +1,14 @@
+package kernel.jdon.moduleapi.domain.auth.util;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+@ConfigurationProperties(prefix = "crypto")
+public class CryptoProperties {
+    private final String aesPrivateKey;
+    private final String hmacPrivateKey;
+}

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/auth/util/CryptoProperties.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/auth/util/CryptoProperties.java
@@ -1,5 +1,7 @@
 package kernel.jdon.moduleapi.domain.auth.util;
 
+import java.nio.charset.StandardCharsets;
+
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 import lombok.Getter;
@@ -11,4 +13,15 @@ import lombok.RequiredArgsConstructor;
 public class CryptoProperties {
     private final String aesPrivateKey;
     private final String hmacPrivateKey;
+    private final String macAlgorithm = "HmacSHA256";
+    private final String cryptoAlgorithm = "AES";
+    private final String cryptoTransformation = "AES/CBC/PKCS5Padding";
+
+    public byte[] getAesPrivateKeyByByte() {
+        return aesPrivateKey.getBytes(StandardCharsets.UTF_8);
+    }
+
+    public byte[] getHmacPrivateKeyByByte() {
+        return hmacPrivateKey.getBytes(StandardCharsets.UTF_8);
+    }
 }

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/auth/util/SecretKeyConstants.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/auth/util/SecretKeyConstants.java
@@ -1,7 +1,0 @@
-package kernel.jdon.moduleapi.domain.auth.util;
-
-public final class SecretKeyConstants {
-	public static final String AES_PRIVATE_KEY = "JDON_SECRET_KEY_AES_USE_THIS_KEY";
-	public static final String HMAC_PRIVATE_KEY = "JDON_SECRET_KEY_HMAC_USE_THIS_KK";
-
-}

--- a/module-api/src/main/java/kernel/jdon/moduleapi/global/config/auth/AllowOriginProperties.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/global/config/auth/AllowOriginProperties.java
@@ -11,6 +11,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 @ConfigurationProperties(prefix = "allowed-origins")
 public class AllowOriginProperties {
-	private final String origin;
-	private final List<String> url;
+    private final String origin;
+    private final List<String> url;
+    private final List<String> monitoring;
 }

--- a/module-api/src/main/java/kernel/jdon/moduleapi/global/config/auth/AllowOriginProperties.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/global/config/auth/AllowOriginProperties.java
@@ -12,6 +12,16 @@ import lombok.RequiredArgsConstructor;
 @ConfigurationProperties(prefix = "allowed-origins")
 public class AllowOriginProperties {
     private final String origin;
-    private final List<String> url;
-    private final List<String> monitoring;
+    private final List<String> urlList;
+    private final Ip ip;
+
+    public List<String> getAllowIpMonitoringList() {
+        return this.ip.monitoringList;
+    }
+
+    @Getter
+    @RequiredArgsConstructor
+    public static class Ip {
+        private final List<String> monitoringList;
+    }
 }

--- a/module-api/src/main/java/kernel/jdon/moduleapi/global/config/auth/OAuth2SecurityConfig.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/global/config/auth/OAuth2SecurityConfig.java
@@ -5,12 +5,17 @@ import java.util.List;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
+import org.springframework.security.authorization.AuthorizationDecision;
+import org.springframework.security.authorization.AuthorizationManager;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.access.intercept.RequestAuthorizationContext;
+import org.springframework.security.web.util.matcher.IpAddressMatcher;
 import org.springframework.web.cors.CorsConfiguration;
 
+import jakarta.servlet.http.HttpServletRequest;
 import kernel.jdon.moduleapi.domain.auth.core.CustomOAuth2UserServiceImpl;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -20,68 +25,80 @@ import lombok.extern.slf4j.Slf4j;
 @EnableWebSecurity
 @Configuration
 public class OAuth2SecurityConfig {
-	private final CustomOAuth2UserServiceImpl customOAuth2UserServiceImpl;
-	private final JdonOAuth2AuthenticationSuccessHandler jdonOAuth2AuthenticationSuccessHandler;
-	private final JdonAuthExceptionHandler jdonAuthExceptionHandler;
-	private final AllowOriginProperties allowOriginProperties;
+    private final CustomOAuth2UserServiceImpl customOAuth2UserServiceImpl;
+    private final JdonOAuth2AuthenticationSuccessHandler jdonOAuth2AuthenticationSuccessHandler;
+    private final JdonAuthExceptionHandler jdonAuthExceptionHandler;
+    private final AllowOriginProperties allowOriginProperties;
 
-	@Bean
-	public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
-		final String[] permitAllGET = {
-			"/oauth2/authorization/**",
-			"/api/v1/coffeechats/**",
-			"/api/v1/skills/hot",
-			"/api/v1/skills/job-category/**",
-			"/api/v1/job-categories",
-			"/api/v1/faqs",
-			"/api/v1/skills/search",
-			"/api/v1/jds/**",
-			"/api/v1/authenticate"
-		};
-		final String[] permitAllPOST = {
-			"/api/v1/register",
-			"/api/v1/nickname/duplicate",
-		};
-		final String[] authenticatedGET = {
-			"/api/v1/coffeechats/guest",
-			"/api/v1/coffeechats/host",
-			"/api/v1/skills/member",
-			"/api/v1/logout"
-		};
+    private static AuthorizationManager<RequestAuthorizationContext> hasIpAddress(List<String> ipAddress) {
+        List<IpAddressMatcher> matcherList = ipAddress.stream().map(IpAddressMatcher::new).toList();
+        return (authentication, context) -> {
+            HttpServletRequest request = context.getRequest();
+            boolean isIpMatch = matcherList.stream()
+                .anyMatch(matcher -> matcher.matches(request));
 
-		http.cors(corsCustomizer -> corsCustomizer.configurationSource(request -> {
-			CorsConfiguration config = new CorsConfiguration();
-			config.setAllowedOrigins(allowOriginProperties.getUrl());
-			config.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE"));
-			config.setAllowedHeaders(List.of("*"));
-			config.setAllowCredentials(true);
-			config.setMaxAge(3600L);
+            return new AuthorizationDecision(isIpMatch);
+        };
+    }
 
-			return config;
-		}));
-		http.exceptionHandling(exceptionConfig -> exceptionConfig
-			.authenticationEntryPoint(jdonAuthExceptionHandler)
-			.accessDeniedHandler(jdonAuthExceptionHandler));
-		http.csrf(AbstractHttpConfigurer::disable);
-		http.sessionManagement(sessionManagementConfigurer -> sessionManagementConfigurer
-			.maximumSessions(1)
-			.maxSessionsPreventsLogin(false));
-		http.authorizeHttpRequests(config -> config
-			.requestMatchers(HttpMethod.GET, permitAllGET).permitAll()
-			.requestMatchers(HttpMethod.POST, permitAllPOST).permitAll()
-			.requestMatchers(HttpMethod.GET, authenticatedGET).authenticated()
-			.anyRequest().authenticated());
-		http.oauth2Login(oauth2Configurer -> oauth2Configurer
-			.successHandler(jdonOAuth2AuthenticationSuccessHandler)
-			.failureHandler(jdonAuthExceptionHandler)
-			.userInfoEndpoint(userInfoEndpointConfigurer -> userInfoEndpointConfigurer
-				.userService(customOAuth2UserServiceImpl)));
-		http.logout(logoutConfigurer -> logoutConfigurer
-			.logoutUrl("/api/v1/logout")
-			.invalidateHttpSession(true)
-			.deleteCookies("JSESSIONID")
-			.logoutSuccessUrl(allowOriginProperties.getOrigin()));
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        final String[] permitAllGET = {
+            "/oauth2/authorization/**",
+            "/api/v1/coffeechats/**",
+            "/api/v1/skills/hot",
+            "/api/v1/skills/job-category/**",
+            "/api/v1/job-categories",
+            "/api/v1/faqs",
+            "/api/v1/skills/search",
+            "/api/v1/jds/**",
+            "/api/v1/authenticate"
+        };
+        final String[] permitAllPOST = {
+            "/api/v1/register",
+            "/api/v1/nickname/duplicate",
+        };
+        final String[] authenticatedGET = {
+            "/api/v1/coffeechats/guest",
+            "/api/v1/coffeechats/host",
+            "/api/v1/skills/member",
+            "/api/v1/logout"
+        };
 
-		return http.build();
-	}
+        http.cors(corsCustomizer -> corsCustomizer.configurationSource(request -> {
+            CorsConfiguration config = new CorsConfiguration();
+            config.setAllowedOrigins(allowOriginProperties.getUrl());
+            config.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE"));
+            config.setAllowedHeaders(List.of("*"));
+            config.setAllowCredentials(true);
+            config.setMaxAge(3600L);
+
+            return config;
+        }));
+        http.exceptionHandling(exceptionConfig -> exceptionConfig
+            .authenticationEntryPoint(jdonAuthExceptionHandler)
+            .accessDeniedHandler(jdonAuthExceptionHandler));
+        http.csrf(AbstractHttpConfigurer::disable);
+        http.sessionManagement(sessionManagementConfigurer -> sessionManagementConfigurer
+            .maximumSessions(1)
+            .maxSessionsPreventsLogin(false));
+        http.authorizeHttpRequests(config -> config
+            .requestMatchers(HttpMethod.GET, permitAllGET).permitAll()
+            .requestMatchers(HttpMethod.POST, permitAllPOST).permitAll()
+            .requestMatchers(HttpMethod.GET, authenticatedGET).authenticated()
+            .requestMatchers("/actuator/**").access(hasIpAddress(allowOriginProperties.getMonitoring()))
+            .anyRequest().authenticated());
+        http.oauth2Login(oauth2Configurer -> oauth2Configurer
+            .successHandler(jdonOAuth2AuthenticationSuccessHandler)
+            .failureHandler(jdonAuthExceptionHandler)
+            .userInfoEndpoint(userInfoEndpointConfigurer -> userInfoEndpointConfigurer
+                .userService(customOAuth2UserServiceImpl)));
+        http.logout(logoutConfigurer -> logoutConfigurer
+            .logoutUrl("/api/v1/logout")
+            .invalidateHttpSession(true)
+            .deleteCookies("JSESSIONID")
+            .logoutSuccessUrl(allowOriginProperties.getOrigin()));
+
+        return http.build();
+    }
 }

--- a/module-api/src/main/java/kernel/jdon/moduleapi/global/config/auth/OAuth2SecurityConfig.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/global/config/auth/OAuth2SecurityConfig.java
@@ -67,7 +67,7 @@ public class OAuth2SecurityConfig {
 
         http.cors(corsCustomizer -> corsCustomizer.configurationSource(request -> {
             CorsConfiguration config = new CorsConfiguration();
-            config.setAllowedOrigins(allowOriginProperties.getUrl());
+            config.setAllowedOrigins(allowOriginProperties.getUrlList());
             config.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE"));
             config.setAllowedHeaders(List.of("*"));
             config.setAllowCredentials(true);
@@ -86,7 +86,7 @@ public class OAuth2SecurityConfig {
             .requestMatchers(HttpMethod.GET, permitAllGET).permitAll()
             .requestMatchers(HttpMethod.POST, permitAllPOST).permitAll()
             .requestMatchers(HttpMethod.GET, authenticatedGET).authenticated()
-            .requestMatchers("/actuator/**").access(hasIpAddress(allowOriginProperties.getMonitoring()))
+            .requestMatchers("/actuator/**").access(hasIpAddress(allowOriginProperties.getAllowIpMonitoringList()))
             .anyRequest().authenticated());
         http.oauth2Login(oauth2Configurer -> oauth2Configurer
             .successHandler(jdonOAuth2AuthenticationSuccessHandler)

--- a/module-api/src/main/resources/application-dev.yml
+++ b/module-api/src/main/resources/application-dev.yml
@@ -91,3 +91,22 @@ redis:
     coffee-chat:
       wait-time: 5
       lease-time: 1
+
+crypto:
+  aes-private-key: ${AES_PRIVATE_KEY}
+  hmac-private-key: ${HMAC_PRIVATE_KEY}
+
+management:
+  info:
+    java:
+      enabled: true
+    os:
+      enabled: true
+  endpoint:
+    health:
+      show-details: always
+  endpoints:
+    web:
+      exposure:
+        include: "*"
+        exclude:

--- a/module-api/src/main/resources/application-dev.yml
+++ b/module-api/src/main/resources/application-dev.yml
@@ -73,6 +73,9 @@ allowed-origins:
     - "https://jdon.kr"
     - "https://jdon.netlify.app"
     - "https://jdon-test.netlify.app/"
+  monitoring:
+    - "3.34.69.116"
+    - "0:0:0:0:0:0:0:1"
 
 redirect-url:
   login:

--- a/module-api/src/main/resources/application-dev.yml
+++ b/module-api/src/main/resources/application-dev.yml
@@ -67,15 +67,16 @@ custom-oauth2:
 
 allowed-origins:
   origin: https://localhost:3000/
-  url:
+  url-list:
     - "http://localhost:3000"
     - "https://localhost:3000"
     - "https://jdon.kr"
     - "https://jdon.netlify.app"
     - "https://jdon-test.netlify.app/"
-  monitoring:
-    - "3.34.69.116"
-    - "0:0:0:0:0:0:0:1"
+  ip:
+    monitoring-list:
+      - "3.34.69.116"
+      - "0:0:0:0:0:0:0:1"
 
 redirect-url:
   login:

--- a/module-api/src/main/resources/application-local.yml
+++ b/module-api/src/main/resources/application-local.yml
@@ -67,6 +67,9 @@ allowed-origins:
     - "https://jdon.kr"
     - "https://jdon.netlify.app"
     - "https://jdon-test.netlify.app/"
+  monitoring:
+    - "3.34.69.116"
+    - "0:0:0:0:0:0:0:1"
 
 # http://localhost:3000
 redirect-url:
@@ -83,3 +86,18 @@ redis:
     coffee-chat:
       wait-time: 5
       lease-time: 1
+
+management:
+  info:
+    java:
+      enabled: true
+    os:
+      enabled: true
+  endpoint:
+    health:
+      show-details: always
+  endpoints:
+    web:
+      exposure:
+        include: "*"
+        exclude:

--- a/module-api/src/main/resources/application-local.yml
+++ b/module-api/src/main/resources/application-local.yml
@@ -61,15 +61,16 @@ custom-oauth2:
 
 allowed-origins:
   origin: http://localhost:3000/
-  url:
+  url-list:
     - "http://localhost:3000"
     - "https://localhost:3000"
     - "https://jdon.kr"
     - "https://jdon.netlify.app"
     - "https://jdon-test.netlify.app/"
-  monitoring:
-    - "3.34.69.116"
-    - "0:0:0:0:0:0:0:1"
+  ip:
+    monitoring-list:
+      - "3.34.69.116"
+      - "0:0:0:0:0:0:0:1"
 
 # http://localhost:3000
 redirect-url:

--- a/module-api/src/main/resources/application-local.yml
+++ b/module-api/src/main/resources/application-local.yml
@@ -87,6 +87,10 @@ redis:
       wait-time: 5
       lease-time: 1
 
+crypto:
+  aes-private-key: JDON_SECRET_KEY_AES_USE_THIS_KEY
+  hmac-private-key: JDON_SECRET_KEY_HMAC_USE_THIS_KK
+
 management:
   info:
     java:

--- a/module-api/src/main/resources/application-prod.yml
+++ b/module-api/src/main/resources/application-prod.yml
@@ -91,3 +91,22 @@ redis:
     coffee-chat:
       wait-time: 5
       lease-time: 1
+
+crypto:
+  aes-private-key: ${AES_PRIVATE_KEY}
+  hmac-private-key: ${HMAC_PRIVATE_KEY}
+
+management:
+  info:
+    java:
+      enabled: true
+    os:
+      enabled: true
+  endpoint:
+    health:
+      show-details: always
+  endpoints:
+    web:
+      exposure:
+        include: "*"
+        exclude:

--- a/module-api/src/main/resources/application-prod.yml
+++ b/module-api/src/main/resources/application-prod.yml
@@ -65,15 +65,16 @@ custom-oauth2:
 
 allowed-origins:
   origin: https://jdon.kr/
-  url:
+  url-list:
     - "http://localhost:3000"
     - "https://localhost:3000"
     - "https://jdon.kr"
     - "https://jdon.netlify.app"
     - "https://jdon-test.netlify.app/"
-  monitoring:
-    - "3.34.69.116"
-    - "0:0:0:0:0:0:0:1"
+  ip:
+    monitoring-list:
+      - "3.34.69.116"
+      - "0:0:0:0:0:0:0:1"
 
 #https://jdon.kr
 redirect-url:

--- a/module-api/src/main/resources/application-prod.yml
+++ b/module-api/src/main/resources/application-prod.yml
@@ -71,6 +71,9 @@ allowed-origins:
     - "https://jdon.kr"
     - "https://jdon.netlify.app"
     - "https://jdon-test.netlify.app/"
+  monitoring:
+    - "3.34.69.116"
+    - "0:0:0:0:0:0:0:1"
 
 #https://jdon.kr
 redirect-url:


### PR DESCRIPTION
## 개요

### 요약

### 변경한 부분
모니터링을 위한 메트릭 수집을 위해 actuator에서 제공하는 api에 접근해야하는데 아무곳에서나 접근하는 것을 막기 위해서 jdon의 모니터링 서버의 ip와 본인의 local에서 띄우고 local의 모니터링을 위한 localhost(0:0:0:0:0:0:0:1)을 만 허용하도록 했습니다. 

ip주소가 application.yml에서 설정해둔 ip인지 비교합니다. 

- aes, hmac에서 사용하는 key를 서버가 아니라 application.yml에서 관리하도록 수정했습니다. 

### 변경한 결과
![image](https://github.com/Kernel360/f1-JDON-Backend/assets/68376744/b26abbbc-58ed-45e2-810c-f102895e7e6d)


### 이슈

- closes: #436 
- closes: #274 

---

## PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경, 주석 변경)
- [ ] 코드 리팩토링
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 파일 혹은 폴더명 수정, 삭제
- [ ] 배포 관련