### PR TITLE
fix: 커피챗 동시성 제어를 위한 락 획득과 반납 과정을 더 명확히 알기 위해 로그 추가

### DIFF
--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/coffeechat/application/CoffeeChatFacade.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/coffeechat/application/CoffeeChatFacade.java
@@ -68,9 +68,10 @@ public class CoffeeChatFacade {
             boolean available = lock.tryLock(lockConfig.getWaitTime(), lockConfig.getLeaseTime(),
                 TimeUnit.SECONDS);
             if (!available) {
-                log.info("커피챗 신청 중 lock 획득 실패, coffeeChatId={} memberId={}", coffeeChatId, memberId);
+                log.info("커피챗 신청 lock 획득 실패, coffeeChatId={}, memberId={}", coffeeChatId, memberId);
                 throw new ApiException(CoffeeChatErrorCode.LOCK_ACQUISITION_FAILURE);
             }
+            log.info("커피챗 신청 lock 획득 성공, coffeeChatId={}, memberId={}", coffeeChatId, memberId);
 
             return coffeeChatService.applyCoffeeChat(coffeeChatId, memberId);
 
@@ -79,6 +80,7 @@ public class CoffeeChatFacade {
             throw new ApiException(CoffeeChatErrorCode.THREAD_INTERRUPTED);
         } finally {
             lock.unlock();
+            log.info("커피챗 신청 lock 반납 성공, coffeeChatId={}, memberId={}", coffeeChatId, memberId);
         }
     }
 


### PR DESCRIPTION
## 개요

### 요약

커피챗 신청 시 동시성 제어를 위해 도입한 레디스에서 예상치 못한 동작(데드락)을 보인 경우가 있었습니다.
락 획득과 반납과정 상세한 디버깅을 위해 로그를 추가했습니다.

### 변경한 부분

AS-IS: lock 획득 실패시에만 로그를 남김
TO-BE: lock 획득과 성공시에 모두 로그를 남기도록 함
### 변경한 결과

### 이슈

- closes: #554 

---

## PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [X] 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경, 주석 변경)
- [ ] 코드 리팩토링
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 파일 혹은 폴더명 수정, 삭제
- [ ] 배포 관련