### PR TITLE
BugFix: QueryCounter 어노테이션 생성 및 AOP 포인트컷 적용

### DIFF
--- a/module-batch/src/main/java/kernel/jdon/modulebatch/scheduler/JdScheduler.java
+++ b/module-batch/src/main/java/kernel/jdon/modulebatch/scheduler/JdScheduler.java
@@ -9,12 +9,14 @@ import org.springframework.stereotype.Component;
 
 import kernel.jdon.modulebatch.global.exception.BatchException;
 import kernel.jdon.modulebatch.global.exception.BatchServerErrorCode;
+import kernel.jdon.modulecommon.log.annotation.QueryCounter;
 import kernel.jdon.modulecommon.slack.SlackSender;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @Component
+@QueryCounter
 @RequiredArgsConstructor
 public class JdScheduler {
     private final JobLauncher jobLauncher;

--- a/module-common/src/main/java/kernel/jdon/modulecommon/log/annotation/QueryCounter.java
+++ b/module-common/src/main/java/kernel/jdon/modulecommon/log/annotation/QueryCounter.java
@@ -1,0 +1,11 @@
+package kernel.jdon.modulecommon.log.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface QueryCounter {
+}

--- a/module-common/src/main/java/kernel/jdon/modulecommon/log/aspect/QueryCounterAspect.java
+++ b/module-common/src/main/java/kernel/jdon/modulecommon/log/aspect/QueryCounterAspect.java
@@ -37,7 +37,7 @@ public class QueryCounterAspect {
         return currentLoggingForm.get();
     }
 
-    @After("within(@org.springframework.web.bind.annotation.RestController *) || within(org.springframework.batch.core.launch.JobLauncher+)")
+    @After("within(@org.springframework.web.bind.annotation.RestController *) || within(@kernel.jdon.modulecommon.log.annotation.QueryCounter *)")
     public void loggingAfterApiFinish() {
         final LoggingForm loggingForm = getCurrentLoggingForm();
 


### PR DESCRIPTION
## 개요

### 요약
[Feat: Job 로깅 AOP PointCut 추가](https://github.com/Kernel360/f1-JDON-Backend/pull/567) PR에서 추가했었던 Job 로깅 포인트컷 적용이 잘못되어 API 서버가 켜지지 않는 장애를 수정했습니다.

### API 서버가 켜지지 않은 원인
아래의 로그 AOP는 common모듈 QueryCounterAspect클래스에 적용되어 있습니다.
![image](https://github.com/Kernel360/f1-JDON-Backend/assets/59242594/9f98ad37-9839-46f3-b0e1-e2288256b643)
batch 서버를 구동시키면 module-batch -> module-common을 의존하는 단방향 관계로 `org.springframework.batch.core.launch.JobLauncher`라이브러리가 존재하여 batch 서버는 정상 동작하지만 
api 서버는 Spring Batch에 의존하지 않기 때문에`org.springframework.batch.core.launch.JobLauncher`포인트 컷이 적용되지 않아 API 서버를 구동하면 에러가 발생했었습니다.

[Feat: Job 로깅 AOP PointCut 추가](https://github.com/Kernel360/f1-JDON-Backend/pull/567) PR에서 테스트했을 때는 배치서버에서만 구동하고 테스트했었기에 미쳐 확인하지 못했었습니다..

### 변경한 부분
따라서 common 모듈에서 `org.springframework.batch.core.launch.JobLauncher`로 AOP 포인트컷을 적용하는게 아니라 QueryCounter라는 어노테이션을 module-common 내부에 만들고 QueryCounter어노테이션이 적용된 클래스의 모든 메서드가 실행될 때 포인트컷하도록 변경하였습니다.

JD 스케줄러 메서드가 위치한 JdScheduler 클래스에 QueryCounter을 적용하고 스케줄러가 실행될 때 해당 스케줄러에서 발생한 쿼리 개수를 로깅하도록 구현했습니다.

지금까지 API를 실행하고 발생한 Query의 개수가 로깅되었던 이유는 AOP 포인트컷이 RestController 어노테이션이 적용된 클래스에서 발생하는 모든 메서드가 반영되어있었기 때문인데요.
저의 경우처럼 RestController가 아닐 때(API에 의해 실행되지 않는 경우가 해당 되겠지요.ㅎㅎ) Query 개수를 로깅하고 싶다면 QueryCounter 어노테이션을 해당 클래스에 붙이면 동일하게 사용하실 수 있습니다.

### 변경한 결과
- JdScheduler 클래스 내부의 runAllWantedJdScrapingJob 스케줄러가 동작한 후 AOP가 정상 동작하여 실행된 Query개수를 확인 할 수 있습니다.
![image](https://github.com/Kernel360/f1-JDON-Backend/assets/59242594/ccd198d9-1998-4720-bfba-8de918aceda5)

- api 서버 구동 시 정상 실행 확인했습니다.
![image](https://github.com/Kernel360/f1-JDON-Backend/assets/59242594/af674514-dd2d-47e9-88d6-f4cce6b11930)


### 이슈

- closes: #570

---

## PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경, 주석 변경)
- [ ] 코드 리팩토링
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 파일 혹은 폴더명 수정, 삭제
- [ ] 배포 관련