### PR TITLE
Chore: 원티드 스크래핑 배치 코드 오타 수정 및 부분 리팩토링

### DIFF
--- a/module-batch/src/main/java/kernel/jdon/modulebatch/domain/wantedjdskill/repository/WantedJdSkillDao.java
+++ b/module-batch/src/main/java/kernel/jdon/modulebatch/domain/wantedjdskill/repository/WantedJdSkillDao.java
@@ -11,7 +11,7 @@ import lombok.RequiredArgsConstructor;
 
 @Component
 @RequiredArgsConstructor
-public class WantedJdSkillDto {
+public class WantedJdSkillDao {
     private final WantedJdSkillRepository wantedJdSkillRepository;
     private final JdbcWantedJdSkillRepository jdbcWantedJdSkillRepository;
 

--- a/module-batch/src/main/java/kernel/jdon/modulebatch/global/config/ScrapingWantedProperties.java
+++ b/module-batch/src/main/java/kernel/jdon/modulebatch/global/config/ScrapingWantedProperties.java
@@ -34,7 +34,15 @@ public class ScrapingWantedProperties {
     }
 
     public int getJobDetailDuplicateLimitCount() {
-        return this.scraping.part.jobDetailDuplicateLimitCount;
+        return this.scraping.jobDetailDuplicateLimitCount;
+    }
+
+    public int getJobListSleepCount() {
+        return this.scraping.jobListSleepCount;
+    }
+
+    public int getJobDetailSleepCount() {
+        return this.scraping.jobDetailSleepCount;
     }
 
     public int getSleepTimeMillis() {
@@ -67,20 +75,8 @@ public class ScrapingWantedProperties {
     public static class Scraping {
         private final int jobListLimit;
         private final int jobListOffset;
-        private final AllScraping all;
-        private final PartScraping part;
-    }
-
-    @Getter
-    @RequiredArgsConstructor
-    public static class AllScraping {
         private final int jobListSleepCount;
         private final int jobDetailSleepCount;
-    }
-
-    @Getter
-    @RequiredArgsConstructor
-    public static class PartScraping {
         private final int jobDetailDuplicateLimitCount;
     }
 }

--- a/module-batch/src/main/java/kernel/jdon/modulebatch/job/jd/reader/PartBackendWantedJdItemReader.java
+++ b/module-batch/src/main/java/kernel/jdon/modulebatch/job/jd/reader/PartBackendWantedJdItemReader.java
@@ -38,9 +38,7 @@ public class PartBackendWantedJdItemReader implements ItemReader<WantedJobDetail
         final PartJobDetailListInfo info = wantedJdClient.getPartJobDetailList(jobPosition,
             jobListFetchManager.getOffset());
 
-        if (info.isMaxDuplicate()) {
-            isLimit = true;
-        }
+        isLimit = info.isMaxDuplicate();
 
         jobListFetchManager.incrementOffset();
 

--- a/module-batch/src/main/java/kernel/jdon/modulebatch/job/jd/reader/PartFrontendWantedJdItemReader.java
+++ b/module-batch/src/main/java/kernel/jdon/modulebatch/job/jd/reader/PartFrontendWantedJdItemReader.java
@@ -38,9 +38,7 @@ public class PartFrontendWantedJdItemReader implements ItemReader<WantedJobDetai
         final PartJobDetailListInfo info = wantedJdClient.getPartJobDetailList(jobPosition,
             jobListFetchManager.getOffset());
 
-        if (info.isMaxDuplicate()) {
-            isLimit = true;
-        }
+        isLimit = info.isMaxDuplicate();
 
         jobListFetchManager.incrementOffset();
 

--- a/module-batch/src/main/java/kernel/jdon/modulebatch/job/jd/reader/fetchmanager/JobDetailFetchManager.java
+++ b/module-batch/src/main/java/kernel/jdon/modulebatch/job/jd/reader/fetchmanager/JobDetailFetchManager.java
@@ -34,11 +34,11 @@ public class JobDetailFetchManager {
     }
 
     private boolean isSleepRequired() {
-        return this.sleepCount >= scrapingWantedProperties.getScraping().getAll().getJobDetailSleepCount();
+        return this.sleepCount >= scrapingWantedProperties.getJobDetailSleepCount();
     }
 
     public boolean isDuplicateRequired(final int count) {
-        return count >= scrapingWantedProperties.getScraping().getPart().getJobDetailDuplicateLimitCount();
+        return count >= scrapingWantedProperties.getJobDetailDuplicateLimitCount();
     }
 
     private void performSleep() {

--- a/module-batch/src/main/java/kernel/jdon/modulebatch/job/jd/reader/fetchmanager/JobListFetchManager.java
+++ b/module-batch/src/main/java/kernel/jdon/modulebatch/job/jd/reader/fetchmanager/JobListFetchManager.java
@@ -40,7 +40,7 @@ public class JobListFetchManager {
     }
 
     private boolean isSleepRequired() {
-        return this.sleepCount == scrapingWantedProperties.getScraping().getAll().getJobListSleepCount();
+        return this.sleepCount == scrapingWantedProperties.getJobListSleepCount();
     }
 
     private void performSleep() {

--- a/module-batch/src/main/java/kernel/jdon/modulebatch/job/jd/writer/WantedJdItemWriter.java
+++ b/module-batch/src/main/java/kernel/jdon/modulebatch/job/jd/writer/WantedJdItemWriter.java
@@ -9,7 +9,7 @@ import org.springframework.stereotype.Component;
 
 import kernel.jdon.modulebatch.domain.skillhistory.repository.SkillHistoryDao;
 import kernel.jdon.modulebatch.domain.wantedjd.repository.WantedJdRepository;
-import kernel.jdon.modulebatch.domain.wantedjdskill.repository.WantedJdSkillDto;
+import kernel.jdon.modulebatch.domain.wantedjdskill.repository.WantedJdSkillDao;
 import kernel.jdon.modulebatch.job.jd.reader.dto.WantedJobDetailListResponse;
 import kernel.jdon.modulebatch.job.jd.reader.dto.WantedJobDetailResponse;
 import kernel.jdon.moduledomain.jobcategory.domain.JobCategory;
@@ -21,7 +21,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class WantedJdItemWriter implements ItemWriter<WantedJobDetailListResponse> {
     private final WantedJdRepository wantedJdRepository;
-    private final WantedJdSkillDto wantedJdSkillDto;
+    private final WantedJdSkillDao wantedJdSkillDao;
     private final SkillHistoryDao skillHistoryDao;
 
     @Override
@@ -54,7 +54,7 @@ public class WantedJdItemWriter implements ItemWriter<WantedJobDetailListRespons
 
     private void changeWantedJdSkillList(final WantedJobDetailResponse wantedJobDetail, final WantedJd findWantedJd,
         final List<WantedJobDetailResponse.WantedSkill> wantedJdSkillList) {
-        wantedJdSkillDto.deleteAllByWantedJdId(findWantedJd.getId());
+        wantedJdSkillDao.deleteAllByWantedJdId(findWantedJd.getId());
         createWantedJdSkill(wantedJobDetail, findWantedJd, wantedJdSkillList);
     }
 
@@ -73,6 +73,6 @@ public class WantedJdItemWriter implements ItemWriter<WantedJobDetailListRespons
         final WantedJobDetailResponse wantedJobDetail,
         final WantedJd wantedJd,
         final List<WantedJobDetailResponse.WantedSkill> wantedDetailSkillList) {
-        wantedJdSkillDto.saveWantedJdSkillList(wantedJobDetail, wantedJd, wantedDetailSkillList);
+        wantedJdSkillDao.saveWantedJdSkillList(wantedJobDetail, wantedJd, wantedDetailSkillList);
     }
 }

--- a/module-batch/src/main/resources/constant/scraping.yml
+++ b/module-batch/src/main/resources/constant/scraping.yml
@@ -20,11 +20,9 @@ scraping:
     scraping:
       job_list_limit: 100           # 각 스크래핑 요청 당 몇 개의 Job Description을 가져올지 설정
       job_list_offset: 100          # 몇 번째 Job Description부터 가져올지 설정
-      all:
-        job_list_sleep_count: 5      # 지정된 횟수 만큼 offset 단위 호출하고 대기할 지 유휴 카운트 설정.
-        job_detail_sleep_count: 10   # 지정된 횟수 만큼 jd 상세 API를 호출하고 대기할 지 유휴 카운트 설정.
-      part:
-        job_detail_duplicate_limit_count: 5 # 연속으로 중복된 JD 상세내역이 스크래핑될 때 스크래핑을 중지할 개수를 설정(항상 limit보다 작다)
+      job_list_sleep_count: 5      # 지정된 횟수 만큼 offset 단위 호출하고 대기할 지 유휴 카운트 설정.
+      job_detail_sleep_count: 10   # 지정된 횟수 만큼 jd 상세 API를 호출하고 대기할 지 유휴 카운트 설정.
+      job_detail_duplicate_limit_count: 5 # 연속으로 중복된 JD 상세내역이 스크래핑될 때 스크래핑을 중지할 개수를 설정(항상 limit보다 작다)
 
     sleep:
       threshold_count: 10 # 지정된 개수까지 Job Description을 스크래핑한 후 해당 시간 만큼 지연하도록 설정


### PR DESCRIPTION
## 개요

### 요약

원티드 스크래핑 배치 코드 중 오타가 발견되어 수정이 필요합니다.

### 변경한 부분
- 클래스명 오타를 수정했습니다. `WantedJdSkillDto` -> `WantedJdSkillDao`
- 부분 원티드 스크래핑 배치 Reader의 중복 JD 식별 조건이 불필요하게 구현되어있어 가독성이 더 좋은 조건으로 변경했습니다.
- 원티드 스크래핑 관련 상수들이 정의되있는 `scraping.yml`의 depth를 간략화하고 이에 따른 `ScrapingWantedProperties` 클래스를 수정했습니다.
- 외부에서 메서드 체이닝으로 `ScrapingWantedProperties`의 내부 값을 사용하던 코드를 단일메서드로 사용하도록 리팩토링 했습니다.

### 변경한 결과

### 이슈

- closes: #572 

---

## PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경, 주석 변경)
- [ ] 코드 리팩토링
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 파일 혹은 폴더명 수정, 삭제
- [ ] 배포 관련