### PR TITLE
Fix: 수동 트리거를 사용하여 deploy 하도록 수정

### DIFF
--- a/.github/workflows/dev-cicd.yml
+++ b/.github/workflows/dev-cicd.yml
@@ -1,11 +1,20 @@
 name: JDON-Backend DEV CI-CD
 
 on:
-  push:
-    branches: [ develop ]
-
-permissions:
-  contents: read
+  workflow_dispatch:
+    branches:
+      - develop
+    inputs:
+      tags:
+        description: '배포할 서버'
+        required: true
+        type: choice
+        default: 'all'
+        options:
+          - all
+          - api
+          - batch
+          - crawler
 
 jobs:
   integration:
@@ -45,8 +54,7 @@ jobs:
   deploy:
     needs: integration
     runs-on: ubuntu-latest
-    if: >
-      !contains(join(github.event.pull_request.labels.*.name, ','), 'NO-Deploy')
+
     steps:
       - name: Deploy to Dev-EC2
         uses: appleboy/ssh-action@v1.0.3
@@ -55,6 +63,30 @@ jobs:
           username: ${{ secrets.AWS_DEV_USERNAME }}
           key: ${{ secrets.AWS_DEV_KEY }}
           script: |
+            echo "> Git pull"
+            cd /home/ec2-user/app/f1-JDON-Backend
+            git pull origin develop
+            
+            echo "> deploy-shell-script 실행"
             cd /home/ec2-user/app
-            sh module-api-deploy.sh
+            TAGS="${{ github.event.inputs.tags }}"
+            if [ "$TAGS" = "all" ]; then
+              echo "all"
+              sh module-api-deploy.sh
+              sh module-batch-deploy.sh
+              sh module-crawler-deploy.sh
+            elif [ "$TAGS" = "api" ]; then
+              echo "api"
+              sh module-api-deploy.sh
+            elif [ "$TAGS" = "batch" ]; then
+              echo "batch"
+              sh module-batch-deploy.sh
+            elif [ "$TAGS" = "crawler" ]; then
+              echo "crawler"
+              sh module-crawler-deploy.sh
+            else
+              echo "Invalid option"
+              exit 1
+            fi
+
             echo "deploy success"

--- a/.github/workflows/prev-ci.yml
+++ b/.github/workflows/prev-ci.yml
@@ -1,0 +1,42 @@
+name: JDON-previous-integration
+
+
+on:
+  pull_request:
+    types: [ opened, reopened ]
+    branches: [ main, develop ]
+
+jobs:
+  integration:
+    runs-on: ubuntu-latest
+
+    services:
+      redis:
+        image: redis:latest
+        ports:
+          - 6379:6379
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: gradle Cache dependencies
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+      - name: Grant execute permission for gradlew & Build
+        run: |
+          cd module-api
+          chmod +x gradlew
+          ./gradlew clean build --stacktrace test
+        shell: bash

--- a/.github/workflows/prod-cicd.yml
+++ b/.github/workflows/prod-cicd.yml
@@ -1,12 +1,20 @@
 name: JDON-Backend PROD CI-CD
 
 on:
-  pull_request:
-    types: [ opened, closed ]
-    branches: [ main ]
-
-permissions:
-  contents: read
+  workflow_dispatch:
+    branches:
+      - main
+    inputs:
+      tags:
+        description: '배포할 서버'
+        required: true
+        type: choice
+        default: 'all'
+        options:
+          - all
+          - api
+          - batch
+          - crawler
 
 jobs:
   integration:
@@ -46,9 +54,7 @@ jobs:
   deploy:
     needs: integration
     runs-on: ubuntu-latest
-    if: >
-      github.event.pull_request.merged == true &&
-      !contains(join(github.event.pull_request.labels.*.name, ','), 'NO-Deploy')
+
     steps:
       - name: Deploy to Dev-EC2
         uses: appleboy/ssh-action@v1.0.3
@@ -57,6 +63,30 @@ jobs:
           username: ${{ secrets.AWS_PROD_USERNAME }}
           key: ${{ secrets.AWS_PROD_KEY }}
           script: |
+            echo "> Git pull"
+            cd /home/ec2-user/app/f1-JDON-Backend
+            git pull origin main
+            
+            echo "> deploy-shell-script 실행"
             cd /home/ec2-user/app
-            sh module-api-deploy.sh
+            TAGS="${{ github.event.inputs.tags }}"
+            if [ "$TAGS" = "all" ]; then
+              echo "all"
+              sh module-api-deploy.sh
+              sh module-batch-deploy.sh
+              sh module-crawler-deploy.sh
+            elif [ "$TAGS" = "api" ]; then
+              echo "api"
+              sh module-api-deploy.sh
+            elif [ "$TAGS" = "batch" ]; then
+              echo "batch"
+              sh module-batch-deploy.sh
+            elif [ "$TAGS" = "crawler" ]; then
+              echo "crawler"
+              sh module-crawler-deploy.sh
+            else
+              echo "Invalid option"
+              exit 1
+            fi
+
             echo "deploy success"


### PR DESCRIPTION
## 개요

### 요약
기존의 문제점
1. 기존에 [trunk based git 전략](https://helloinyong.tistory.com/335)을 사용하면서 각자의 repo에서 원본 repo로 pr을 생성했을 때 깃헙의 `secret env`를 읽어오지 못한다는 문제
2. 멀티모듈을 사용하면서 `원하는 서버만 다시 deploy` 하고 싶다는 요구사항이 생겼었습니다. 

1번 문제를 해결하려면 workflow가 동작하는 시점에서 원본 Repo의 위치여야 합니다. 
2번 문제를 해결하려면 어떤 서버를 deploy 하고자 하는지 workflow에서 판별할 수 있어야 합니다. 
push에 트리거를 걸면 2번을 해결할 수 없고, pull request에 트리거를 걸면 1번을 해결할 수 없어

버튼을 이용한 수동 트리거를 생성하고 수동 트리거의 option을 이용해서 배포하고자할 서버를 선택하도록 설정했습니다. 

### 변경한 부분

원래는 github action의 트리거로 push 나 pull request를 이용했었는데 1, 2 번 문제를 모두 해결하기 위해서 Action 창에서 직접 버튼을 눌러 workflow를 동작시키는 수동 트리거를 생성했습니다. 

pr 이 머지된 후 배포하고 싶다면 
1. Action 창으로 이동한다. 
![image](https://github.com/Kernel360/f1-JDON-Backend/assets/68376744/f08f571f-795a-40fa-b93e-6e1360fd633b)

2. 동작시키고자 하는 workflow를 선택한다. 
![image](https://github.com/Kernel360/f1-JDON-Backend/assets/68376744/899494d1-656f-4faa-bc56-b3c5aff60bbf)

3. 수동 트리거를 누르고 옵션을 선택한다. 
![image](https://github.com/Kernel360/f1-JDON-Backend/assets/68376744/50e1c15f-f136-48ea-a708-58f97e4ccc8b)

4. 배포할 서버를 선택했다면 초록색 Run workflow 버튼을 누른다. 
![image](https://github.com/Kernel360/f1-JDON-Backend/assets/68376744/3bd789e6-93f7-4d58-87ca-01316bbed857)

5. 배포되는 것을 지켜본다. 

### 변경한 결과

### 이슈

- closes: #525 

---

## PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경, 주석 변경)
- [ ] 코드 리팩토링
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 파일 혹은 폴더명 수정, 삭제
- [ ] 배포 관련