### PR TITLE
Chore: BaseThrowException common 모듈로 이동

### DIFF
--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/auth/error/AuthErrorCode.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/auth/error/AuthErrorCode.java
@@ -3,7 +3,7 @@ package kernel.jdon.moduleapi.domain.auth.error;
 import org.springframework.http.HttpStatus;
 
 import kernel.jdon.moduleapi.global.exception.ApiException;
-import kernel.jdon.moduleapi.global.exception.BaseThrowException;
+import kernel.jdon.modulecommon.error.BaseThrowException;
 import kernel.jdon.modulecommon.error.ErrorCode;
 import lombok.RequiredArgsConstructor;
 

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/coffeechat/error/CoffeeChatErrorCode.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/coffeechat/error/CoffeeChatErrorCode.java
@@ -3,7 +3,7 @@ package kernel.jdon.moduleapi.domain.coffeechat.error;
 import org.springframework.http.HttpStatus;
 
 import kernel.jdon.moduleapi.global.exception.ApiException;
-import kernel.jdon.moduleapi.global.exception.BaseThrowException;
+import kernel.jdon.modulecommon.error.BaseThrowException;
 import kernel.jdon.modulecommon.error.ErrorCode;
 import lombok.AllArgsConstructor;
 

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/faq/error/FaqErrorCode.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/faq/error/FaqErrorCode.java
@@ -3,7 +3,7 @@ package kernel.jdon.moduleapi.domain.faq.error;
 import org.springframework.http.HttpStatus;
 
 import kernel.jdon.moduleapi.global.exception.ApiException;
-import kernel.jdon.moduleapi.global.exception.BaseThrowException;
+import kernel.jdon.modulecommon.error.BaseThrowException;
 import kernel.jdon.modulecommon.error.ErrorCode;
 import lombok.AllArgsConstructor;
 

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/favorite/error/FavoriteErrorCode.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/favorite/error/FavoriteErrorCode.java
@@ -3,7 +3,7 @@ package kernel.jdon.moduleapi.domain.favorite.error;
 import org.springframework.http.HttpStatus;
 
 import kernel.jdon.moduleapi.global.exception.ApiException;
-import kernel.jdon.moduleapi.global.exception.BaseThrowException;
+import kernel.jdon.modulecommon.error.BaseThrowException;
 import kernel.jdon.modulecommon.error.ErrorCode;
 import lombok.AllArgsConstructor;
 

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/inflearncourse/error/InflearncourseErrorCode.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/inflearncourse/error/InflearncourseErrorCode.java
@@ -3,7 +3,7 @@ package kernel.jdon.moduleapi.domain.inflearncourse.error;
 import org.springframework.http.HttpStatus;
 
 import kernel.jdon.moduleapi.global.exception.ApiException;
-import kernel.jdon.moduleapi.global.exception.BaseThrowException;
+import kernel.jdon.modulecommon.error.BaseThrowException;
 import kernel.jdon.modulecommon.error.ErrorCode;
 import lombok.AllArgsConstructor;
 

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/jd/error/JdErrorCode.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/jd/error/JdErrorCode.java
@@ -3,7 +3,7 @@ package kernel.jdon.moduleapi.domain.jd.error;
 import org.springframework.http.HttpStatus;
 
 import kernel.jdon.moduleapi.global.exception.ApiException;
-import kernel.jdon.moduleapi.global.exception.BaseThrowException;
+import kernel.jdon.modulecommon.error.BaseThrowException;
 import kernel.jdon.modulecommon.error.ErrorCode;
 import lombok.RequiredArgsConstructor;
 

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/jobcategory/error/JobCategoryErrorCode.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/jobcategory/error/JobCategoryErrorCode.java
@@ -3,7 +3,7 @@ package kernel.jdon.moduleapi.domain.jobcategory.error;
 import org.springframework.http.HttpStatus;
 
 import kernel.jdon.moduleapi.global.exception.ApiException;
