### PR TITLE
Feature: crawler 모듈 실행 시 슬랙알림 설정

### DIFF
--- a/module-crawler/src/main/java/kernel/jdon/ModuleCrawlerApplication.java
+++ b/module-crawler/src/main/java/kernel/jdon/ModuleCrawlerApplication.java
@@ -1,8 +1,14 @@
 package kernel.jdon;
 
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
+import org.springframework.stereotype.Component;
+
+import kernel.jdon.modulecommon.slack.SlackSender;
+import lombok.RequiredArgsConstructor;
 
 @SpringBootApplication
 @ConfigurationPropertiesScan
@@ -10,6 +16,23 @@ public class ModuleCrawlerApplication {
 
     public static void main(String[] args) {
         SpringApplication.run(ModuleCrawlerApplication.class, args);
+    }
+
+    @Component
+    @RequiredArgsConstructor
+    class ModuleCrawlerApplicationRunner implements ApplicationRunner {
+        private static final String MODULE_NAME = "module-crawler";
+
+        private final SlackSender slackSender;
+
+        @Override
+        public void run(ApplicationArguments args) throws Exception {
+            sendServerStart();
+        }
+
+        private void sendServerStart() {
+            slackSender.sendServerStart(MODULE_NAME);
+        }
     }
 
 }

--- a/module-crawler/src/main/resources/application-dev.yml
+++ b/module-crawler/src/main/resources/application-dev.yml
@@ -24,6 +24,9 @@ spring:
 logging:
   level:
     root: info
+  slack:
+    webhook-uri: ${SLACK_WEBHOOK_URL}
+  config: classpath:logback-spring.xml
 
 decorator:
   datasource:

--- a/module-crawler/src/main/resources/application-prod.yml
+++ b/module-crawler/src/main/resources/application-prod.yml
@@ -24,6 +24,9 @@ spring:
 logging:
   level:
     root: info
+  slack:
+    webhook-uri: ${SLACK_WEBHOOK_URL}
+  config: classpath:logback-spring.xml
 
 decorator:
   datasource:


### PR DESCRIPTION
## 개요

### 요약

- 기존 api, batch 모듈과 동일하게 crawler 모듈 실행 시 슬랙 알림이 전송되도록 설정했습니다.
- `dev`환경과 `prod`환경의 application이 실행될 때 슬랙으로 알림이 전송되도록 설정했습니다.

### 변경한 부분
- `application-dev.yml`, `application-prod.yml` 파일 내부에 슬랙 URL 환경변수를 추가했습니다.
- `ApplicationRunner`를 `implement`하여 `run`메서드 내부에서 `SlackSender`클래스의 `sendServerStart` 호출하여 알림이 전송되도록 구현했습니다.

### 변경한 결과
- `dev`환경과 `prod`환경의 application이 실행될 때만 슬랙으로 알림이 전송되지만, 결과 확인을 위해 `local` 환경에 임시로 환경변수를 설정하여 서버 실행 시 슬랙채널에 알림이 전송된 것을 확인했습니다.
![image](https://github.com/Kernel360/f1-JDON-Backend/assets/59242594/1c7ee0fc-3662-44b3-91a2-fcbbb71808b2)

### 이슈

- closes: #599 

---

## PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경, 주석 변경)
- [ ] 코드 리팩토링
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 파일 혹은 폴더명 수정, 삭제
- [ ] 배포 관련