### PR TITLE
Feature: 커피챗 만료처리 스케쥴링 적용

### DIFF
--- a/module-batch/src/main/java/kernel/jdon/modulebatch/domain/coffeechat/repository/CoffeeChatRepository.java
+++ b/module-batch/src/main/java/kernel/jdon/modulebatch/domain/coffeechat/repository/CoffeeChatRepository.java
@@ -1,6 +1,12 @@
 package kernel.jdon.modulebatch.domain.coffeechat.repository;
 
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+
 import kernel.jdon.moduledomain.coffeechat.repository.CoffeeChatDomainRepository;
 
 public interface CoffeeChatRepository extends CoffeeChatDomainRepository {
+    @Modifying
+    @Query("update CoffeeChat c set c.coffeeChatStatus = 'CLOSE' where c.meetDate < CURRENT_TIMESTAMP")
+    void updateStatusToCloseForPastCoffeeChats();
 }

--- a/module-batch/src/main/java/kernel/jdon/modulebatch/domain/coffeechat/repository/CoffeeChatRepository.java
+++ b/module-batch/src/main/java/kernel/jdon/modulebatch/domain/coffeechat/repository/CoffeeChatRepository.java
@@ -1,0 +1,6 @@
+package kernel.jdon.modulebatch.domain.coffeechat.repository;
+
+import kernel.jdon.moduledomain.coffeechat.repository.CoffeeChatDomainRepository;
+
+public interface CoffeeChatRepository extends CoffeeChatDomainRepository {
+}

--- a/module-batch/src/main/java/kernel/jdon/modulebatch/domain/coffeechat/repository/CoffeeChatRepository.java
+++ b/module-batch/src/main/java/kernel/jdon/modulebatch/domain/coffeechat/repository/CoffeeChatRepository.java
@@ -7,6 +7,6 @@ import kernel.jdon.moduledomain.coffeechat.repository.CoffeeChatDomainRepository
 
 public interface CoffeeChatRepository extends CoffeeChatDomainRepository {
     @Modifying
-    @Query("update CoffeeChat c set c.coffeeChatStatus = 'CLOSE' where c.meetDate < CURRENT_TIMESTAMP")
+    @Query("update CoffeeChat c set c.coffeeChatStatus = 'CLOSE' where c.coffeeChatStatus <> 'CLOSE' and c.meetDate < CURRENT_TIMESTAMP")
     void updateStatusToCloseForPastCoffeeChats();
 }

