### PR TITLE
Bugfix: 기술스택 기반 인프런 강의 SQL 중복제거 조건 추가

### DIFF
--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/skill/infrastructure/SkillRepositoryImpl.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/skill/infrastructure/SkillRepositoryImpl.java
@@ -93,6 +93,7 @@ public class SkillRepositoryImpl implements CustomSkillRepository {
                         .from(skill)
                         .where(skill.keyword.in(originSkillKeywordList))))
             .orderBy(Expressions.numberTemplate(Double.class, "function('rand')").asc())
+            .distinct()
             .limit(inflearnLectureCount)
             .fetch();
     }


### PR DESCRIPTION
## 개요

### 요약
기술스택 기반 인프런 강의 조회 SQL 질의에 중복제거 조건을 추가했습니다.

### 변경한 부분
기술스택 기반 인프런 강의를 검색할 때, 연관검색어가 곂치는 기술스택일 경우 중복된 데이터가 출력되는 장애사항이 있었습니다.
장애 원인은 검색한 키워드가 연관검색어가 곂치는 기술스택일 경우 같은 기술스택의 강의 데이터를 가져오기 때문이었는데요.
이를 해결하기위해 인프런 강의 SQL조건에 `distinct`를 추가하여 중복을 제거한 3개의 데이터를 가져오도록 수정했습니다.

### 변경한 결과
#### 변경 전 중복되는 기술스택 키워드 출력되는 현상 (개발서버)
<img width="709" alt="image" src="https://github.com/Kernel360/f1-JDON-Backend/assets/59242594/e23b5786-1e70-43c7-b1f0-79cc590008a1">

#### 변경 후 중복되는 기술스택 없음. (로컬서버)
<img width="714" alt="image" src="https://github.com/Kernel360/f1-JDON-Backend/assets/59242594/891f07a6-aa07-468f-ac5a-e88bf7d7a47d">




### 이슈

- closes: #468 

---

## PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경, 주석 변경)
- [ ] 코드 리팩토링
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 파일 혹은 폴더명 수정, 삭제
- [ ] 배포 관련