### PR TITLE
Hotfix: DateParserUtil localDateTimeToDateString 날짜 처리 수정

### DIFF
--- a/module-common/src/main/java/kernel/jdon/modulecommon/util/DateParserUtil.java
+++ b/module-common/src/main/java/kernel/jdon/modulecommon/util/DateParserUtil.java
@@ -2,6 +2,7 @@ package kernel.jdon.modulecommon.util;
 
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.Optional;
 
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
@@ -10,8 +11,11 @@ import lombok.NoArgsConstructor;
 public class DateParserUtil {
 
     public static String localDateTimeToDateString(final LocalDateTime localDateTime) {
-        final String toString = localDateTime.format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"));
-
-        return toString.substring(0, 10);
+        return Optional.ofNullable(localDateTime)
+            .map(item -> {
+                String localDateTimeToString = item.format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"));
+                return localDateTimeToString.substring(0, 10);
+            })
+            .orElse("");
     }
 }


### PR DESCRIPTION
## 개요

### 요약
deadlineDate가 null인 상시채용 JD의 상세 페이지에서 500에러 발생하는 것을 확인했습니다.
원인은 기존 DateParserUtil의 localDateTimeToDateString 메서드에서 매개변수로 받은 localDateTime의 null 체크 없이 String으로 캐스팅 하기 때문이었는데, null 체크 하도록 수정 했습니다.

### 변경한 부분
localDateTimeToDateString 메서드 매개변수가 null인 경우 빈 String 반환하도록 수정했습니다.

### 변경한 결과
- deadlineDate가 null일 경우 빈 문자열로 반환되도록 수정 후 확인했습니다.
![image](https://github.com/Kernel360/f1-JDON-Backend/assets/59242594/7d6331f4-a542-4f8b-af1f-009322d3f65a)


### 이슈

- closes: #

---

## PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경, 주석 변경)
- [ ] 코드 리팩토링
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 파일 혹은 폴더명 수정, 삭제
- [ ] 배포 관련