### PR TITLE
Fix: WantedJd 생성 로직 캡슐화

### DIFF
--- a/module-crawler/src/main/java/kernel/jdon/modulecrawler/wanted/dto/response/WantedJobDetailResponse.java
+++ b/module-crawler/src/main/java/kernel/jdon/modulecrawler/wanted/dto/response/WantedJobDetailResponse.java
@@ -1,12 +1,6 @@
 package kernel.jdon.modulecrawler.wanted.dto.response;
 
-import static kernel.jdon.moduledomain.wantedjd.domain.WantedJdActiveStatus.*;
-
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
 import java.util.List;
-import java.util.Optional;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
@@ -29,31 +23,21 @@ public class WantedJobDetailResponse {
         this.jobCategory = jobCategory;
     }
 
-    private LocalDateTime getDeadlineDate(String deadlineDateString) {
-        return Optional.ofNullable(deadlineDateString)
-            .map(str -> {
-                DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
-                return LocalDate.parse(this.job.deadlineDate, formatter).plusDays(1).atStartOfDay();
-            })
-            .orElse(null);
-    }
-
     public WantedJd toWantedJdEntity() {
-        return WantedJd.builder()
-            .jobCategory(this.jobCategory)
-            .companyName(this.job.company.name)
-            .title(this.job.title)
-            .detailId(this.job.id)
-            .detailUrl(this.detailUrl)
-            .imageUrl(this.job.getFirstCompanyImage())
-            .requirements(this.job.detail.requirements)
-            .mainTasks(this.job.detail.mainTasks)
-            .intro(this.job.detail.intro)
-            .benefits(this.job.detail.benefits)
-            .preferredPoints(this.job.detail.preferredPoints)
-            .wantedJdStatus(getWantedJdActiveStatus(this.job.deadlineDate))
-            .deadlineDate(getDeadlineDate(this.job.deadlineDate))
-            .build();
+        return new WantedJd(
+            this.job.company.name,
+            this.job.title,
+            this.job.id,
+            this.detailUrl,
+            this.job.getFirstCompanyImage(),
+            this.job.detail.requirements,
+            this.job.detail.mainTasks,
+            this.job.detail.intro,
+            this.job.detail.benefits,
+            this.job.detail.preferredPoints,
+            this.job.deadlineDate,
+            this.jobCategory
+        );
     }
 
     @Getter

--- a/module-domain/src/main/java/kernel/jdon/moduledomain/wantedjd/domain/WantedJd.java
+++ b/module-domain/src/main/java/kernel/jdon/moduledomain/wantedjd/domain/WantedJd.java
@@ -1,8 +1,13 @@
 package kernel.jdon.moduledomain.wantedjd.domain;
 
+import static kernel.jdon.moduledomain.wantedjd.domain.WantedJdActiveStatus.*;
+
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -22,7 +27,6 @@ import kernel.jdon.moduledomain.jobcategory.domain.JobCategory;
 import kernel.jdon.moduledomain.review.domain.Review;
 import kernel.jdon.moduledomain.wantedjdskill.domain.WantedJdSkill;
 import lombok.AccessLevel;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -83,10 +87,9 @@ public class WantedJd extends AbstractEntity {
     @OneToMany(mappedBy = "wantedJd")
     private List<Review> reviewList = new ArrayList<>();
 
-    @Builder
     public WantedJd(String companyName, String title, Long detailId, String detailUrl, String imageUrl,
         String requirements, String mainTasks, String intro, String benefits, String preferredPoints,
-        LocalDateTime deadlineDate, WantedJdActiveStatus wantedJdStatus, JobCategory jobCategory) {
+        String deadlineDate, JobCategory jobCategory) {
         this.companyName = companyName;
         this.title = title;
         this.detailId = detailId;
@@ -97,8 +100,17 @@ public class WantedJd extends AbstractEntity {
         this.intro = intro;
         this.benefits = benefits;
         this.preferredPoints = preferredPoints;
-        this.deadlineDate = deadlineDate;
-        this.wantedJdStatus = wantedJdStatus;
+        this.deadlineDate = getDeadlineDate(deadlineDate);
         this.jobCategory = jobCategory;
+        this.wantedJdStatus = getWantedJdActiveStatus(deadlineDate);
+    }
+
+    private LocalDateTime getDeadlineDate(String deadlineDateString) {
+        return Optional.ofNullable(deadlineDateString)
+            .map(str -> {
+                DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+                return LocalDate.parse(deadlineDateString, formatter).plusDays(1).atStartOfDay();
+            })
+            .orElse(null);
     }
 }


### PR DESCRIPTION
## 개요

### 요약

### 변경한 부분
- WantedJd 엔티티의 생성자에 @builder 어노테이션을 제거했습니다.
- WantedJobDetailResponse에 존재하는 WantedJd의 생성 관련 로직을 WantedJd 이동 시키고 캡슐화 하였습니다.

### 변경한 결과
엔티티 정상 등록 확인했습니다.
<img width="555" alt="image" src="https://github.com/Kernel360/f1-JDON-Backend/assets/59242594/771a5c54-fa8f-4f60-bec8-b9e00e90e222">


### 이슈

- closes: #485

---

## PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경, 주석 변경)
- [ ] 코드 리팩토링
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 파일 혹은 폴더명 수정, 삭제
- [ ] 배포 관련