### PR TITLE
Feature: Job, Step 실행 및 종료 슬랙 알림 설정

### DIFF
--- a/module-batch/src/main/java/kernel/jdon/modulebatch/job/jd/AllWantedJobScrapingJobConfig.java
+++ b/module-batch/src/main/java/kernel/jdon/modulebatch/job/jd/AllWantedJobScrapingJobConfig.java
@@ -45,7 +45,7 @@ public class AllWantedJobScrapingJobConfig {
     public Job allWantedJdScrapingJob(JobRepository jobRepository) {
         return new JobBuilder(JOB_NAME, jobRepository)
             .incrementer(new RunIdIncrementer())
-            .listener(new AllWantedJobScrapingJobListener())
+            .listener(new AllWantedJobScrapingJobListener(slackSender))
             .start(allBackendWantedJdScrapingStep(jobRepository)) // 백엔드 JD 스크래핑
             .next(allFrontendWantedJdScrapingStep(jobRepository)) // 프론트엔드 JD 스크래핑
             .next(updateJdStatusStep(jobRepository)) // JD 상태 업데이트

--- a/module-batch/src/main/java/kernel/jdon/modulebatch/job/jd/AllWantedJobScrapingJobConfig.java
+++ b/module-batch/src/main/java/kernel/jdon/modulebatch/job/jd/AllWantedJobScrapingJobConfig.java
@@ -14,6 +14,7 @@ import org.springframework.transaction.PlatformTransactionManager;
 
 import kernel.jdon.modulebatch.domain.wantedjd.repository.WantedJdRepository;
 import kernel.jdon.modulebatch.job.jd.listener.AllBackendWantedJobScrapingJStepListener;
+import kernel.jdon.modulebatch.job.jd.listener.AllFrontWantedJobScrapingJStepListener;
 import kernel.jdon.modulebatch.job.jd.listener.AllWantedJobScrapingJobListener;
 import kernel.jdon.modulebatch.job.jd.listener.UpdateJdStatusStepListener;
 import kernel.jdon.modulebatch.job.jd.reader.AllBackendWantedJdItemReader;
@@ -67,7 +68,7 @@ public class AllWantedJobScrapingJobConfig {
     @JobScope
     public Step allFrontendWantedJdScrapingStep(JobRepository jobRepository) {
         return new StepBuilder("allFrontendWantedJdScrapingStep", jobRepository)
-            .listener(new AllBackendWantedJobScrapingJStepListener(slackSender))
+            .listener(new AllFrontWantedJobScrapingJStepListener(slackSender))
             .<WantedJobDetailListResponse, WantedJobDetailListResponse>chunk(CHUNK_SIZE, platformTransactionManager)
             .reader(allFrontendWantedJdItemReader)
             .writer(wantedJdItemWriter)

--- a/module-batch/src/main/java/kernel/jdon/modulebatch/job/jd/PartWantedJdScrapingJobConfig.java
+++ b/module-batch/src/main/java/kernel/jdon/modulebatch/job/jd/PartWantedJdScrapingJobConfig.java
@@ -42,7 +42,7 @@ public class PartWantedJdScrapingJobConfig {
     public Job partWantedJdScrapingJob(JobRepository jobRepository) {
         return new JobBuilder(JOB_NAME, jobRepository)
             .incrementer(new RunIdIncrementer())
-            .listener(new PartWantedJobScrapingJobListener())
+            .listener(new PartWantedJobScrapingJobListener(slackSender))
             .start(partBackendWantedJdScrapingStep(jobRepository)) // 백엔드 JD 스크래핑
             .next(partFrontendWantedJdScrapingStep(jobRepository)) // 프론트엔드 JD 스크래핑
             .build();

--- a/module-batch/src/main/java/kernel/jdon/modulebatch/job/jd/PartWantedJdScrapingJobConfig.java
+++ b/module-batch/src/main/java/kernel/jdon/modulebatch/job/jd/PartWantedJdScrapingJobConfig.java
@@ -11,23 +11,27 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.transaction.PlatformTransactionManager;
 
+import kernel.jdon.modulebatch.job.jd.listener.PartBackendWantedJobScrapingJStepListener;
+import kernel.jdon.modulebatch.job.jd.listener.PartFrontWantedJobScrapingJStepListener;
 import kernel.jdon.modulebatch.job.jd.listener.PartWantedJobScrapingJobListener;
 import kernel.jdon.modulebatch.job.jd.reader.PartBackendWantedJdItemReader;
 import kernel.jdon.modulebatch.job.jd.reader.PartFrontendWantedJdItemReader;
 import kernel.jdon.modulebatch.job.jd.reader.dto.WantedJobDetailListResponse;
 import kernel.jdon.modulebatch.job.jd.writer.WantedJdItemWriter;
+import kernel.jdon.modulecommon.slack.SlackSender;
 import lombok.RequiredArgsConstructor;
 
 @Configuration
 @RequiredArgsConstructor
 public class PartWantedJdScrapingJobConfig {
-
+    private static final String JOB_NAME = "partWantedJdScrapingJob";
     private static final int CHUNK_SIZE = 1;
 
     private final PlatformTransactionManager platformTransactionManager;
     private final PartBackendWantedJdItemReader partBackendWantedJdItemReader;
     private final PartFrontendWantedJdItemReader partFrontendWantedJdItemReader;
     private final WantedJdItemWriter wantedJdItemWriter;
+    private final SlackSender slackSender;
 
     /**
      * [부분_원티드_채용공고_스크래핑]
@@ -36,7 +40,7 @@ public class PartWantedJdScrapingJobConfig {
      */
     @Bean
     public Job partWantedJdScrapingJob(JobRepository jobRepository) {
-        return new JobBuilder("partWantedJdScrapingJob", jobRepository)
+        return new JobBuilder(JOB_NAME, jobRepository)
             .incrementer(new RunIdIncrementer())
             .listener(new PartWantedJobScrapingJobListener())
             .start(partBackendWantedJdScrapingStep(jobRepository)) // 백엔드 JD 스크래핑
@@ -48,6 +52,7 @@ public class PartWantedJdScrapingJobConfig {
     @JobScope
     public Step partBackendWantedJdScrapingStep(JobRepository jobRepository) {
         return new StepBuilder("partBackendWantedJdScrapingStep", jobRepository)
+            .listener(new PartBackendWantedJobScrapingJStepListener(slackSender))
             .<WantedJobDetailListResponse, WantedJobDetailListResponse>chunk(CHUNK_SIZE, platformTransactionManager)
             .reader(partBackendWantedJdItemReader)
             .writer(wantedJdItemWriter)
@@ -58,6 +63,7 @@ public class PartWantedJdScrapingJobConfig {
     @JobScope
     public Step partFrontendWantedJdScrapingStep(JobRepository jobRepository) {
         return new StepBuilder("partFrontendWantedJdScrapingStep", jobRepository)
+            .listener(new PartFrontWantedJobScrapingJStepListener(slackSender))
             .<WantedJobDetailListResponse, WantedJobDetailListResponse>chunk(CHUNK_SIZE, platformTransactionManager)
             .reader(partFrontendWantedJdItemReader)
             .writer(wantedJdItemWriter)

--- a/module-batch/src/main/java/kernel/jdon/modulebatch/job/jd/listener/AllBackendWantedJobScrapingJStepListener.java
+++ b/module-batch/src/main/java/kernel/jdon/modulebatch/job/jd/listener/AllBackendWantedJobScrapingJStepListener.java
@@ -34,7 +34,6 @@ public class AllBackendWantedJobScrapingJStepListener implements StepExecutionLi
         }
         if (stepExecution.getStatus() == BatchStatus.COMPLETED) {
             slackSender.sendStepEnd(STEP_NAME);
-
         }
         log.info("[AllBackendWantedJobScrapingJStepListener #afterJob] stepExecution is " + stepExecution.getStatus());
 

--- a/module-batch/src/main/java/kernel/jdon/modulebatch/job/jd/listener/AllBackendWantedJobScrapingJStepListener.java
+++ b/module-batch/src/main/java/kernel/jdon/modulebatch/job/jd/listener/AllBackendWantedJobScrapingJStepListener.java
@@ -1,0 +1,43 @@
+package kernel.jdon.modulebatch.job.jd.listener;
+
+import org.springframework.batch.core.BatchStatus;
+import org.springframework.batch.core.ExitStatus;
+import org.springframework.batch.core.StepExecution;
+import org.springframework.batch.core.StepExecutionListener;
+import org.springframework.batch.core.configuration.annotation.StepScope;
+
+import kernel.jdon.modulecommon.slack.SlackSender;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@StepScope
+@RequiredArgsConstructor
+public class AllBackendWantedJobScrapingJStepListener implements StepExecutionListener {
+    private static final String STEP_NAME = "allBackendWantedJdScrapingStep";
+
+    private final SlackSender slackSender;
+
+    @Override
+    public void beforeStep(StepExecution stepExecution) {
+        if (stepExecution.getStatus() == BatchStatus.STARTED) {
+            slackSender.sendStepStart(STEP_NAME);
+        }
+        log.info("[AllBackendWantedJobScrapingJStepListener #beforeJob] stepExecution is " + stepExecution.getStatus());
+    }
+
+    @Override
+    public ExitStatus afterStep(StepExecution stepExecution) {
+        if (stepExecution.getStatus() == BatchStatus.FAILED) {
+            slackSender.sendStepError(STEP_NAME);
+            log.error("[AllBackendWantedJobScrapingJStepListener #afterJob] stepExecution is FAILED!!! RECOVER ASAP");
+        }
+        if (stepExecution.getStatus() == BatchStatus.COMPLETED) {
+            slackSender.sendStepEnd(STEP_NAME);
+
+        }
+        log.info("[AllBackendWantedJobScrapingJStepListener #afterJob] stepExecution is " + stepExecution.getStatus());
+
+        return new ExitStatus(stepExecution.getStatus().name());
+    }
+}

--- a/module-batch/src/main/java/kernel/jdon/modulebatch/job/jd/listener/AllFrontWantedJobScrapingJStepListener.java
+++ b/module-batch/src/main/java/kernel/jdon/modulebatch/job/jd/listener/AllFrontWantedJobScrapingJStepListener.java
@@ -1,0 +1,43 @@
+package kernel.jdon.modulebatch.job.jd.listener;
+
+import org.springframework.batch.core.BatchStatus;
+import org.springframework.batch.core.ExitStatus;
+import org.springframework.batch.core.StepExecution;
+import org.springframework.batch.core.StepExecutionListener;
+import org.springframework.batch.core.configuration.annotation.StepScope;
+
+import kernel.jdon.modulecommon.slack.SlackSender;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@StepScope
+@RequiredArgsConstructor
+public class AllFrontWantedJobScrapingJStepListener implements StepExecutionListener {
+    private static final String STEP_NAME = "allFrontendWantedJdScrapingStep";
+
+    private final SlackSender slackSender;
+
+    @Override
+    public void beforeStep(StepExecution stepExecution) {
+        if (stepExecution.getStatus() == BatchStatus.STARTED) {
+            slackSender.sendStepStart(STEP_NAME);
+        }
+        log.info("[AllFrontWantedJobScrapingJStepListener #beforeJob] stepExecution is " + stepExecution.getStatus());
+    }
+
+    @Override
+    public ExitStatus afterStep(StepExecution stepExecution) {
+        if (stepExecution.getStatus() == BatchStatus.FAILED) {
+            slackSender.sendStepError(STEP_NAME);
+            log.error("[AllFrontWantedJobScrapingJStepListener #afterJob] stepExecution is FAILED!!! RECOVER ASAP");
+        }
+        if (stepExecution.getStatus() == BatchStatus.COMPLETED) {
+            slackSender.sendStepEnd(STEP_NAME);
+
+        }
+        log.info("[AllFrontWantedJobScrapingJStepListener #afterJob] stepExecution is " + stepExecution.getStatus());
+
+        return new ExitStatus(stepExecution.getStatus().name());
+    }
+}

--- a/module-batch/src/main/java/kernel/jdon/modulebatch/job/jd/listener/AllFrontWantedJobScrapingJStepListener.java
+++ b/module-batch/src/main/java/kernel/jdon/modulebatch/job/jd/listener/AllFrontWantedJobScrapingJStepListener.java
@@ -34,7 +34,6 @@ public class AllFrontWantedJobScrapingJStepListener implements StepExecutionList
         }
         if (stepExecution.getStatus() == BatchStatus.COMPLETED) {
             slackSender.sendStepEnd(STEP_NAME);
-
         }
         log.info("[AllFrontWantedJobScrapingJStepListener #afterJob] stepExecution is " + stepExecution.getStatus());
 

--- a/module-batch/src/main/java/kernel/jdon/modulebatch/job/jd/listener/AllWantedJobScrapingJobListener.java
+++ b/module-batch/src/main/java/kernel/jdon/modulebatch/job/jd/listener/AllWantedJobScrapingJobListener.java
@@ -3,21 +3,36 @@ package kernel.jdon.modulebatch.job.jd.listener;
 import org.springframework.batch.core.BatchStatus;
 import org.springframework.batch.core.JobExecution;
 import org.springframework.batch.core.JobExecutionListener;
+import org.springframework.batch.core.configuration.annotation.JobScope;
 
+import kernel.jdon.modulecommon.slack.SlackSender;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
+@JobScope
+@RequiredArgsConstructor
 public class AllWantedJobScrapingJobListener implements JobExecutionListener {
+    private static final String JOB_NAME = "allWantedJdScrapingJob";
+
+    private final SlackSender slackSender;
 
     @Override
     public void beforeJob(JobExecution jobExecution) {
+        if (jobExecution.getStatus() == BatchStatus.STARTED) {
+            slackSender.sendJobStart(JOB_NAME);
+        }
         log.info("[AllWantedJobScrapingJobListener #beforeJob] jobExecution is " + jobExecution.getStatus());
     }
 
     @Override
     public void afterJob(JobExecution jobExecution) {
         if (jobExecution.getStatus() == BatchStatus.FAILED) {
+            slackSender.sendJobError(JOB_NAME);
             log.error("[AllWantedJobScrapingJobListener #afterJob] jobExecution is FAILED!!! RECOVER ASAP");
+        }
+        if (jobExecution.getStatus() == BatchStatus.COMPLETED) {
+            slackSender.sendJobEnd(JOB_NAME);
         }
         log.info("[AllWantedJobScrapingJobListener #afterJob] jobExecution is " + jobExecution.getStatus());
     }

--- a/module-batch/src/main/java/kernel/jdon/modulebatch/job/jd/listener/PartBackendWantedJobScrapingJStepListener.java
+++ b/module-batch/src/main/java/kernel/jdon/modulebatch/job/jd/listener/PartBackendWantedJobScrapingJStepListener.java
@@ -1,0 +1,44 @@
+package kernel.jdon.modulebatch.job.jd.listener;
+
+import org.springframework.batch.core.BatchStatus;
+import org.springframework.batch.core.ExitStatus;
+import org.springframework.batch.core.StepExecution;
+import org.springframework.batch.core.StepExecutionListener;
+import org.springframework.batch.core.configuration.annotation.StepScope;
+
+import kernel.jdon.modulecommon.slack.SlackSender;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@StepScope
+@RequiredArgsConstructor
+public class PartBackendWantedJobScrapingJStepListener implements StepExecutionListener {
+    private static final String STEP_NAME = "partBackendWantedJdScrapingStep";
+
+    private final SlackSender slackSender;
+
+    @Override
+    public void beforeStep(StepExecution stepExecution) {
+        if (stepExecution.getStatus() == BatchStatus.STARTED) {
+            slackSender.sendStepStart(STEP_NAME);
+        }
+        log.info(
+            "[PartBackendWantedJobScrapingJStepListener #beforeJob] stepExecution is " + stepExecution.getStatus());
+    }
+
+    @Override
+    public ExitStatus afterStep(StepExecution stepExecution) {
+        if (stepExecution.getStatus() == BatchStatus.FAILED) {
+            slackSender.sendStepError(STEP_NAME);
+            log.error("[PartBackendWantedJobScrapingJStepListener #afterJob] stepExecution is FAILED!!! RECOVER ASAP");
+        }
+        if (stepExecution.getStatus() == BatchStatus.COMPLETED) {
+            slackSender.sendStepEnd(STEP_NAME);
+
+        }
+        log.info("[PartBackendWantedJobScrapingJStepListener #afterJob] stepExecution is " + stepExecution.getStatus());
+
+        return new ExitStatus(stepExecution.getStatus().name());
+    }
+}

--- a/module-batch/src/main/java/kernel/jdon/modulebatch/job/jd/listener/PartFrontWantedJobScrapingJStepListener.java
+++ b/module-batch/src/main/java/kernel/jdon/modulebatch/job/jd/listener/PartFrontWantedJobScrapingJStepListener.java
@@ -1,0 +1,43 @@
+package kernel.jdon.modulebatch.job.jd.listener;
+
+import org.springframework.batch.core.BatchStatus;
+import org.springframework.batch.core.ExitStatus;
+import org.springframework.batch.core.StepExecution;
+import org.springframework.batch.core.StepExecutionListener;
+import org.springframework.batch.core.configuration.annotation.StepScope;
+
+import kernel.jdon.modulecommon.slack.SlackSender;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@StepScope
+@RequiredArgsConstructor
+public class PartFrontWantedJobScrapingJStepListener implements StepExecutionListener {
+    private static final String STEP_NAME = "partFrontendWantedJdScrapingStep";
+
+    private final SlackSender slackSender;
+
+    @Override
+    public void beforeStep(StepExecution stepExecution) {
+        if (stepExecution.getStatus() == BatchStatus.STARTED) {
+            slackSender.sendStepStart(STEP_NAME);
+        }
+        log.info("[PartFrontWantedJobScrapingJStepListener #beforeJob] stepExecution is " + stepExecution.getStatus());
+    }
+
+    @Override
+    public ExitStatus afterStep(StepExecution stepExecution) {
+        if (stepExecution.getStatus() == BatchStatus.FAILED) {
+            slackSender.sendStepError(STEP_NAME);
+            log.error("[PartFrontWantedJobScrapingJStepListener #afterJob] stepExecution is FAILED!!! RECOVER ASAP");
+        }
+        if (stepExecution.getStatus() == BatchStatus.COMPLETED) {
+            slackSender.sendStepEnd(STEP_NAME);
+
+        }
+        log.info("[PartFrontWantedJobScrapingJStepListener #afterJob] stepExecution is " + stepExecution.getStatus());
+
+        return new ExitStatus(stepExecution.getStatus().name());
+    }
+}

--- a/module-batch/src/main/java/kernel/jdon/modulebatch/job/jd/listener/PartWantedJobScrapingJobListener.java
+++ b/module-batch/src/main/java/kernel/jdon/modulebatch/job/jd/listener/PartWantedJobScrapingJobListener.java
@@ -3,21 +3,36 @@ package kernel.jdon.modulebatch.job.jd.listener;
 import org.springframework.batch.core.BatchStatus;
 import org.springframework.batch.core.JobExecution;
 import org.springframework.batch.core.JobExecutionListener;
+import org.springframework.batch.core.configuration.annotation.JobScope;
 
+import kernel.jdon.modulecommon.slack.SlackSender;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
+@JobScope
+@RequiredArgsConstructor
 public class PartWantedJobScrapingJobListener implements JobExecutionListener {
+    private static final String JOB_NAME = "partWantedJdScrapingJob";
+
+    private final SlackSender slackSender;
 
     @Override
     public void beforeJob(JobExecution jobExecution) {
+        if (jobExecution.getStatus() == BatchStatus.STARTED) {
+            slackSender.sendJobStart(JOB_NAME);
+        }
         log.info("[PartWantedJobScrapingJobListener #beforeJob] jobExecution is " + jobExecution.getStatus());
     }
 
     @Override
     public void afterJob(JobExecution jobExecution) {
         if (jobExecution.getStatus() == BatchStatus.FAILED) {
+            slackSender.sendJobError(JOB_NAME);
             log.error("[PartWantedJobScrapingJobListener #afterJob] jobExecution is FAILED!!! RECOVER ASAP");
+        }
+        if (jobExecution.getStatus() == BatchStatus.COMPLETED) {
+            slackSender.sendJobEnd(JOB_NAME);
         }
         log.info("[PartWantedJobScrapingJobListener #afterJob] jobExecution is " + jobExecution.getStatus());
     }

--- a/module-batch/src/main/java/kernel/jdon/modulebatch/job/jd/listener/UpdateJdStatusStepListener.java
+++ b/module-batch/src/main/java/kernel/jdon/modulebatch/job/jd/listener/UpdateJdStatusStepListener.java
@@ -1,0 +1,42 @@
+package kernel.jdon.modulebatch.job.jd.listener;
+
+import org.springframework.batch.core.BatchStatus;
+import org.springframework.batch.core.ExitStatus;
+import org.springframework.batch.core.StepExecution;
+import org.springframework.batch.core.StepExecutionListener;
+import org.springframework.batch.core.configuration.annotation.StepScope;
+
+import kernel.jdon.modulecommon.slack.SlackSender;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@StepScope
+@RequiredArgsConstructor
+public class UpdateJdStatusStepListener implements StepExecutionListener {
+    private static final String STEP_NAME = "updateJdStatusStep";
+
+    private final SlackSender slackSender;
+
+    @Override
+    public void beforeStep(StepExecution stepExecution) {
+        if (stepExecution.getStatus() == BatchStatus.STARTED) {
+            slackSender.sendStepStart(STEP_NAME);
+        }
+        log.info("[UpdateJdStatusStepListener #beforeJob] stepExecution is " + stepExecution.getStatus());
+    }
+
+    @Override
+    public ExitStatus afterStep(StepExecution stepExecution) {
+        if (stepExecution.getStatus() == BatchStatus.FAILED) {
+            slackSender.sendStepError(STEP_NAME);
+            log.error("[UpdateJdStatusStepListener #afterJob] stepExecution is FAILED!!! RECOVER ASAP");
+        }
+        if (stepExecution.getStatus() == BatchStatus.COMPLETED) {
+            slackSender.sendStepEnd(STEP_NAME);
+        }
+        log.info("[UpdateJdStatusStepListener #afterJob] stepExecution is " + stepExecution.getStatus());
+
+        return new ExitStatus(stepExecution.getStatus().name());
+    }
+}

--- a/module-batch/src/main/java/kernel/jdon/modulebatch/scheduler/JdScheduler.java
+++ b/module-batch/src/main/java/kernel/jdon/modulebatch/scheduler/JdScheduler.java
@@ -28,9 +28,7 @@ public class JdScheduler {
             .addLong("time", System.currentTimeMillis())
             .toJobParameters();
         try {
-            slackSender.sendSchedulerStart("partWantedJdScrapingJob");
             jobLauncher.run(partWantedJdScrapingJob, jobParameters);
-            slackSender.sendSchedulerEnd("partWantedJdScrapingJob");
         } catch (Exception e) {
             log.error("[partWantedJdScrapingJob] 실행중 Error 발생");
             throw new BatchException(BatchServerErrorCode.INTERNAL_SERVER_ERROR_SCHEDULER);

--- a/module-common/src/main/java/kernel/jdon/modulecommon/slack/SlackSender.java
+++ b/module-common/src/main/java/kernel/jdon/modulecommon/slack/SlackSender.java
@@ -23,6 +23,10 @@ import lombok.extern.slf4j.Slf4j;
 @Component
 @RequiredArgsConstructor
 public class SlackSender {
+    private static final String serverStartColor = "#439FE0";
+    private static final String activeColor = "#009000";
+    private static final String errorColor = "#FF0000";
+
     private final Slack slackClient = Slack.getInstance();
     private final SlackProperties slackProperties;
     private final ApplicationContext applicationContext;
@@ -67,17 +71,25 @@ public class SlackSender {
         final String activeProfile = String.join(", ", applicationContext.getEnvironment().getActiveProfiles());
         sendMessage(
             SlackMessage.of("서버 실행 알림")
-                .setColor("#439FE0")
+                .setColor(serverStartColor)
                 .putMessage("Start-Module-Name", moduleName)
                 .putMessage("Active-Profile", activeProfile));
+    }
+
+    public void sendJobError(final String jobName) {
+        final String activeProfile = String.join(", ", applicationContext.getEnvironment().getActiveProfiles());
+        sendMessage(
+            SlackMessage.of("Job 에러 발생 알림")
+                .setColor(errorColor)
+                .putMessage("Active-Profile", activeProfile)
+                .putMessage("Job-Name", jobName));
     }
 
     public void sendStepError(final String stepName) {
         final String activeProfile = String.join(", ", applicationContext.getEnvironment().getActiveProfiles());
         sendMessage(
             SlackMessage.of("Step 에러 발생 알림")
-                .setColor("#ff0000")
-                .putMessage("Start-Module-Name", "module-batch")
+                .setColor(errorColor)
                 .putMessage("Active-Profile", activeProfile)
                 .putMessage("Step-Name", stepName));
     }
@@ -86,8 +98,8 @@ public class SlackSender {
         final String activeProfile = String.join(", ", applicationContext.getEnvironment().getActiveProfiles());
         sendMessage(
             SlackMessage.of(title)
-                .setColor("#009000")
-                .putMessage("Start-Job-Scheduler-Name", stepName)
+                .setColor(activeColor)
+                .putMessage("Step-Name", stepName)
                 .putMessage("Active-Profile", activeProfile));
     }
 
@@ -95,8 +107,17 @@ public class SlackSender {
         final String activeProfile = String.join(", ", applicationContext.getEnvironment().getActiveProfiles());
         sendMessage(
             SlackMessage.of(title)
-                .setColor("#009000")
-                .putMessage("Start-Job-Scheduler-Name", jobSchedulerName)
+                .setColor(activeColor)
+                .putMessage("Scheduler-Name", jobSchedulerName)
+                .putMessage("Active-Profile", activeProfile));
+    }
+
+    private void sendJob(final String jobName, final String title) {
+        final String activeProfile = String.join(", ", applicationContext.getEnvironment().getActiveProfiles());
+        sendMessage(
+            SlackMessage.of(title)
+                .setColor(activeColor)
+                .putMessage("Job-Name", jobName)
                 .putMessage("Active-Profile", activeProfile));
     }
 
@@ -106,6 +127,14 @@ public class SlackSender {
 
     public void sendSchedulerEnd(final String jobSchedulerName) {
         sendScheduler(jobSchedulerName, "배치 스케줄러 종료 알림");
+    }
+
+    public void sendJobStart(final String jobName) {
+        sendJob(jobName, "배치 Job 실행 알림");
+    }
+
+    public void sendJobEnd(final String jobName) {
+        sendJob(jobName, "배치 Job 종료 알림");
     }
 
     public void sendStepStart(final String stepName) {

--- a/module-common/src/main/java/kernel/jdon/modulecommon/slack/SlackSender.java
+++ b/module-common/src/main/java/kernel/jdon/modulecommon/slack/SlackSender.java
@@ -72,12 +72,23 @@ public class SlackSender {
                 .putMessage("Active-Profile", activeProfile));
     }
 
-    public void sendSchedulerStart(final String jobSchedulerName) {
-        sendScheduler(jobSchedulerName, "배치 스케줄러 실행 알림");
+    public void sendStepError(final String stepName) {
+        final String activeProfile = String.join(", ", applicationContext.getEnvironment().getActiveProfiles());
+        sendMessage(
+            SlackMessage.of("Step 에러 발생 알림")
+                .setColor("#ff0000")
+                .putMessage("Start-Module-Name", "module-batch")
+                .putMessage("Active-Profile", activeProfile)
+                .putMessage("Step-Name", stepName));
     }
 
-    public void sendSchedulerEnd(final String jobSchedulerName) {
-        sendScheduler(jobSchedulerName, "배치 스케줄러 종료 알림");
+    private void sendStep(final String stepName, final String title) {
+        final String activeProfile = String.join(", ", applicationContext.getEnvironment().getActiveProfiles());
+        sendMessage(
+            SlackMessage.of(title)
+                .setColor("#009000")
+                .putMessage("Start-Job-Scheduler-Name", stepName)
+                .putMessage("Active-Profile", activeProfile));
     }
 
     private void sendScheduler(final String jobSchedulerName, final String title) {
@@ -87,6 +98,22 @@ public class SlackSender {
                 .setColor("#009000")
                 .putMessage("Start-Job-Scheduler-Name", jobSchedulerName)
                 .putMessage("Active-Profile", activeProfile));
+    }
+
+    public void sendSchedulerStart(final String jobSchedulerName) {
+        sendScheduler(jobSchedulerName, "배치 스케줄러 실행 알림");
+    }
+
+    public void sendSchedulerEnd(final String jobSchedulerName) {
+        sendScheduler(jobSchedulerName, "배치 스케줄러 종료 알림");
+    }
+
+    public void sendStepStart(final String stepName) {
+        sendStep(stepName, "배치 Step 실행 알림");
+    }
+
+    public void sendStepEnd(final String stepName) {
+        sendStep(stepName, "배치 Step 종료 알림");
     }
 
     @Getter


### PR DESCRIPTION
## 개요

### 요약
Job, Step 실행 및 종료 시점에 슬랙 알림이 전송되도록 구현했습니다.

### 변경한 부분
- **스케줄러 시작 및 종료 슬랙 알림을 Job 시작 및 종료 슬랙 알림으로 변경**
  기존 스케줄러 실행 시 run 메서드 앞 뒤에 스케줄링 실행 및 종료 슬랙 알림을 보내도록 설정했었습니다.
현재는 스케줄러에 의해 Job을 실행시키지만 Job을 임의로 실행시켰을 때 Job 실행 종료 알림이 구현되어 있지 않아 해당 기능을 추가해야했었는데 스케줄링을 통해 Job이 실행되는 경우에는 결국 스케줄링에 의해 Job이 실행되므로 Job 실행 및 종료 알림을 보내는 것으로 대체해도 무관하다고 판단되어 스케줄링 알림을 Job 리스너를 활용하여 Job 알림으로 변경하였고 기존의 스케줄링 알림을 까지 보내면 너무 많은 알림이 전송되는 것 같다고 판단하여 스케줄링 알림은 삭제했습니다.

- **전체, 부분 원티드 JD 스크래핑 Job의 Step 시작 및 종료 슬랙 알림 설정**
 각 스탭이 실행 종료 되는 시점에 슬랙 알림을 보내도록 Step 리스너를 통해 구현했습니다.

### 변경한 결과
- 부분 원티드 Jd 스크래핑 배치 Job, Step 실행 종료 알림 
<img width="363" alt="image" src="https://github.com/Kernel360/f1-JDON-Backend/assets/59242594/ddaedd93-dea8-4454-b62b-9dc69d06d551">

- 전체 원티드 Jd 스크래핑 배치 Job, Step 실행 종료 알림 
<img width="339" alt="image" src="https://github.com/Kernel360/f1-JDON-Backend/assets/59242594/9ba1b5e5-3571-4e45-86f8-882f1346b2be">
<img width="276" alt="image" src="https://github.com/Kernel360/f1-JDON-Backend/assets/59242594/cd08c20f-2a9d-4083-8f8d-a3320cd7cc6e">


### 이슈

- closes: #547 

---

## PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경, 주석 변경)
- [ ] 코드 리팩토링
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 파일 혹은 폴더명 수정, 삭제
- [ ] 배포 관련