### PR TITLE
Refactor: 커피챗 목록조회 API 동적쿼리에서 join을 서브쿼리로 대체

### DIFF
--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/coffeechat/infrastructure/CoffeeChatRepositoryImpl.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/coffeechat/infrastructure/CoffeeChatRepositoryImpl.java
@@ -71,8 +71,6 @@ public class CoffeeChatRepositoryImpl implements CustomCoffeeChatRepository {
         Long totalCount = jpaQueryFactory
             .select(coffeeChat.count())
             .from(coffeeChat)
-            .join(member)
-            .on(coffeeChat.member.eq(member))
             .where(
                 excludeDeleteCoffeeChat(),
                 coffeeChatTitleContains(command.getKeyword()),

--- a/module-api/src/main/java/kernel/jdon/moduleapi/domain/coffeechat/infrastructure/CoffeeChatRepositoryImpl.java
+++ b/module-api/src/main/java/kernel/jdon/moduleapi/domain/coffeechat/infrastructure/CoffeeChatRepositoryImpl.java
@@ -15,6 +15,7 @@ import org.springframework.data.domain.Pageable;
 import com.querydsl.core.types.Order;
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
 import kernel.jdon.moduleapi.domain.coffeechat.core.CoffeeChatCommand;
@@ -32,8 +33,6 @@ public class CoffeeChatRepositoryImpl implements CustomCoffeeChatRepository {
         List<Long> ids = jpaQueryFactory
             .select(coffeeChat.id)
             .from(coffeeChat)
-            .join(member)
-            .on(coffeeChat.member.eq(member))
             .where(
                 excludeDeleteCoffeeChat(),
                 coffeeChatTitleContains(command.getKeyword()),
@@ -96,7 +95,13 @@ public class CoffeeChatRepositoryImpl implements CustomCoffeeChatRepository {
     }
 
     private BooleanExpression memberJobCategoryEq(Long jobCategoryId) {
-        return jobCategoryId != null ? member.jobCategory.id.eq(jobCategoryId) : null;
+        return jobCategoryId != null ? JPAExpressions
+            .selectOne()
+            .from(member)
+            .where(
+                member.id.eq(coffeeChat.member.id),
+                member.jobCategory.id.eq(jobCategoryId)
+            ).exists() : null;
     }
 
     private BooleanExpression coffeeChatTitleContains(String keyword) {


### PR DESCRIPTION
## 개요

### 요약

- 커피챗 목록조회 API에서 분리한 `id 조회 쿼리`와 `카운트 쿼리`가 항상 멤버테이블을 조인하던 것을 조인하지 않고 서브쿼리로 대체하도록 수정했습니다.
- jobCategory 조건이 없는 경우 서브쿼리를 실행하지 않도록 최적화 했습니다.

### 변경한 부분

ids를 조회하는 쿼리와 totalCount를 조회하는 쿼리에서 조인문을 삭제헀습니다.
jobCategory조건이 있을 경우 where문의 서브쿼리를 통해 조회합니다. 

### 변경한 결과

![image](https://github.com/Kernel360/f1-JDON-Backend/assets/111513287/9c3f360a-3bb2-4e5b-b2f6-4781abeef7df)
![image](https://github.com/Kernel360/f1-JDON-Backend/assets/111513287/77194e0b-b29a-4aaa-a798-b8487ed63d5e)
![image](https://github.com/Kernel360/f1-JDON-Backend/assets/111513287/61669573-407f-44b0-87ca-b9b07a81609c)
![image](https://github.com/Kernel360/f1-JDON-Backend/assets/111513287/d544ca1a-1aa4-42b2-8289-73331bb5bd61)
jobCategory조건이 없는 경우 조인없이 커피챗 테이블을 통해서만 조회하고 그 결과 커버링 인덱스가 적용됩니다.

### 이슈

- closes: #579 

---

## PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경, 주석 변경)
- [X] 코드 리팩토링
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 파일 혹은 폴더명 수정, 삭제
- [ ] 배포 관련