### PR TITLE
Fix: 원티드 채용공고 스크래핑 항목에 마감일자 항목 추가

### DIFF
--- a/module-crawler/src/main/java/kernel/jdon/modulecrawler/wanted/dto/response/WantedJobDetailResponse.java
+++ b/module-crawler/src/main/java/kernel/jdon/modulecrawler/wanted/dto/response/WantedJobDetailResponse.java
@@ -71,7 +71,7 @@ public class WantedJobDetailResponse {
         private String deadlineDate;
 
         public String getFirstCompanyImage() {
-            return String.valueOf(companyImages.get(0).url);
+            return !companyImages.isEmpty() ? companyImages.get(0).url : null;
         }
     }
 

--- a/module-crawler/src/main/java/kernel/jdon/modulecrawler/wanted/dto/response/WantedJobDetailResponse.java
+++ b/module-crawler/src/main/java/kernel/jdon/modulecrawler/wanted/dto/response/WantedJobDetailResponse.java
@@ -1,11 +1,16 @@
 package kernel.jdon.modulecrawler.wanted.dto.response;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
+import java.util.Optional;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import kernel.jdon.moduledomain.jobcategory.domain.JobCategory;
 import kernel.jdon.moduledomain.wantedjd.domain.WantedJd;
+import kernel.jdon.moduledomain.wantedjd.domain.WantedJdActiveStatus;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -23,6 +28,15 @@ public class WantedJobDetailResponse {
         this.jobCategory = jobCategory;
     }
 
+    private LocalDateTime getDeadlineDate(String deadlineDateString) {
+        return Optional.ofNullable(deadlineDateString)
+            .map(str -> {
+                DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+                return LocalDate.parse(this.job.deadlineDate, formatter).atStartOfDay();
+            })
+            .orElse(null);
+    }
+
     public WantedJd toWantedJdEntity() {
         return WantedJd.builder()
             .jobCategory(this.getJobCategory())
@@ -36,6 +50,8 @@ public class WantedJobDetailResponse {
             .intro(this.getJob().getDetail().getIntro())
             .benefits(this.getJob().getDetail().getBenefits())
             .preferredPoints(this.getJob().getDetail().getPreferredPoints())
+            .wantedJdStatus(WantedJdActiveStatus.OPEN)
+            .deadlineDate(getDeadlineDate(this.job.deadlineDate))
             .build();
     }
 
@@ -51,6 +67,8 @@ public class WantedJobDetailResponse {
         private List<WantedSkill> skill;
         @JsonProperty("company_images")
         private List<CompanyImages> companyImages;
+        @JsonProperty("due_time")
+        private String deadlineDate;
 
         public String getCompanyImages() {
             return String.valueOf(companyImages.get(0).url);

--- a/module-crawler/src/main/java/kernel/jdon/modulecrawler/wanted/dto/response/WantedJobDetailResponse.java
+++ b/module-crawler/src/main/java/kernel/jdon/modulecrawler/wanted/dto/response/WantedJobDetailResponse.java
@@ -39,17 +39,17 @@ public class WantedJobDetailResponse {
 
     public WantedJd toWantedJdEntity() {
         return WantedJd.builder()
-            .jobCategory(this.getJobCategory())
-            .companyName(this.getJob().getCompany().getName())
-            .title(this.getJob().getTitle())
-            .detailId(this.getJob().getId())
-            .detailUrl(this.getDetailUrl())
-            .imageUrl(this.getJob().getCompanyImages())
-            .requirements(this.getJob().getDetail().getRequirements())
-            .mainTasks(this.getJob().getDetail().getMainTasks())
-            .intro(this.getJob().getDetail().getIntro())
-            .benefits(this.getJob().getDetail().getBenefits())
-            .preferredPoints(this.getJob().getDetail().getPreferredPoints())
+            .jobCategory(this.jobCategory)
+            .companyName(this.job.company.name)
+            .title(this.job.title)
+            .detailId(this.job.id)
+            .detailUrl(this.detailUrl)
+            .imageUrl(this.job.getFirstCompanyImage())
+            .requirements(this.job.detail.requirements)
+            .mainTasks(this.job.detail.mainTasks)
+            .intro(this.job.detail.intro)
+            .benefits(this.job.detail.benefits)
+            .preferredPoints(this.job.detail.preferredPoints)
             .wantedJdStatus(WantedJdActiveStatus.OPEN)
             .deadlineDate(getDeadlineDate(this.job.deadlineDate))
             .build();
@@ -70,7 +70,7 @@ public class WantedJobDetailResponse {
         @JsonProperty("due_time")
         private String deadlineDate;
 
-        public String getCompanyImages() {
+        public String getFirstCompanyImage() {
             return String.valueOf(companyImages.get(0).url);
         }
     }


### PR DESCRIPTION
## 개요

### 요약
- 원티드 채용공고 스크래핑 항목에 마감일자 항목 추가
### 변경한 부분
- 원티드 채용공고 상세 DTO에 마감일자 `deadlineDate` 필드를 추가했습니다.
  - 원티드에서는  `due_time`로 주지만 저희 서비스에서는 `deadlineDate`를 사용합니다.
  - 상시채용일 경우 마감일자가 null이기 때문에 문자열인 `deadlineDate`가 null일 경우 null을 반환하고 아니라면 LocalDateTime으로 형변환하여 반환하는 getDeadlineDate 메서드를 추가했습니다.
- WantedJd 엔티티 생성 시 WantedJdActiveStatus을 OPEN 값으로 생성하도록 코드를 추가했습니다.

### 변경한 결과
원티드 채용공고 상태코드, 마감일자 항목 정상 추가 확인했습니다.
<img width="1102" alt="image" src="https://github.com/Kernel360/f1-JDON-Backend/assets/59242594/bcfe6587-a7de-4476-a204-c8c59bf2d562">

### 이슈

- closes: #476 

---

## PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경, 주석 변경)
- [ ] 코드 리팩토링
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 파일 혹은 폴더명 수정, 삭제
- [ ] 배포 관련