### PR TITLE
Chore: slack-appender 오타 수정

### DIFF
--- a/module-batch/src/main/resources/slack-appender-dev.xml
+++ b/module-batch/src/main/resources/slack-appender-dev.xml
@@ -6,7 +6,7 @@
             <pattern>
                 [Dev 배치 서버 에러 발생]
                 ${PID:-} --- [%15.15thread] %-40.40logger{36} %msg%n %n
-                * CURRENT_MODULE : MODULE-API %n
+                * CURRENT_MODULE : MODULE-BATCH %n
                 * REQUEST_ID : %X{REQUEST_ID:-NO REQUEST ID} %n
                 * REQUEST_METHOD : %X{REQUEST_METHOD:-NO REQUEST METHOD} %n
                 * REQUEST_URI : %X{REQUEST_URI:-NO REQUEST URI} %n

--- a/module-batch/src/main/resources/slack-appender-prod.xml
+++ b/module-batch/src/main/resources/slack-appender-prod.xml
@@ -6,7 +6,7 @@
             <pattern>
                 [Prod 배치 서버 에러 발생]
                 ${PID:-} --- [%15.15thread] %-40.40logger{36} %msg%n %n
-                * CURRENT_MODULE : MODULE-API %n
+                * CURRENT_MODULE : MODULE-BATCH %n
                 * REQUEST_ID : %X{REQUEST_ID:-NO REQUEST ID} %n
                 * REQUEST_METHOD : %X{REQUEST_METHOD:-NO REQUEST METHOD} %n
                 * REQUEST_URI : %X{REQUEST_URI:-NO REQUEST URI} %n


### PR DESCRIPTION
## 개요

### 요약
batch 모듈의 slack-appender 내부의 오타를 수정했습니다.

### 변경한 부분
BATCH 모듈 내부의 CURRENT_MODULE 을 API로 잘못 표기하고 있던 부분을 수정했습니다.


### 변경한 결과

### 이슈

- closes: #

---

## PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경, 주석 변경)
- [ ] 코드 리팩토링
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 파일 혹은 폴더명 수정, 삭제
- [ ] 배포 관련