### PR TITLE
Fix: 오픈채팅 URL Validation 카카오톡 기준으로 변경

### DIFF
--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/coffeechat/presentation/CoffeeChatDto.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/coffeechat/presentation/CoffeeChatDto.java
@@ -4,7 +4,6 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 import org.hibernate.validator.constraints.Range;
-import org.hibernate.validator.constraints.URL;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonInclude;
@@ -12,6 +11,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import jakarta.validation.constraints.Future;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 import kernel.jdon.moduleapi.global.page.CustomPageInfo;
 import lombok.AccessLevel;
@@ -95,7 +95,8 @@ public class CoffeeChatDto {
         @Future(message = "일시는 과거 시점으로 설정할 수 없습니다.")
         @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm", timezone = "Asia/Seoul")
         private LocalDateTime meetDate;
-        @URL(message = "URL형식이 올바르지 않습니다.")
+        @NotBlank(message = "오픈채팅 링크는 필수 입력 항목 입니다.")
+        @Pattern(regexp = "https:\\/\\/open\\.kakao\\.com\\/o\\/[A-Za-z0-9]{8}$", message = "URL 형식이 올바르지 않습니다.")
         private String openChatUrl;
     }
 
@@ -116,7 +117,8 @@ public class CoffeeChatDto {
         @Future(message = "일시는 과거 시점으로 설정할 수 없습니다.")
         @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm", timezone = "Asia/Seoul")
         private LocalDateTime meetDate;
-        @URL(message = "URL형식이 올바르지 않습니다.")
+        @NotBlank(message = "오픈채팅 링크는 필수 입력 항목 입니다.")
+        @Pattern(regexp = "https:\\/\\/open\\.kakao\\.com\\/o\\/[A-Za-z0-9]{8}$", message = "URL 형식이 올바르지 않습니다.")
         private String openChatUrl;
     }
 


### PR DESCRIPTION
## 개요

### 요약

정책상 커피챗 생성,수정시 오픈채팅 링크를 카카오톡 서비스로 제한함에 따라
URL입력 Validation을 해당 서비스 기준에 맞춰 수정했습니다.

공식문서에 오픈채팅 링크 생성규칙이 나와있진 않지만 직접 생성해보고 다른 링크들을 찾아보니
~.com/o/ 이후로 영어 대소문자,숫자 포함 8자리가 오는 걸로 보여서 아래의 정규식으로 검증했습니다.
https:\/\/open\.kakao\.com\/o\/[A-Za-z0-9]{8}$

카카오톡이 오픈채팅 링크 생성 규칙을 바꾸면 서비스 장애가 될 수 있으나
해당 규칙으로 가능한 경우의 수는 약 210조개로 가능성이 희박합니다.


### 변경한 부분

- 생성, 수정 request dto에 validation 적용하고 message를 추가했습니다.

### 변경한 결과

URL형식이 올바르지 않은 경우 예외
![image](https://github.com/Kernel360/f1-JDON-Backend/assets/111513287/bf97f4af-1b3c-4c07-874b-09e7a5a631fc)

null인 경우 예외
![image](https://github.com/Kernel360/f1-JDON-Backend/assets/111513287/1270b1c5-13df-4a5a-bd40-0d260d85772a)

빈 문자열인 경우 예외
![image](https://github.com/Kernel360/f1-JDON-Backend/assets/111513287/21811efb-3646-4e2b-ae15-af53f3d93087)

정상 요청 및 응답
![image](https://github.com/Kernel360/f1-JDON-Backend/assets/111513287/8c8892f1-4715-4d09-997f-f4c2cbe24358)


### 이슈

- closes: #443 

---

## PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [X] 버그가 아닌 변경사항
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경, 주석 변경)
- [ ] 코드 리팩토링
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 파일 혹은 폴더명 수정, 삭제
- [ ] 배포 관련