### PR TITLE
Fix: oauth2 인증 중 error 처리 로직과 ci-cd event trigger 수정

### DIFF
--- a/.github/workflows/dev-cicd.yml
+++ b/.github/workflows/dev-cicd.yml
@@ -49,7 +49,6 @@ jobs:
     needs: integration
     runs-on: ubuntu-latest
     if: >
-      github.event.pull_request.merged == true &&
       !contains(join(github.event.pull_request.labels.*.name, ','), 'NO-Deploy')
     steps:
       - name: Deploy to Dev-EC2

--- a/.github/workflows/dev-cicd.yml
+++ b/.github/workflows/dev-cicd.yml
@@ -2,7 +2,7 @@ name: JDON-Backend DEV CI-CD
 
 on:
   push:
-    branches: [ develop, feature/#448-ci-cd ]
+    branches: [ develop, feaure/#448-cicd ]
   pull_request:
     types: [ opened, closed ]
     branches: [ develop ]

--- a/.github/workflows/dev-cicd.yml
+++ b/.github/workflows/dev-cicd.yml
@@ -2,9 +2,6 @@ name: JDON-Backend DEV CI-CD
 
 on:
   push:
-    branches: [ develop, feaure/#448-cicd ]
-  pull_request:
-    types: [ opened, closed ]
     branches: [ develop ]
 
 permissions:

--- a/.github/workflows/dev-cicd.yml
+++ b/.github/workflows/dev-cicd.yml
@@ -1,6 +1,8 @@
 name: JDON-Backend DEV CI-CD
 
 on:
+  push:
+    branches: [ develop, feature/#448-ci-cd ]
   pull_request:
     types: [ opened, closed ]
     branches: [ develop ]

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/auth/infrastructure/KakaoOAuth2StrategyImpl.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/auth/infrastructure/KakaoOAuth2StrategyImpl.java
@@ -17,7 +17,7 @@ import org.springframework.web.util.UriComponentsBuilder;
 
 import kernel.jdon.moduleapi.domain.auth.core.OAuth2Strategy;
 import kernel.jdon.moduleapi.domain.member.core.MemberCommand;
-import kernel.jdon.moduleapi.global.config.auth.WithdrawProperties;
+import kernel.jdon.moduleapi.global.config.auth.properties.WithdrawProperties;
 import kernel.jdon.moduleapi.global.dto.SessionUserInfo;
 import kernel.jdon.moduledomain.member.domain.SocialProviderType;
 import lombok.RequiredArgsConstructor;

--- a/module-api/src/main/java/kernel/jdon/moduleapi/global/config/auth/JdonOAuth2AuthenticationSuccessHandler.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/global/config/auth/JdonOAuth2AuthenticationSuccessHandler.java
@@ -15,6 +15,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import kernel.jdon.moduleapi.domain.auth.core.JdonOAuth2User;
 import kernel.jdon.moduleapi.domain.auth.util.CryptoManager;
+import kernel.jdon.moduleapi.global.config.auth.properties.LoginRedirectUrlProperties;
 import kernel.jdon.moduledomain.member.domain.MemberRole;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;

--- a/module-api/src/main/java/kernel/jdon/moduleapi/global/config/auth/OAuth2SecurityConfig.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/global/config/auth/OAuth2SecurityConfig.java
@@ -17,6 +17,7 @@ import org.springframework.web.cors.CorsConfiguration;
 
 import jakarta.servlet.http.HttpServletRequest;
 import kernel.jdon.moduleapi.domain.auth.core.CustomOAuth2UserServiceImpl;
+import kernel.jdon.moduleapi.global.config.auth.properties.AllowOriginProperties;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 

--- a/module-api/src/main/java/kernel/jdon/moduleapi/global/config/auth/properties/AllowOriginProperties.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/global/config/auth/properties/AllowOriginProperties.java
@@ -1,4 +1,4 @@
-package kernel.jdon.moduleapi.global.config.auth;
+package kernel.jdon.moduleapi.global.config.auth.properties;
 
 import java.util.List;
 

--- a/module-api/src/main/java/kernel/jdon/moduleapi/global/config/auth/properties/LoginRedirectUrlProperties.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/global/config/auth/properties/LoginRedirectUrlProperties.java
@@ -1,4 +1,4 @@
-package kernel.jdon.moduleapi.global.config.auth;
+package kernel.jdon.moduleapi.global.config.auth.properties;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
 

--- a/module-api/src/main/java/kernel/jdon/moduleapi/global/config/auth/properties/WithdrawProperties.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/global/config/auth/properties/WithdrawProperties.java
@@ -1,4 +1,4 @@
-package kernel.jdon.moduleapi.global.config.auth;
+package kernel.jdon.moduleapi.global.config.auth.properties;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
 


### PR DESCRIPTION
## 개요

### 요약

### 변경한 부분
- cicd event trigger 변경
- auth 관련 properties를 package로 묶어서 관리
- oauth2 인증 과정 중 발생하는 에러를 처리하는 로직을 refactor

### 변경한 결과
- 이제 develop 브랜치에 push 할 때마다 개발서버에 자동 배포할 수 있습니다. 
   - 만일 자동 배포하고 싶지 않다! -> label에서 NO-Deploy를 등록하시면 됩니다. 

### 이슈

- closes: #480 

---

## PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경, 주석 변경)
- [ ] 코드 리팩토링
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 파일 혹은 폴더명 수정, 삭제
- [x] 배포 관련