### PR TITLE
Fix: 검색 키워드 길이 제한 validation 추가

### DIFF
--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/coffeechat/presentation/CoffeeChatController.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/coffeechat/presentation/CoffeeChatController.java
@@ -3,7 +3,9 @@ package kernel.jdon.moduleapi.domain.coffeechat.presentation;
 import java.net.URI;
 import java.util.Optional;
 
+import org.hibernate.validator.constraints.Length;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
@@ -28,6 +30,7 @@ import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @RestController
+@Validated
 @RequiredArgsConstructor
 public class CoffeeChatController {
 
@@ -38,7 +41,7 @@ public class CoffeeChatController {
     public ResponseEntity<CommonResponse<CoffeeChatInfo.FindCoffeeChatListResponse>> getCoffeeChatList(
         @ModelAttribute final PageInfoRequest pageInfoRequest,
         @RequestParam(value = "sort", defaultValue = "") final CoffeeChatSortType sort,
-        @RequestParam(value = "keyword", defaultValue = "") final String keyword,
+        @RequestParam(value = "keyword", defaultValue = "") @Length(max = 20) final String keyword,
         @RequestParam(value = "jobCategory", defaultValue = "") final Long jobCategory) {
         final CoffeeChatCommand.FindCoffeeChatListRequest request = coffeeChatDtoMapper.of(
             new CoffeeChatCondition(sort, keyword, jobCategory));

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/jd/presentation/JdController.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/jd/presentation/JdController.java
@@ -1,6 +1,8 @@
 package kernel.jdon.moduleapi.domain.jd.presentation;
 
+import org.hibernate.validator.constraints.Length;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -16,6 +18,7 @@ import kernel.jdon.modulecommon.dto.response.CommonResponse;
 import lombok.RequiredArgsConstructor;
 
 @RestController
+@Validated
 @RequiredArgsConstructor
 public class JdController {
     private final JdFacade jdFacade;
@@ -36,7 +39,7 @@ public class JdController {
         @RequestParam(value = "skill", defaultValue = "") final String skill,
         @RequestParam(value = "jobCategory", defaultValue = "") final Long jobCategory,
         @RequestParam(value = "keywordType", defaultValue = "") final JdSearchType keywordType,
-        @RequestParam(value = "keyword", defaultValue = "") final String keyword,
+        @RequestParam(value = "keyword", defaultValue = "") @Length(max = 20) final String keyword,
         @RequestParam(value = "sort", defaultValue = "") final JdSortType sort) {
         final JdInfo.FindWantedJdListResponse info = jdFacade.getJdList(pageInfoRequest,
             JdCondition.of(skill, jobCategory, keywordType, keyword, sort));

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/skill/presentation/SkillController.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/skill/presentation/SkillController.java
@@ -2,7 +2,9 @@ package kernel.jdon.moduleapi.domain.skill.presentation;
 
 import java.util.Optional;
 
+import org.hibernate.validator.constraints.Length;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -16,6 +18,7 @@ import kernel.jdon.modulecommon.dto.response.CommonResponse;
 import lombok.RequiredArgsConstructor;
 
 @RestController
+@Validated
 @RequiredArgsConstructor
 public class SkillController {
     private final SkillFacade skillFacade;
@@ -49,7 +52,7 @@ public class SkillController {
 
     @GetMapping("/api/v1/skills/search")
     public ResponseEntity<CommonResponse<SkillDto.FindDataListBySkillResponse>> getLectureListAndJdListBySkill(
-        @RequestParam(name = "keyword", defaultValue = "") final String keyword,
+        @RequestParam(name = "keyword", defaultValue = "") @Length(max = 20) final String keyword,
         @LoginUser final SessionUserInfo member) {
         final Long memberId = getSessionUserId(member);
         final SkillInfo.FindDataListBySkillResponse info = skillFacade.getDataListBySkill(keyword, memberId);

--- a/module-api/src/main/java/kernel/jdon/moduleapi/global/exception/GlobalExceptionHandler.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/global/exception/GlobalExceptionHandler.java
@@ -1,5 +1,7 @@
 package kernel.jdon.moduleapi.global.exception;
 
+import java.util.Optional;
+
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
@@ -7,6 +9,8 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.ConstraintViolationException;
 import kernel.jdon.modulecommon.dto.response.ErrorResponse;
 import lombok.extern.slf4j.Slf4j;
 
@@ -28,6 +32,17 @@ public class GlobalExceptionHandler {
         String firstErrorMessage = e.getBindingResult().getFieldErrors().get(0).getDefaultMessage();
         return ResponseEntity.status(e.getStatusCode())
             .body(ErrorResponse.of(e.getStatusCode(), firstErrorMessage, request));
+    }
+
+    @ExceptionHandler(ConstraintViolationException.class)
+    public ResponseEntity<ErrorResponse> handlerConstraintViolationException(ConstraintViolationException e,
+        HttpServletRequest request) {
+        log.warn(e.getMessage(), e);
+        final Optional<ConstraintViolation<?>> constraintViolation = e.getConstraintViolations().stream().findFirst();
+        final String firstErrorMessage = constraintViolation.isPresent() ? constraintViolation.get().getMessage()
+            : e.getMessage();
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+            .body(ErrorResponse.of(HttpStatus.BAD_REQUEST, firstErrorMessage, request));
     }
 
     @ExceptionHandler(AuthException.class)


### PR DESCRIPTION
## 개요

### 요약
검색 키워드를 길게 넣었을 때 414(URI Too Long) 에러가 발생하여 20자로 제한하는 validation을 추가했습니다. 

### 변경한 부분
`@RequestParam`으로 받고 있는 검색 키워드의 유효성 검증은 [다음과 같이](https://yulee.tistory.com/115) controller에 `@Validated`를 붙이고 파라미터에 직접 validation 어노테이션을 적용하면 됩니다. 

다만 이렇게 유효성 검증을 할 때 dto validation과 다르게 jakarta.validation 패키지의 `ConstraintViolationException`을 발생시킵니다. 이 Exception을 핸들링할 수 있도록 `ControllerAdvice`에 ConstraintViolationException을 핸들링하는 메서드를 추가했습니다.  

### 변경한 결과
![image](https://github.com/Kernel360/f1-JDON-Backend/assets/68376744/d66f9ef8-668b-4eb2-84bb-235460f3cffa)

### 이슈

- closes: #490 

---

## PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경, 주석 변경)
- [ ] 코드 리팩토링
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 파일 혹은 폴더명 수정, 삭제
- [ ] 배포 관련