### PR TITLE
Fix: WantedJd 엔티티 ScrapingDate 삭제 및 신규 컬럼 추가

### DIFF
--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/jd/infrastructure/WantedJdRepositoryImpl.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/jd/infrastructure/WantedJdRepositoryImpl.java
@@ -98,7 +98,7 @@ public class WantedJdRepositoryImpl implements CustomWantedJdRepository {
     private OrderSpecifier createOrderSpecifier(final JdSortType sort) {
         return switch (sort) {
             case REVIEW -> new OrderSpecifier<>(Order.DESC, wantedJd.reviewList.size());
-            default -> new OrderSpecifier<>(Order.DESC, wantedJd.scrapingDate);
+            default -> new OrderSpecifier<>(Order.DESC, wantedJd.modifiedDate);
         };
     }
 }

--- a/module-domain/src/main/java/kernel/jdon/moduledomain/wantedjd/domain/WantedJd.java
+++ b/module-domain/src/main/java/kernel/jdon/moduledomain/wantedjd/domain/WantedJd.java
@@ -4,12 +4,10 @@ import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.springframework.data.annotation.CreatedDate;
-import org.springframework.data.jpa.domain.support.AuditingEntityListener;
-
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.EntityListeners;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -19,6 +17,7 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
+import kernel.jdon.moduledomain.base.AbstractEntity;
 import kernel.jdon.moduledomain.jobcategory.domain.JobCategory;
 import kernel.jdon.moduledomain.review.domain.Review;
 import kernel.jdon.moduledomain.wantedjdskill.domain.WantedJdSkill;
@@ -30,9 +29,8 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@EntityListeners(AuditingEntityListener.class)
 @Table(name = "wanted_jd", uniqueConstraints = @UniqueConstraint(columnNames = {"detail_id", "job_category_id"}))
-public class WantedJd {
+public class WantedJd extends AbstractEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -68,9 +66,12 @@ public class WantedJd {
     @Column(name = "preferredPoints", columnDefinition = "TEXT")
     private String preferredPoints;
 
-    @CreatedDate
-    @Column(name = "scraping_date", columnDefinition = "DATETIME", nullable = false)
-    private LocalDateTime scrapingDate;
+    @Column(name = "deadline_date", columnDefinition = "DATETIME")
+    private LocalDateTime deadlineDate;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "active_status", columnDefinition = "VARCHAR(50)", nullable = false)
+    private WantedJdActiveStatus wantedJdStatus = WantedJdActiveStatus.OPEN;
 
     @ManyToOne(fetch = FetchType.EAGER)
     @JoinColumn(name = "job_category_id", columnDefinition = "BIGINT")
@@ -85,7 +86,7 @@ public class WantedJd {
     @Builder
     public WantedJd(String companyName, String title, Long detailId, String detailUrl, String imageUrl,
         String requirements, String mainTasks, String intro, String benefits, String preferredPoints,
-        LocalDateTime scrapingDate, JobCategory jobCategory) {
+        LocalDateTime deadlineDate, WantedJdActiveStatus wantedJdStatus, JobCategory jobCategory) {
         this.companyName = companyName;
         this.title = title;
         this.detailId = detailId;
@@ -96,7 +97,8 @@ public class WantedJd {
         this.intro = intro;
         this.benefits = benefits;
         this.preferredPoints = preferredPoints;
-        this.scrapingDate = scrapingDate;
+        this.deadlineDate = deadlineDate;
+        this.wantedJdStatus = wantedJdStatus;
         this.jobCategory = jobCategory;
     }
 }

--- a/module-domain/src/main/java/kernel/jdon/moduledomain/wantedjd/domain/WantedJdActiveStatus.java
+++ b/module-domain/src/main/java/kernel/jdon/moduledomain/wantedjd/domain/WantedJdActiveStatus.java
@@ -1,0 +1,16 @@
+package kernel.jdon.moduledomain.wantedjd.domain;
+
+public enum WantedJdActiveStatus {
+    OPEN("모집중"),
+    CLOSE("모집종료");
+
+    private final String activeStatus;
+
+    WantedJdActiveStatus(String activeStatus) {
+        this.activeStatus = activeStatus;
+    }
+
+    public String getActiveStatus() {
+        return activeStatus;
+    }
+}


### PR DESCRIPTION
## 개요

### 요약

### 변경한 부분
- 원티드 채용공고를 스크래핑하면서 마감여부를 체크하는 마감일자 및 마감여부 컬럼이 필요해 추가했습니다.
- WantedJd 엔티티가 AbstractEntity 상속받도록하여 등록일자, 수정일자 컬럼 추가를 갇도록 수정했습니다.
- 등록일자 컬럼이 추가되면서 더 이상 필요하지 않은 기존의 scraping_date 컬럼을 삭제했습니다.

#### DB 컬럼 수정사항
- 마감일자 deadline_date 컬럼 추가
- 활성상태 active_status 컬럼 추가
- 등록일자 created_date 컬럼 추가
- 수정일자 modified_date 컬럼 추가
- 스크래핑일자 scraping_date 컬럼 삭제

# 개발, 운영서버는 제가 수정할테니 개인 로컬 DB만 실행해주세요.
### 배포될 때 마다 제가 해당 서버 DB 수정하겠습니다.

기존에 운영되고 있는 테이블을 수정함에 따라 아래의 SQL 스크립트 실행이 필요합니다.

#### created_date 컬럼 추가
```
ALTER TABLE wanted_jd
ADD COLUMN created_date DATETIME;
```
#### created_date 컬럼에 scraping_date 컬럼 데이터 업데이트
```
UPDATE wanted_jd
SET created_date = scraping_date;
```
#### created_date 컬럼 NOT NULL 속성 추가
```
ALTER TABLE wanted_jd
MODIFY COLUMN created_date DATETIME NOT NULL;
```
#### scraping_date 컬럼 삭제
```
ALTER TABLE wanted_jd
DROP COLUMN scraping_date;
```



### 변경한 결과

### 이슈

- closes: #474 

---

## PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경, 주석 변경)
- [ ] 코드 리팩토링
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 파일 혹은 폴더명 수정, 삭제
- [ ] 배포 관련