### PR TITLE
Fix: health check용 api securityConfig에 권한 허용

### DIFF
--- a/module-api/src/main/java/kernel/jdon/moduleapi/global/config/auth/OAuth2SecurityConfig.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/global/config/auth/OAuth2SecurityConfig.java
@@ -46,6 +46,7 @@ public class OAuth2SecurityConfig {
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         final String[] permitAllGET = {
+            "/actuator/health",
             "/oauth2/authorization/**",
             "/api/v1/coffeechats/**",
             "/api/v1/skills/hot",

--- a/module-api/src/main/resources/application-dev.yml
+++ b/module-api/src/main/resources/application-dev.yml
@@ -104,7 +104,7 @@ management:
       enabled: true
   endpoint:
     health:
-      show-details: always
+      show-details: never
   endpoints:
     web:
       exposure:

--- a/module-api/src/main/resources/application-local.yml
+++ b/module-api/src/main/resources/application-local.yml
@@ -101,7 +101,7 @@ management:
       enabled: true
   endpoint:
     health:
-      show-details: always
+      show-details: never
   endpoints:
     web:
       exposure:

--- a/module-api/src/main/resources/application-prod.yml
+++ b/module-api/src/main/resources/application-prod.yml
@@ -102,7 +102,7 @@ management:
       enabled: true
   endpoint:
     health:
-      show-details: always
+      show-details: never
   endpoints:
     web:
       exposure:


### PR DESCRIPTION
## 개요

### 요약
로드 밸런서에서 health check를 위해서 요청을 보내주는 api를 `/actuator/health`로 설정하고자 
 - `/actuator/health` 를 permitAll 로 열었습니다. 
 - 다만 서버 내부에 대한 정보를 최대한 숨기고자 서버의 상태만 응답 내용으로 담도록 application.yml을 수정했습니다. 

### 변경한 부분
- application-profile.yml 의 health.show-details를 never로 올렸습니다. 
- `GET /actuator/health` 를 permitAll 로 전체공개했습니다. 

### 변경한 결과
![image](https://github.com/Kernel360/f1-JDON-Backend/assets/68376744/b420af9c-87bd-4121-8725-d8c059cda4c2)


### 이슈

- closes: #516 

---

## PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경, 주석 변경)
- [ ] 코드 리팩토링
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 파일 혹은 폴더명 수정, 삭제
- [ ] 배포 관련