### PR TITLE
Fix: RestTemplate Timeout 설정

### DIFF
--- a/module-crawler/build.gradle
+++ b/module-crawler/build.gradle
@@ -27,6 +27,9 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
 
+    // restTemplate retry
+    implementation 'org.springframework.retry:spring-retry:1.2.5.RELEASE'
+
     runtimeOnly 'com.mysql:mysql-connector-j'
 
     compileOnly 'org.projectlombok:lombok'
@@ -34,6 +37,7 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok'
 
     implementation group: 'org.jsoup', name: 'jsoup', version: '1.17.1'
+
 
     // test
     testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/module-crawler/src/main/java/kernel/jdon/modulecrawler/config/RestTemplateConfig.java
+++ b/module-crawler/src/main/java/kernel/jdon/modulecrawler/config/RestTemplateConfig.java
@@ -5,7 +5,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.web.client.RestTemplate;
 
 @Configuration
-public class AppConfig {
+public class RestTemplateConfig {
     @Bean
     public RestTemplate restTemplate() {
         return new RestTemplate();

--- a/module-crawler/src/main/java/kernel/jdon/modulecrawler/config/RestTemplateConfig.java
+++ b/module-crawler/src/main/java/kernel/jdon/modulecrawler/config/RestTemplateConfig.java
@@ -1,13 +1,45 @@
 package kernel.jdon.modulecrawler.config;
 
+import java.time.Duration;
+
+import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.ClientHttpRequestInterceptor;
+import org.springframework.retry.policy.SimpleRetryPolicy;
+import org.springframework.retry.support.RetryTemplate;
 import org.springframework.web.client.RestTemplate;
 
+import kernel.jdon.modulecrawler.global.error.code.CrawlerServerErrorCode;
+import kernel.jdon.modulecrawler.global.error.exception.CrawlerException;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
 @Configuration
 public class RestTemplateConfig {
+
     @Bean
-    public RestTemplate restTemplate() {
-        return new RestTemplate();
+    public RestTemplate restTemplate(RestTemplateBuilder restTemplateBuilder) {
+        final int connectTimeoutSecond = 5;
+        final int readTimeoutSecond = 5;
+        return restTemplateBuilder
+            .setConnectTimeout(Duration.ofSeconds(connectTimeoutSecond))
+            .setReadTimeout(Duration.ofSeconds(readTimeoutSecond))
+            .additionalInterceptors(clientHttpRequestInterceptor())
+            .build();
+    }
+
+    public ClientHttpRequestInterceptor clientHttpRequestInterceptor() {
+        final int retryCount = 3;
+        return (request, body, execution) -> {
+            RetryTemplate retryTemplate = new RetryTemplate();
+            retryTemplate.setRetryPolicy(new SimpleRetryPolicy(retryCount));
+            try {
+                return retryTemplate.execute(context -> execution.execute(request, body));
+            } catch (Throwable throwable) {
+                log.error("AppConfig.clientHttpRequestInterceptor {}", "restTemplate retry 중 Error 발생");
+                throw new CrawlerException((CrawlerServerErrorCode.INTERNAL_SERVER_ERROR_REST_TEMPLATE_RETRY));
+            }
+        };
     }
 }

--- a/module-crawler/src/main/java/kernel/jdon/modulecrawler/global/error/code/CrawlerServerErrorCode.java
+++ b/module-crawler/src/main/java/kernel/jdon/modulecrawler/global/error/code/CrawlerServerErrorCode.java
@@ -1,0 +1,38 @@
+package kernel.jdon.modulecrawler.global.error.code;
+
+import org.springframework.http.HttpStatus;
+
+import kernel.jdon.modulecommon.error.ErrorCode;
+import kernel.jdon.modulecrawler.global.error.exception.BaseThrowException;
+import kernel.jdon.modulecrawler.global.error.exception.CrawlerException;
+import lombok.AllArgsConstructor;
+
+@AllArgsConstructor
+public enum CrawlerServerErrorCode implements ErrorCode,
+    BaseThrowException<CrawlerServerErrorCode.CrawlerServerBaseException> {
+    INTERNAL_SERVER_ERROR_REST_TEMPLATE_RETRY(HttpStatus.INTERNAL_SERVER_ERROR, "RestTemplate Retry 중 서버 에러가 발생했습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+
+    @Override
+    public HttpStatus getHttpStatus() {
+        return httpStatus;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+
+    @Override
+    public CrawlerServerBaseException throwException() {
+        return new CrawlerServerBaseException(this);
+    }
+
+    public class CrawlerServerBaseException extends CrawlerException {
+        public CrawlerServerBaseException(CrawlerServerErrorCode crawlerServerErrorCode) {
+            super(crawlerServerErrorCode);
+        }
+    }
+}

--- a/module-crawler/src/main/java/kernel/jdon/modulecrawler/global/error/exception/BaseThrowException.java
+++ b/module-crawler/src/main/java/kernel/jdon/modulecrawler/global/error/exception/BaseThrowException.java
@@ -1,0 +1,5 @@
+package kernel.jdon.modulecrawler.global.error.exception;
+
+public interface BaseThrowException<T> {
+    T throwException();
+}

--- a/module-crawler/src/main/java/kernel/jdon/modulecrawler/global/error/exception/CrawlerException.java
+++ b/module-crawler/src/main/java/kernel/jdon/modulecrawler/global/error/exception/CrawlerException.java
@@ -10,4 +10,9 @@ public class CrawlerException extends RuntimeException {
     public CrawlerException(ErrorCode errorCode) {
         this.errorCode = errorCode;
     }
+
+    public CrawlerException(ErrorCode errorCode, Throwable cause) {
+        super(errorCode.getMessage(), cause);
+        this.errorCode = errorCode;
+    }
 }


### PR DESCRIPTION
## 개요

### 요약
RestTemplate Timeout을 설정 했습니다.

### 변경한 부분
- 프로젝트 초반 `AppConfig`라는 이름으로 생성했던 RestTemplate을 Bean으로 등록하는 Config 클래스 파일의 이름을 `RestTemplateConfig`로 변경하였습니다.
- RestTemplate Timeout 과 Retry설정을 추가했습니다.

참고한 블로그 공유드립니다.
[[Spring] RestTemplate 타임아웃(Timeout), 재시도(Retry), 로깅(Logging) 등 설정하기](https://mangkyu.tistory.com/256)

### 변경한 결과

### 이슈

- closes: #493 

---

## PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경, 주석 변경)
- [ ] 코드 리팩토링
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 파일 혹은 폴더명 수정, 삭제
- [ ] 배포 관련