-import kernel.jdon.moduleapi.global.exception.BaseThrowException;
+import kernel.jdon.modulecommon.error.BaseThrowException;
 import kernel.jdon.modulecommon.error.ErrorCode;
 import lombok.RequiredArgsConstructor;
 

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/member/error/MemberErrorCode.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/member/error/MemberErrorCode.java
@@ -3,7 +3,7 @@ package kernel.jdon.moduleapi.domain.member.error;
 import org.springframework.http.HttpStatus;
 
 import kernel.jdon.moduleapi.global.exception.ApiException;
-import kernel.jdon.moduleapi.global.exception.BaseThrowException;
+import kernel.jdon.modulecommon.error.BaseThrowException;
 import kernel.jdon.modulecommon.error.ErrorCode;
 import lombok.RequiredArgsConstructor;
 

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/review/error/ReviewErrorCode.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/review/error/ReviewErrorCode.java
@@ -3,7 +3,7 @@ package kernel.jdon.moduleapi.domain.review.error;
 import org.springframework.http.HttpStatus;
 
 import kernel.jdon.moduleapi.global.exception.ApiException;
-import kernel.jdon.moduleapi.global.exception.BaseThrowException;
+import kernel.jdon.modulecommon.error.BaseThrowException;
 import kernel.jdon.modulecommon.error.ErrorCode;
 import lombok.AllArgsConstructor;
 

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/skill/error/SkillErrorCode.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/skill/error/SkillErrorCode.java
@@ -3,7 +3,7 @@ package kernel.jdon.moduleapi.domain.skill.error;
 import org.springframework.http.HttpStatus;
 
 import kernel.jdon.moduleapi.global.exception.ApiException;
-import kernel.jdon.moduleapi.global.exception.BaseThrowException;
+import kernel.jdon.modulecommon.error.BaseThrowException;
 import kernel.jdon.modulecommon.error.ErrorCode;
 import lombok.RequiredArgsConstructor;
 

--- a/module-common/src/main/java/kernel/jdon/modulecommon/error/BaseThrowException.java
+++ b/module-common/src/main/java/kernel/jdon/modulecommon/error/BaseThrowException.java
@@ -1,4 +1,4 @@
-package kernel.jdon.moduleapi.global.exception;
+package kernel.jdon.modulecommon.error;
 
 public interface BaseThrowException<T> {
     T throwException();

--- a/module-crawler/src/main/java/kernel/jdon/modulecrawler/global/error/code/CrawlerServerErrorCode.java
+++ b/module-crawler/src/main/java/kernel/jdon/modulecrawler/global/error/code/CrawlerServerErrorCode.java
@@ -2,8 +2,8 @@ package kernel.jdon.modulecrawler.global.error.code;
 
 import org.springframework.http.HttpStatus;
 
+import kernel.jdon.modulecommon.error.BaseThrowException;
 import kernel.jdon.modulecommon.error.ErrorCode;
-import kernel.jdon.modulecrawler.global.error.exception.BaseThrowException;
 import kernel.jdon.modulecrawler.global.error.exception.CrawlerException;
 import lombok.AllArgsConstructor;
 

--- a/module-crawler/src/main/java/kernel/jdon/modulecrawler/global/error/exception/BaseThrowException.java
+++ b/module-crawler/src/main/java/kernel/jdon/modulecrawler/global/error/exception/BaseThrowException.java
@@ -1,5 +1,0 @@
-package kernel.jdon.modulecrawler.global.error.exception;
-
-public interface BaseThrowException<T> {
-    T throwException();
-}


### PR DESCRIPTION
## 개요

### 요약
BaseThrowException common 모듈로 이동

### 변경한 부분
모든 에러코드를 구현할 때 사용하는 각 모듈에 위치했던 순수 자바 인터페이스 BaseThrowException를 Common 모듈로 이동시켰습니다.

### 변경한 결과

### 이슈

- closes: #

---

## PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경, 주석 변경)
- [ ] 코드 리팩토링
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 파일 혹은 폴더명 수정, 삭제
- [ ] 배포 관련