### PR TITLE
Feat: Job 로깅 AOP PointCut 추가

### DIFF
--- a/module-common/src/main/java/kernel/jdon/modulecommon/log/aspect/QueryCounterAspect.java
+++ b/module-common/src/main/java/kernel/jdon/modulecommon/log/aspect/QueryCounterAspect.java
@@ -37,7 +37,7 @@ public class QueryCounterAspect {
         return currentLoggingForm.get();
     }
 
-    @After("within(@org.springframework.web.bind.annotation.RestController *)")
+    @After("within(@org.springframework.web.bind.annotation.RestController *) || within(org.springframework.batch.core.launch.JobLauncher+)")
     public void loggingAfterApiFinish() {
         final LoggingForm loggingForm = getCurrentLoggingForm();
 


### PR DESCRIPTION
## 개요

### 요약
배치 Job 종료 시 Job의 SQL 실행횟수를 남기도록 AOP에 PointCut 추가

### 변경한 부분
현재 존재하는 RestController 어노테이션 실행 후 SQL 실행 횟수를 로깅하는 AOP에
job 실행 후에도 SQL이 작성되도록 PointCut을 추가했습니다.

### 변경한 결과
기존 API에만 로깅을 남기던 부분을 잡 실행 후에도 동일한 로깅이 추가되도록 변경했습니다.
![image](https://github.com/Kernel360/f1-JDON-Backend/assets/59242594/6d612923-197d-41aa-a8b5-63e6fa992cc3)


### 이슈

- closes: #566 

---

## PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경, 주석 변경)
- [ ] 코드 리팩토링
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 파일 혹은 폴더명 수정, 삭제
- [ ] 배포 관련