### PR TITLE
fix: 커피챗 만료 스케쥴링 매 30분마다 실행하도록 변경

### DIFF
--- a/module-batch/src/main/java/kernel/jdon/modulebatch/scheduler/CoffeeChatScheduler.java
+++ b/module-batch/src/main/java/kernel/jdon/modulebatch/scheduler/CoffeeChatScheduler.java
@@ -17,7 +17,7 @@ public class CoffeeChatScheduler {
     private final SlackSender slackSender;
 
     @Transactional
-    @Scheduled(cron = "0 30 * * * ?")
+    @Scheduled(cron = "0 0/30 * * * ?")
     public void expirePastCoffeeChats() {
         log.info("[expirePastCoffeeChats] 스케쥴러 실행");
         slackSender.sendSchedulerStart("expirePastCoffeeChats");


### PR DESCRIPTION
## 개요

### 요약

커피챗 meetDate 생성주기인 30분 마다 만료처리 하도록 스케쥴러 CRON식을 변경했습니다
### 변경한 부분

AS-IS : 매 시각 30분마다 실행 (07:30 -> 08:30 -> 09:30)
TO-BE: 매 30분 마다 실행 (07:30 -> 08:00 -> 08:30)
### 변경한 결과

### 이슈

- closes: #552 

---

## PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [X] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경, 주석 변경)
- [ ] 코드 리팩토링
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 파일 혹은 폴더명 수정, 삭제
- [ ] 배포 관련