### PR TITLE
Chore: logback-slack-appender 의존성 추가

### DIFF
--- a/module-common/build.gradle
+++ b/module-common/build.gradle
@@ -28,6 +28,7 @@ dependencies {
 
     // slack
     implementation 'com.slack.api:slack-api-client:1.30.0'
+    implementation 'com.github.maricn:logback-slack-appender:1.4.0'
 
     compileOnly 'org.projectlombok:lombok'
 


### PR DESCRIPTION
## 개요

### 요약
logback-slack-appender 의존성 추가

### 변경한 부분
이전 PR #539 에서 제거했던 logback-slack-appender 의존성을 추가했습니다.
이전 PR에서 logback-slack-appender 의존성을 제거한 이유는 slack-api-client만 선언하더라도 슬랙 알림에 문제가 없었다고 판단해서인데... logback 파일에 profile이 dev일 때 logback-slack-appender를 참조하도록 slack-appender.xml에 설정되있어서 로컬 환경에서는 확인이 안됐었습니다...

이전 PR을 dev에 배포하는 과정에서 logback-slack-appender을 찾을 수 없다는 로그가 확인되어 급히 의존성을 추가했습니다.

### 변경한 결과

### 이슈

- closes: #

---

## PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경, 주석 변경)
- [ ] 코드 리팩토링
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 파일 혹은 폴더명 수정, 삭제
- [ ] 배포 관련