### PR TITLE
Fix: WantedJdActiveStatus `ALWAYS` 상수 추가

### DIFF
--- a/module-crawler/src/main/java/kernel/jdon/modulecrawler/wanted/dto/response/WantedJobDetailResponse.java
+++ b/module-crawler/src/main/java/kernel/jdon/modulecrawler/wanted/dto/response/WantedJobDetailResponse.java
@@ -33,7 +33,7 @@ public class WantedJobDetailResponse {
         return Optional.ofNullable(deadlineDateString)
             .map(str -> {
                 DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
-                return LocalDate.parse(this.job.deadlineDate, formatter).atStartOfDay();
+                return LocalDate.parse(this.job.deadlineDate, formatter).plusDays(1).atStartOfDay();
             })
             .orElse(null);
     }

--- a/module-crawler/src/main/java/kernel/jdon/modulecrawler/wanted/dto/response/WantedJobDetailResponse.java
+++ b/module-crawler/src/main/java/kernel/jdon/modulecrawler/wanted/dto/response/WantedJobDetailResponse.java
@@ -1,5 +1,7 @@
 package kernel.jdon.modulecrawler.wanted.dto.response;
 
+import static kernel.jdon.moduledomain.wantedjd.domain.WantedJdActiveStatus.*;
+
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
@@ -10,7 +12,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 import kernel.jdon.moduledomain.jobcategory.domain.JobCategory;
 import kernel.jdon.moduledomain.wantedjd.domain.WantedJd;
-import kernel.jdon.moduledomain.wantedjd.domain.WantedJdActiveStatus;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -50,7 +51,7 @@ public class WantedJobDetailResponse {
             .intro(this.job.detail.intro)
             .benefits(this.job.detail.benefits)
             .preferredPoints(this.job.detail.preferredPoints)
-            .wantedJdStatus(WantedJdActiveStatus.OPEN)
+            .wantedJdStatus(getWantedJdActiveStatus(this.job.deadlineDate))
             .deadlineDate(getDeadlineDate(this.job.deadlineDate))
             .build();
     }

--- a/module-domain/src/main/java/kernel/jdon/moduledomain/wantedjd/domain/WantedJdActiveStatus.java
+++ b/module-domain/src/main/java/kernel/jdon/moduledomain/wantedjd/domain/WantedJdActiveStatus.java
@@ -1,13 +1,30 @@
 package kernel.jdon.moduledomain.wantedjd.domain;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Optional;
+
 public enum WantedJdActiveStatus {
     OPEN("모집중"),
-    CLOSE("모집종료");
+    CLOSE("모집종료"),
+    ALWAYS("상시채용");
 
     private final String activeStatus;
 
     WantedJdActiveStatus(String activeStatus) {
         this.activeStatus = activeStatus;
+    }
+
+    public static WantedJdActiveStatus getWantedJdActiveStatus(String deadLineDateToString) {
+        return Optional.ofNullable(deadLineDateToString)
+            .map(str -> {
+                DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+                LocalDateTime deadLineDate = LocalDate.parse(deadLineDateToString, formatter).atStartOfDay();
+                LocalDateTime today = LocalDateTime.now();
+                return today.isBefore(deadLineDate) || today.isEqual(deadLineDate) ? OPEN : CLOSE;
+            })
+            .orElse(ALWAYS);
     }
 
     public String getActiveStatus() {


### PR DESCRIPTION
## 개요

### 요약
- WantedJdActiveStatus 클래스'상시채용' 상수를 추가했습니다.
- 원티트 채용공고 스크래핑 시 마감일자 항목이 null로 넘어올 경우 WantedJdActiveStatus `상시채용` 상수로 바인딩하여 저장되도록 수정했습니다.

### 변경한 부분
- WantedJdActiveStatus 열거형 클래스에 상시채용을 의미하는 `ALWAYS` 필드를 추가했습니다.'
- 원티트 채용공고 스크래핑 시 마감일자 항목이 null로 넘어올 경우 WantedJdActiveStatus `ALWAYS` 상수로 바인딩하여 저장되도록 수정했습니다.
- 기존에 마감일자를 체크하는 로직은 LocalDateTime.now()와 비교 했기 때문에
- 원티드에서 스크래핑한 마감일자는 문자열로 들어오기 때문에 마감일자가 2024-03-18 이라면 2024-03-18 00:00:00으로 DB에 저장하고 있었습니다. 기존 마감일자를 체크하여 원티드 채용공고 상태코드를 계산하는 로직은 LocalDateTime.now()와 2024-03-18 00:00:00 형식을 비교하여 계산했었는데, 마감 당일인경우 2024-03-18 00:00:00보다 이후이기에 잘못된 상태코드를 저장하는 장애가 있었습니다. 따라서 원티드에서 가져온 마감일자 `deadline_date`를 DB에 생성할 때 `deadlineDate` + 1 하여 등록하도록 변경했습니다.

### 변경한 결과
로컬에서 스크래핑시 정상 등록 확인했습니다.
<img width="587" alt="image" src="https://github.com/Kernel360/f1-JDON-Backend/assets/59242594/5d48039a-6577-4143-838b-728a866564ec">

### 이슈

- closes: #483 

---

## PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경, 주석 변경)
- [ ] 코드 리팩토링
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 파일 혹은 폴더명 수정, 삭제
- [ ] 배포 관련