### PR TITLE
Fix: cors allow origin에 개발 서버 도메인 추가, 개발 서버의 redirect url 도메인 수정

### DIFF
--- a/module-api/src/main/resources/application-dev.yml
+++ b/module-api/src/main/resources/application-dev.yml
@@ -1,5 +1,4 @@
 spring:
-
   config:
     activate:
       on-profile: dev
@@ -66,13 +65,11 @@ custom-oauth2:
     delete-user-url: https://kapi.kakao.com/v1/user/unlink
 
 allowed-origins:
-  origin: https://localhost:3000/
+  origin: https://dev.jdon.kr/
   url-list:
-    - "http://localhost:3000"
+    - "https://dev.jdon.kr"
     - "https://localhost:3000"
-    - "https://jdon.kr"
-    - "https://jdon.netlify.app"
-    - "https://jdon-test.netlify.app/"
+
   ip:
     monitoring-list:
       - "3.34.69.116"
@@ -81,13 +78,13 @@ allowed-origins:
 redirect-url:
   login:
     success:
-      member: https://localhost:3000/oauth/login/success
-      guest: https://localhost:3000/oauth/info?
+      member: https://dev.jdon.kr/oauth/login/success
+      guest: https://dev.jdon.kr/oauth/info?
     failure:
-      not-found-email: https://localhost:3000/oauth/login/fail/not-found-email
-      not-match-provider: https://localhost:3000/oauth/login/fail/not-match-provider
-      another-withdraw-account: https://localhost:3000/oauth/login/fail/another-withdraw-account
-      already-withdraw-account: https://localhost:3000/oauth/login/fail/already-withdraw-account
+      not-found-email: https://dev.jdon.kr/oauth/login/fail/not-found-email
+      not-match-provider: https://dev.jdon.kr/oauth/login/fail/not-match-provider
+      another-withdraw-account: https://dev.jdon.kr/oauth/login/fail/another-withdraw-account
+      already-withdraw-account: https://dev.jdon.kr/oauth/login/fail/already-withdraw-account
 
 redis:
   lock:

--- a/module-api/src/main/resources/application-local.yml
+++ b/module-api/src/main/resources/application-local.yml
@@ -65,6 +65,7 @@ allowed-origins:
     - "http://localhost:3000"
     - "https://localhost:3000"
     - "https://jdon.kr"
+    - "https://dev.jdon.kr"
     - "https://jdon.netlify.app"
     - "https://jdon-test.netlify.app/"
   ip:

--- a/module-api/src/main/resources/application-prod.yml
+++ b/module-api/src/main/resources/application-prod.yml
@@ -66,11 +66,7 @@ custom-oauth2:
 allowed-origins:
   origin: https://jdon.kr/
   url-list:
-    - "http://localhost:3000"
-    - "https://localhost:3000"
     - "https://jdon.kr"
-    - "https://jdon.netlify.app"
-    - "https://jdon-test.netlify.app/"
   ip:
     monitoring-list:
       - "3.34.69.116"


### PR DESCRIPTION
## 개요

### 요약

### 변경한 부분
개발서버의 도메인을 변경하여 cors allow origin에 dev.jdon.kr을 추가하고
redirect url의 도메인을 localhost:3000에서 dev.jdon.kr로 수정했습니다. 

또한 application-**.yml에서 cors allow origin에 3가지 profile 모두 localhost, dev, prod 도메인 모두를 담고 있었습니다.
dev, prod 프로필에 대해서 정말 관리되어야하는 origin 항목만 남기고 삭제하였습니다. 

### 변경한 결과


### 이슈

- closes: #462 

---

## PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경, 주석 변경)
- [ ] 코드 리팩토링
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 파일 혹은 폴더명 수정, 삭제
- [ ] 배포 관련