### PR TITLE
Fix: 엔티티 @ManyToOne 필드 notnull 속성 추가

### DIFF
--- a/module-domain/src/main/java/kernel/jdon/moduledomain/faq/domain/Faq.java
+++ b/module-domain/src/main/java/kernel/jdon/moduledomain/faq/domain/Faq.java
@@ -20,6 +20,7 @@ import lombok.NoArgsConstructor;
 @DynamicUpdate
 @Table(name = "faq")
 public class Faq extends AbstractEntity {
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;

--- a/module-domain/src/main/java/kernel/jdon/moduledomain/favorite/domain/Favorite.java
+++ b/module-domain/src/main/java/kernel/jdon/moduledomain/favorite/domain/Favorite.java
@@ -38,11 +38,11 @@ public class Favorite {
     private LocalDateTime createdDate;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "member_id", columnDefinition = "BIGINT")
+    @JoinColumn(name = "member_id", columnDefinition = "BIGINT", nullable = false)
     private Member member;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "inflearn_id", columnDefinition = "BIGINT")
+    @JoinColumn(name = "inflearn_id", columnDefinition = "BIGINT", nullable = false)
     private InflearnCourse inflearnCourse;
 
     @Builder

--- a/module-domain/src/main/java/kernel/jdon/moduledomain/inflearnjdskill/domain/InflearnJdSkill.java
+++ b/module-domain/src/main/java/kernel/jdon/moduledomain/inflearnjdskill/domain/InflearnJdSkill.java
@@ -26,11 +26,11 @@ public class InflearnJdSkill {
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "course_id", columnDefinition = "BIGINT")
+    @JoinColumn(name = "course_id", columnDefinition = "BIGINT", nullable = false)
     private InflearnCourse inflearnCourse;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "skill_id", columnDefinition = "BIGINT")
+    @JoinColumn(name = "skill_id", columnDefinition = "BIGINT", nullable = false)
     private Skill skill;
 
     @Builder

--- a/module-domain/src/main/java/kernel/jdon/moduledomain/member/domain/Member.java
+++ b/module-domain/src/main/java/kernel/jdon/moduledomain/member/domain/Member.java
@@ -35,18 +35,6 @@ import lombok.NoArgsConstructor;
 @Table(name = "member")
 public class Member {
 
-    @OneToMany(mappedBy = "member")
-    private List<CoffeeChat> hostChatList = new ArrayList<>();
-
-    @OneToMany(mappedBy = "member")
-    private List<CoffeeChatMember> guestChatList = new ArrayList<>();
-
-    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<MemberSkill> memberSkillList = new ArrayList<>();
-
-    @OneToMany(mappedBy = "member")
-    private List<Favorite> favoriteList = new ArrayList<>();
-
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -87,8 +75,20 @@ public class Member {
     private SocialProviderType socialProvider;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "job_category_id", columnDefinition = "BIGINT")
+    @JoinColumn(name = "job_category_id", columnDefinition = "BIGINT", nullable = false)
     private JobCategory jobCategory;
+
+    @OneToMany(mappedBy = "member")
+    private List<CoffeeChat> hostChatList = new ArrayList<>();
+
+    @OneToMany(mappedBy = "member")
+    private List<CoffeeChatMember> guestChatList = new ArrayList<>();
+
+    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<MemberSkill> memberSkillList = new ArrayList<>();
+
+    @OneToMany(mappedBy = "member")
+    private List<Favorite> favoriteList = new ArrayList<>();
 
     @Builder
     public Member(Long id, String email, String nickname, String birth, Gender gender, LocalDateTime joinDate,

--- a/module-domain/src/main/java/kernel/jdon/moduledomain/memberskill/domain/MemberSkill.java
+++ b/module-domain/src/main/java/kernel/jdon/moduledomain/memberskill/domain/MemberSkill.java
@@ -25,11 +25,11 @@ public class MemberSkill {
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "member_id", columnDefinition = "BIGINT")
+    @JoinColumn(name = "member_id", columnDefinition = "BIGINT", nullable = false)
     private Member member;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "skill_id", columnDefinition = "BIGINT")
+    @JoinColumn(name = "skill_id", columnDefinition = "BIGINT", nullable = false)
     private Skill skill;
 
     @Builder

--- a/module-domain/src/main/java/kernel/jdon/moduledomain/skill/domain/Skill.java
+++ b/module-domain/src/main/java/kernel/jdon/moduledomain/skill/domain/Skill.java
@@ -37,12 +37,12 @@ public class Skill {
     @Column(name = "keyword", columnDefinition = "VARCHAR(50)", nullable = false)
     private String keyword;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "job_category_id", columnDefinition = "BIGINT", nullable = false)
+    private JobCategory jobCategory;
+    
     @OneToMany(mappedBy = "skill")
     private List<WantedJdSkill> wantedJdSkillList = new ArrayList<>();
-
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "job_category_id", columnDefinition = "BIGINT")
-    private JobCategory jobCategory;
 
     @OneToMany(mappedBy = "skill")
     private List<SkillKeyword> skillKeywordList = new ArrayList<>();

--- a/module-domain/src/main/java/kernel/jdon/moduledomain/skillhistory/domain/SkillHistory.java
+++ b/module-domain/src/main/java/kernel/jdon/moduledomain/skillhistory/domain/SkillHistory.java
@@ -20,6 +20,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "skill_history")
 public class SkillHistory {
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -28,11 +29,11 @@ public class SkillHistory {
     private String keyword;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "job_category_id", columnDefinition = "BIGINT")
+    @JoinColumn(name = "job_category_id", columnDefinition = "BIGINT", nullable = false)
     private JobCategory jobCategory;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "wanted_jd_id", columnDefinition = "BIGINT")
+    @JoinColumn(name = "wanted_jd_id", columnDefinition = "BIGINT", nullable = false)
     private WantedJd wantedJd;
 
     public SkillHistory(String keyword, JobCategory jobCategory, WantedJd wantedJd) {

--- a/module-domain/src/main/java/kernel/jdon/moduledomain/skillkeyword/domain/SkillKeyword.java
+++ b/module-domain/src/main/java/kernel/jdon/moduledomain/skillkeyword/domain/SkillKeyword.java
@@ -28,7 +28,7 @@ public class SkillKeyword {
     private String relatedKeyword;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "skill_id", referencedColumnName = "id")
+    @JoinColumn(name = "skill_id", columnDefinition = "BIGINT", nullable = false)
     private Skill skill;
 }
 


### PR DESCRIPTION
## 개요

### 요약

엔티티 @ManyToOne 필드 notnull 속성 추가

### 변경한 부분

ERD상에 NOTNULL 컬럼으로 설정되어 있지만 엔티티 @ManyToOne 적용 필드 중 적용되어있지 않은 필드가 있어
`nullable = false` 속성을 추가하였습니다.

### 변경한 결과

### 이슈

- closes: #555 

---

## PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경, 주석 변경)
- [ ] 코드 리팩토링
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 파일 혹은 폴더명 수정, 삭제
- [ ] 배포 관련