--- a/module-batch/src/main/java/kernel/jdon/modulebatch/scheduler/CoffeeChatScheduler.java
+++ b/module-batch/src/main/java/kernel/jdon/modulebatch/scheduler/CoffeeChatScheduler.java
@@ -20,8 +20,8 @@ public class CoffeeChatScheduler {
     @Scheduled(cron = "0 30 * * * ?")
     public void expirePastCoffeeChats() {
         log.info("[expirePastCoffeeChats] 스케쥴러 실행");
+        slackSender.sendSchedulerStart("expirePastCoffeeChats");
         try {
-            slackSender.sendSchedulerStart("expirePastCoffeeChats");
             coffeeChatRepository.updateStatusToCloseForPastCoffeeChats();
         } catch (Exception e) {
             log.error("[expirePastCoffeeChats] 스케쥴러 실행 중 Error 발생", e);

--- a/module-batch/src/main/java/kernel/jdon/modulebatch/scheduler/CoffeeChatScheduler.java
+++ b/module-batch/src/main/java/kernel/jdon/modulebatch/scheduler/CoffeeChatScheduler.java
@@ -15,8 +15,13 @@ public class CoffeeChatScheduler {
     private final CoffeeChatRepository coffeeChatRepository;
 
     @Transactional
-    @Scheduled(cron = "0 0 0 * * ?")
+    @Scheduled(cron = "0 30 * * * ?")
     public void expirePastCoffeeChats() {
-        coffeeChatRepository.updateStatusToCloseForPastCoffeeChats();
+        log.info("[expirePastCoffeeChats] 스케쥴러 실행");
+        try {
+            coffeeChatRepository.updateStatusToCloseForPastCoffeeChats();
+        } catch (Exception e) {
+            log.error("[expirePastCoffeeChats] 스케쥴러 실행 중 Error 발생", e);
+        }
     }
 }

--- a/module-batch/src/main/java/kernel/jdon/modulebatch/scheduler/CoffeeChatScheduler.java
+++ b/module-batch/src/main/java/kernel/jdon/modulebatch/scheduler/CoffeeChatScheduler.java
@@ -5,6 +5,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
 import kernel.jdon.modulebatch.domain.coffeechat.repository.CoffeeChatRepository;
+import kernel.jdon.modulecommon.slack.SlackSender;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -13,15 +14,19 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 public class CoffeeChatScheduler {
     private final CoffeeChatRepository coffeeChatRepository;
+    private final SlackSender slackSender;
 
     @Transactional
     @Scheduled(cron = "0 30 * * * ?")
     public void expirePastCoffeeChats() {
         log.info("[expirePastCoffeeChats] 스케쥴러 실행");
         try {
+            slackSender.sendSchedulerStart("expirePastCoffeeChats");
             coffeeChatRepository.updateStatusToCloseForPastCoffeeChats();
         } catch (Exception e) {
             log.error("[expirePastCoffeeChats] 스케쥴러 실행 중 Error 발생", e);
         }
+        log.info("[expirePastCoffeeChats] 스케쥴러 종료");
+        slackSender.sendSchedulerEnd("expirePastCoffeeChats");
     }
 }

--- a/module-batch/src/main/java/kernel/jdon/modulebatch/scheduler/CoffeeChatScheduler.java
+++ b/module-batch/src/main/java/kernel/jdon/modulebatch/scheduler/CoffeeChatScheduler.java
@@ -1,0 +1,22 @@
+package kernel.jdon.modulebatch.scheduler;
+
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import kernel.jdon.modulebatch.domain.coffeechat.repository.CoffeeChatRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class CoffeeChatScheduler {
+    private final CoffeeChatRepository coffeeChatRepository;
+
+    @Transactional
+    @Scheduled(cron = "0 0 0 * * ?")
+    public void expirePastCoffeeChats() {
+        coffeeChatRepository.updateStatusToCloseForPastCoffeeChats();
+    }
+}

--- a/module-domain/src/main/java/kernel/jdon/moduledomain/coffeechat/domain/CoffeeChat.java
+++ b/module-domain/src/main/java/kernel/jdon/moduledomain/coffeechat/domain/CoffeeChat.java
@@ -149,8 +149,4 @@ public class CoffeeChat extends AbstractEntity {
     private void changeStatusOpen() {
         this.coffeeChatStatus = CoffeeChatActiveStatus.OPEN;
     }
-
-    public void changeStatusClose() {
-        this.coffeeChatStatus = CoffeeChatActiveStatus.CLOSE;
-    }
 }

--- a/module-domain/src/main/java/kernel/jdon/moduledomain/coffeechat/domain/CoffeeChat.java
+++ b/module-domain/src/main/java/kernel/jdon/moduledomain/coffeechat/domain/CoffeeChat.java
@@ -149,4 +149,8 @@ public class CoffeeChat extends AbstractEntity {
     private void changeStatusOpen() {
         this.coffeeChatStatus = CoffeeChatActiveStatus.OPEN;
     }
+
+    public void changeStatusClose() {
+        this.coffeeChatStatus = CoffeeChatActiveStatus.CLOSE;
+    }
 }


### PR DESCRIPTION
## 개요

### 요약

- 배치 모듈에 만료(meetDate가 과거 날짜)된 커피챗의 상태를 변경하는 스케쥴러를 생성했습니다 
- 현재 서비스상 커피챗 생성시 meetDate를 5분 단위로 지정가능합니다. 
아래의 내용들을 고려해서 30분 단위로 지정 가능하도록 변경하고 그에 따라, 상태변경도 30분 단위로 진행하고자 합니다.

  - 당일 00:00시 까지만 신청가능 하도록 하게 해서 실행 횟수를 줄이는 방법도 고려했으나 다음의 이유로 고사했습니다.
    - 프론트에서 시간비교 연산을 통해 신청을 막아야 하므로 프론트에 의존적이게 된다.
    - 변경 할 데이터의 볼륨이 아주커진다고 가정하면 데이터베이스의 부하를 고려해서 일 단위 보다 작은 단위로 쪼개는 것이 유리하다.
    
  - 커피챗 서비스 특성 상 5분 단위까지 세세한 시간 구분이 필요하지 않다. 일반적으로 시간 약속을 하는 30분 단위가 적합하다고 판단.
 


### 변경한 부분

### 변경한 결과
meetDate가 현재보다 과거이면서 상태가 CLOSE가 아닌 데이터가 있는 경우
![스크린샷 2024-03-26 오후 7 25 57](https://github.com/Kernel360/f1-JDON-Backend/assets/111513287/4879dcb6-0bff-4647-8b54-7cd3fd3c5ed2)
스케쥴러가 작동해서 쿼리를 실행하면
![스크린샷 2024-03-26 오후 7 27 24](https://github.com/Kernel360/f1-JDON-Backend/assets/111513287/cf3794d9-4c9d-4f86-95fe-d7e061d1da05)
상태를 CLOSE로 변경합니다
![스크린샷 2024-03-26 오후 7 27 45](https://github.com/Kernel360/f1-JDON-Backend/assets/111513287/7bdbb96c-8e74-43f7-b975-742fe416dc43)


### 이슈

- closes: #507 

---

## PR 유형

어떤 변경 사항이 있나요?

- [X] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경, 주석 변경)
- [ ] 코드 리팩토링
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 파일 혹은 폴더명 수정, 삭제
- [ ] 배포 관련