### PR TITLE
Fix: 원티드 채용공고 스크래핑 API 따닥 제어

### DIFF
--- a/module-crawler/build.gradle
+++ b/module-crawler/build.gradle
@@ -26,7 +26,8 @@ dependencies {
     implementation project(':module-domain')
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
-
+    implementation 'org.redisson:redisson-spring-boot-starter:3.26.0'
+    
     // restTemplate retry
     implementation 'org.springframework.retry:spring-retry:1.2.5.RELEASE'
 

--- a/module-crawler/src/main/java/kernel/jdon/modulecrawler/domain/jd/application/JdFacade.java
+++ b/module-crawler/src/main/java/kernel/jdon/modulecrawler/domain/jd/application/JdFacade.java
@@ -18,13 +18,13 @@ public class JdFacade {
 
     private final JdService jdService;
     private final RedissonClient redissonClient;
-    private boolean isLocked = false;
 
     public void scrapeWantedJd() {
+        boolean isLocked = false;
         final RLock lock = redissonClient.getLock(LOCK_KEY);
         try {
-            final boolean isAvailable = lock.tryLock(0, TimeUnit.SECONDS);
-            if (!isAvailable) {
+            isLocked = lock.tryLock(0, TimeUnit.SECONDS);
+            if (!isLocked) {
                 throw new CrawlerException(JdErrorCode.CONFLICT_FAIL_LOCK);
             }
             jdService.scrapeWantedJd();

--- a/module-crawler/src/main/java/kernel/jdon/modulecrawler/domain/jd/application/JdFacade.java
+++ b/module-crawler/src/main/java/kernel/jdon/modulecrawler/domain/jd/application/JdFacade.java
@@ -1,16 +1,39 @@
 package kernel.jdon.modulecrawler.domain.jd.application;
 
+import java.util.concurrent.TimeUnit;
+
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
 import org.springframework.stereotype.Service;
 
 import kernel.jdon.modulecrawler.domain.jd.core.JdService;
+import kernel.jdon.modulecrawler.domain.jd.error.JdErrorCode;
+import kernel.jdon.modulecrawler.global.exception.CrawlerException;
 import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor
 public class JdFacade {
+    private static final String LOCK_KEY = "scrape:jd";
+
     private final JdService jdService;
+    private final RedissonClient redissonClient;
+    private boolean isLocked = false;
 
     public void scrapeWantedJd() {
-        jdService.scrapeWantedJd();
+        final RLock lock = redissonClient.getLock(LOCK_KEY);
+        try {
+            final boolean isAvailable = lock.tryLock(0, TimeUnit.SECONDS);
+            if (!isAvailable) {
+                throw new CrawlerException(JdErrorCode.CONFLICT_FAIL_LOCK);
+            }
+            jdService.scrapeWantedJd();
+        } catch (InterruptedException e) {
+            throw new CrawlerException(JdErrorCode.THREAD_INTERRUPTED);
+        } finally {
+            if (isLocked) {
+                lock.unlock();
+            }
+        }
     }
 }

--- a/module-crawler/src/main/java/kernel/jdon/modulecrawler/domain/jd/core/JdServiceImpl.java
+++ b/module-crawler/src/main/java/kernel/jdon/modulecrawler/domain/jd/core/JdServiceImpl.java
@@ -9,6 +9,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.client.RestTemplate;
 
 import kernel.jdon.modulecrawler.domain.jd.core.condition.JobSearchExperience;
@@ -30,6 +31,7 @@ import kernel.jdon.moduledomain.wantedjd.domain.WantedJd;
 import lombok.RequiredArgsConstructor;
 
 @Service
+@Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class JdServiceImpl implements JdService {
     private final RestTemplate restTemplate;
@@ -41,6 +43,7 @@ public class JdServiceImpl implements JdService {
     private final SkillHistoryStore skillHistoryStore;
 
     @Override
+    @Transactional
     public void scrapeWantedJd() {
         final JobSearchJobPosition[] allJobPositions = JobSearchJobPosition.getAllPositions();
 

--- a/module-crawler/src/main/java/kernel/jdon/modulecrawler/domain/jd/error/JdErrorCode.java
+++ b/module-crawler/src/main/java/kernel/jdon/modulecrawler/domain/jd/error/JdErrorCode.java
@@ -1,0 +1,38 @@
+package kernel.jdon.modulecrawler.domain.jd.error;
+
+import org.springframework.http.HttpStatus;
+
+import kernel.jdon.modulecommon.error.BaseThrowException;
+import kernel.jdon.modulecommon.error.ErrorCode;
+import kernel.jdon.modulecrawler.global.exception.CrawlerException;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public enum JdErrorCode implements ErrorCode, BaseThrowException<JdErrorCode.JobBaseException> {
+    CONFLICT_FAIL_LOCK(HttpStatus.CONFLICT, "다른 요청에 의해 이미 스케줄링 작업이 진행중 입니다."),
+    THREAD_INTERRUPTED(HttpStatus.SERVICE_UNAVAILABLE, "처리 중 문제가 발생했습니다. 잠시 후 다시 시도해주세요.");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+
+    @Override
+    public HttpStatus getHttpStatus() {
+        return httpStatus;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+
+    @Override
+    public JobBaseException throwException() {
+        return new JobBaseException(this);
+    }
+
+    public class JobBaseException extends CrawlerException {
+        public JobBaseException(JdErrorCode skillErrorCode) {
+            super(skillErrorCode);
+        }
+    }
+}

--- a/module-crawler/src/main/resources/application.yml
+++ b/module-crawler/src/main/resources/application.yml
@@ -36,22 +36,3 @@ scraping:
       max_initial: 3000
       max: 10000
       increment: 1000
-
-#  wanted:
-#    url:
-#      detail: https://www.wanted.co.kr/wd/
-#      api:
-#        detail: https://www.wanted.co.kr/api/v4/jobs/
-#        list: https://www.wanted.co.kr/api/chaos/navigation/v1/results?country=kr&
-#
-#    max_fetch_jd_list:
-#      size: 10            # 스크래핑 시 총 몇 개의 Job Description을 가져올지 설정
-#      offset: 5           # 각 스크래핑 요청 당 몇 개의 Job Description을 가져올지 설정
-#
-#    limit:
-#      fail_count: 10      # 연속으로 중복된 JD가 스크래핑될 때 제한할 개수를 설정
-#
-#    sleep:
-#      threshold_count: 10 # 지정된 개수까지 Job Description을 스크래핑한 후 해당 시간 만큼 지연하도록 설정
-#      time_millis: 1000   # 지연 시간의 길이를 밀리초 단위로 설정
-

--- a/module-crawler/src/test/java/kernel/jdon/modulecrawler/domain/jd/application/JdFacadeTest.java
+++ b/module-crawler/src/test/java/kernel/jdon/modulecrawler/domain/jd/application/JdFacadeTest.java
@@ -88,7 +88,7 @@ class JdFacadeTest {
         for (int i = 0; i < threadCount; i++) {
             Future<?> future = futures.get(i);
             try {
-                future.get(); // 스레드가 완료될 때까지 대기하고, 발생한 예외를 검사
+                future.get();
             } catch (ExecutionException e) {
                 Throwable cause = e.getCause();
                 if (cause.getCause() instanceof CrawlerException exception) {

--- a/module-crawler/src/test/java/kernel/jdon/modulecrawler/domain/jd/application/JdFacadeTest.java
+++ b/module-crawler/src/test/java/kernel/jdon/modulecrawler/domain/jd/application/JdFacadeTest.java
@@ -1,0 +1,59 @@
+package kernel.jdon.modulecrawler.domain.jd.application;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+import kernel.jdon.modulecrawler.domain.jd.core.JdService;
+import kernel.jdon.modulecrawler.global.exception.CrawlerException;
+
+@DisplayName("채용공고_스크래핑_따닥_테스트")
+@SpringBootTest
+class JdFacadeTest {
+    @MockBean
+    private JdService jdService;
+
+    @Autowired
+    private JdFacade jdFacade;
+
+    @DisplayName("멀티스레드 환경에서 다수의 요청이 들어와도 1개의 요청만 scrapeWantedJd 메서드의 락을 획득한다.")
+    @Test
+    void 채용공고_스크래핑_동시성_테스트() throws InterruptedException {
+        // given
+        final int threadCount = 10;
+        final ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
+        final CountDownLatch latch = new CountDownLatch(threadCount);
+        final AtomicInteger successCount = new AtomicInteger();
+        final AtomicInteger failCount = new AtomicInteger();
+
+        for (int i = 0; i < threadCount; i++) {
+            executorService.execute(() -> {
+                try {
+                    jdFacade.scrapeWantedJd();
+                    successCount.getAndIncrement();
+                } catch (CrawlerException e) {
+                    failCount.getAndIncrement();
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+        latch.await();
+        executorService.shutdown();
+
+        assertAll(
+            () -> assertThat(successCount.get()).isEqualTo(1),
+            () -> assertThat(failCount.get()).isEqualTo(9)
+        );
+    }
+}

--- a/module-crawler/src/test/java/kernel/jdon/modulecrawler/domain/jd/application/JdFacadeTest.java
+++ b/module-crawler/src/test/java/kernel/jdon/modulecrawler/domain/jd/application/JdFacadeTest.java
@@ -3,9 +3,13 @@ package kernel.jdon.modulecrawler.domain.jd.application;
 import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.*;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.jupiter.api.DisplayName;
@@ -15,6 +19,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 
 import kernel.jdon.modulecrawler.domain.jd.core.JdService;
+import kernel.jdon.modulecrawler.domain.jd.error.JdErrorCode;
 import kernel.jdon.modulecrawler.global.exception.CrawlerException;
 
 @DisplayName("채용공고_스크래핑_따닥_테스트")
@@ -28,7 +33,7 @@ class JdFacadeTest {
 
     @DisplayName("멀티스레드 환경에서 다수의 요청이 들어와도 1개의 요청만 scrapeWantedJd 메서드의 락을 획득한다.")
     @Test
-    void 채용공고_스크래핑_동시성_테스트() throws InterruptedException {
+    void 채용공고_스크래핑_따닥_성공_개수_테스트() throws InterruptedException {
         // given
         final int threadCount = 10;
         final ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
@@ -55,5 +60,48 @@ class JdFacadeTest {
             () -> assertThat(successCount.get()).isEqualTo(1),
             () -> assertThat(failCount.get()).isEqualTo(9)
         );
+    }
+
+    @DisplayName("멀티스레드 환경에서 스레드1이 scrapeWantedJd를 실행중일 때 스레드2에서 scrapeWantedJd 메서드 실행 시 예외를 반환한다.")
+    @Test
+    void 채용공고_스크래핑_따닥_예외반환_테스트() throws InterruptedException {
+        // given
+        final int threadCount = 2;
+        final ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
+        final CountDownLatch latch = new CountDownLatch(threadCount);
+        final List<Future<?>> futures = new ArrayList<>();
+
+        // when
+        for (int i = 0; i < threadCount; i++) {
+            futures.add(executorService.submit(() -> {
+                try {
+                    jdFacade.scrapeWantedJd();
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                } finally {
+                    latch.countDown();
+                }
+            }));
+        }
+
+        CrawlerException crawlerException = null;
+        for (int i = 0; i < threadCount; i++) {
+            Future<?> future = futures.get(i);
+            try {
+                future.get(); // 스레드가 완료될 때까지 대기하고, 발생한 예외를 검사
+            } catch (ExecutionException e) {
+                Throwable cause = e.getCause();
+                if (cause.getCause() instanceof CrawlerException exception) {
+                    crawlerException = exception;
+                }
+            }
+        }
+
+        latch.await();
+        executorService.shutdown();
+
+        // then
+        assertThat(crawlerException.getErrorCode())
+            .isEqualTo(JdErrorCode.CONFLICT_FAIL_LOCK);
     }
 }

--- a/module-crawler/src/test/resources/application.yml
+++ b/module-crawler/src/test/resources/application.yml
@@ -8,7 +8,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: validate # create-drop
+      ddl-auto: create-drop
 
     properties:
       hibernate:


### PR DESCRIPTION
## 개요

### 요약
- 원티드 채용공고 스크래핑 API의 중복 실행을 방지하기 위해 동시성 제어 코드를 추가했습니다.

### 변경한 부분
- scrapeWantedJd 메서드에 선언적 트랜잭션이 누락되어 `@Transaction` 어노테이션을 추가했습니다.
- pub-sub 기반의 `Redisson`을 사용하여 동시성을 제어했습니다.
- A요청에서 원티드 채용공고 스크래핑 API를 호출했을 때, A요청의 API가 종료되기 전에 다른 요청에서  원티드 채용공고 스크래핑 API를 실행할 수 없도록 구현했습니다.
- 구현한 코드 기반 테스트 코드를 작성했습니다.
  - 멀티스레드 환경에서 다수의 요청이 들어와도 1개의 요청만 `scrapeWantedJd` 메서드의 락을 획득하는 테스트 코드를 추가했습니다.
  - 멀티스레드 환경에서 스레드1이 `scrapeWantedJd`를 실행중일 때 스레드2에서 `scrapeWantedJd` 메서드 실행 시 예외를 반환하고 의도한 예외가 맞는지 확인하는 테스트 코드를 추가했습니다.
- 커피챗 신청에 누락된 unlock을 수정했습니다.

### 변경한 결과

#### 테스트 코드 정상 작동 결과
![image](https://github.com/Kernel360/f1-JDON-Backend/assets/59242594/cb0b818a-e4e4-47d4-92ab-5f3257ac1084)

### 이슈

- closes: #577 

---

## PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경, 주석 변경)
- [ ] 코드 리팩토링
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 파일 혹은 폴더명 수정, 삭제
- [ ] 배포 관련