### PR TITLE
Feature: 전체 원티드 JD 스크래핑 후 마감된 JD 정보 반영 기능 구현

### DIFF
--- a/module-batch/src/main/java/kernel/jdon/modulebatch/domain/wantedjd/repository/WantedJdRepository.java
+++ b/module-batch/src/main/java/kernel/jdon/modulebatch/domain/wantedjd/repository/WantedJdRepository.java
@@ -1,5 +1,8 @@
 package kernel.jdon.modulebatch.domain.wantedjd.repository;
 
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+
 import kernel.jdon.moduledomain.jobcategory.domain.JobCategory;
 import kernel.jdon.moduledomain.wantedjd.domain.WantedJd;
 import kernel.jdon.moduledomain.wantedjd.repository.WantedJdDomainRepository;
@@ -8,4 +11,10 @@ public interface WantedJdRepository extends WantedJdDomainRepository {
     WantedJd findByJobCategoryAndDetailId(JobCategory jobCategory, Long detailId);
 
     boolean existsByJobCategoryAndDetailId(JobCategory jobCategory, Long detailId);
+
+    @Modifying
+    @Query(value = "update wanted_jd set active_status = 'CLOSE' "
+        + "where DATE_FORMAT(modified_date, '%Y-%m-%d') != DATE_FORMAT(now(), '%Y-%m-%d') "
+        + "or modified_date is null", nativeQuery = true)
+    void updateWantedJdActiveStatus();
 }


### PR DESCRIPTION
## 개요

### 요약
전체 원티드 JD 스크래핑 후 마감된 JD 정보 반영 기능 구현했습니다.
기존에는 마감일자 전에 스크래핑 했지만 마감일자 이후 전체 원티드 JD 스크래핑할 경우 마감일자를 비교해서 JD 상태를 관리했지만 실제로 스크래핑 한 데이터를 확인해보니 원티드 JD 목록조회 시 마감되었거나 삭제된 JD를 페이지에 보여주고 있지 않는 문제를 발견했습니다.
따라서 과거에 스크래핑 했지만 전체 원티드 JD 스크래핑한 일자(매주 수요일)에 스크래핑되지 않은 jd 데이터의 상태값을 CLOSE(모집종료)로 변경하도록 하는 기능을 구현했고 백엔드, 프론트엔드 각각의 Step을 완료한 다음 마지막에 실행되도록 마지막 Step에 설정하여 구현했습니다.

### 변경한 부분
- JD 상태 컬럼 업데이트 Step 구현 및 연결

### 변경한 결과
- 24-03-26 20:10 경에 전체 원티드 JD 스크래핑 Job을 수동으로 실행시켰습니다. 어제인  24-03-25 날짜에도 동일한 Job을 수동으로 실행시켰었는데 금일 실행한 스크래핑에서 modified_date가 update되지 않은 항목을 추적했고 상태가 CLOSE로 변경되어 있는 것을 확인했습니다.
<img width="1052" alt="image" src="https://github.com/Kernel360/f1-JDON-Backend/assets/59242594/a5e6d023-cf17-4709-beae-ec07beb3d00e">
<img width="1097" alt="image" src="https://github.com/Kernel360/f1-JDON-Backend/assets/59242594/42cc6afa-e774-4725-8fd8-aa05528fc6ea">

실제로 확인해보기 위해 detail_id로 해당 JD의 원티드 페이지에 접근하여 아래와 같이 지원 마감된 것을 확인했습니다.
![image](https://github.com/Kernel360/f1-JDON-Backend/assets/59242594/76e13422-b9ab-4ff7-b870-809004578932)


-  


### 이슈

- closes: #542 

---

## PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경, 주석 변경)
- [ ] 코드 리팩토링
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 파일 혹은 폴더명 수정, 삭제
- [ ] 배포 관련