### PR TITLE
BugFix: cryptoManaget에서 aes의 iv 키 길이 에러 수정

### DIFF
--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/auth/util/CryptoManager.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/auth/util/CryptoManager.java
@@ -40,7 +40,7 @@ public class CryptoManager {
     private Cipher getCipher(final int mode) throws Exception {
         final SecretKeySpec secretKey = new SecretKeySpec(
             cryptoProperties.getAesPrivateKeyByByte(), cryptoProperties.getCryptoAlgorithm());
-        final IvParameterSpec IV = new IvParameterSpec(cryptoProperties.getAesPrivateKeyByByte());
+        final IvParameterSpec IV = new IvParameterSpec(cryptoProperties.getAesIVByByte());
         final Cipher cipher = Cipher.getInstance(cryptoProperties.getCryptoTransformation());
         cipher.init(mode, secretKey, IV);
 

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/auth/util/CryptoProperties.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/auth/util/CryptoProperties.java
@@ -21,6 +21,10 @@ public class CryptoProperties {
         return aesPrivateKey.getBytes(StandardCharsets.UTF_8);
     }
 
+    public byte[] getAesIVByByte() {
+        return aesPrivateKey.substring(0, 16).getBytes(StandardCharsets.UTF_8);
+    }
+
     public byte[] getHmacPrivateKeyByByte() {
         return hmacPrivateKey.getBytes(StandardCharsets.UTF_8);
     }


### PR DESCRIPTION
## 개요

### 요약

### 변경한 부분
iv의 길이가 16자 이하여야 하는데 제한을 두지 않아서 암호문을 생성하지 못하는 에러가 발생하여 수정했습니다. 

### 변경한 결과
![image](https://github.com/Kernel360/f1-JDON-Backend/assets/68376744/ac5f37ae-ca13-48f1-997b-2f5642d7e1bc)
회원가입 시 info 뒤에 null로 들어오던 에러가 수정되었습니다. 

### 이슈

- closes: #

---

## PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경, 주석 변경)
- [ ] 코드 리팩토링
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 파일 혹은 폴더명 수정, 삭제
- [ ] 배포 관련