### PR TITLE
Refactor: 원티드 스크래핑 객체 리팩토링

### DIFF
--- a/module-batch/src/main/java/kernel/jdon/modulebatch/job/jd/reader/AllBackendWantedJdItemReader.java
+++ b/module-batch/src/main/java/kernel/jdon/modulebatch/job/jd/reader/AllBackendWantedJdItemReader.java
@@ -31,11 +31,11 @@ public class AllBackendWantedJdItemReader implements ItemReader<WantedJobDetailL
         ParseException,
         NonTransientResourceException {
         final JobSearchJobPosition jobPosition = JobSearchJobPosition.JOB_POSITION_SERVER;
-        final List<WantedJobDetailResponse> jobDetailList = wantedJdClient.getJobDetailList(jobPosition,
+        final List<WantedJobDetailResponse> jdList = wantedJdClient.getJdList(jobPosition,
             jobListFetchManager.getOffset());
 
         jobListFetchManager.incrementOffset();
 
-        return !jobDetailList.isEmpty() ? new WantedJobDetailListResponse(jobDetailList) : null;
+        return !jdList.isEmpty() ? new WantedJobDetailListResponse(jdList) : null;
     }
 }

--- a/module-batch/src/main/java/kernel/jdon/modulebatch/job/jd/reader/AllFrontendWantedJdItemReader.java
+++ b/module-batch/src/main/java/kernel/jdon/modulebatch/job/jd/reader/AllFrontendWantedJdItemReader.java
@@ -31,7 +31,7 @@ public class AllFrontendWantedJdItemReader implements ItemReader<WantedJobDetail
         ParseException,
         NonTransientResourceException {
         final JobSearchJobPosition jobPosition = JobSearchJobPosition.JOB_POSITION_FRONTEND;
-        final List<WantedJobDetailResponse> jobDetailList = wantedJdClient.getJobDetailList(jobPosition,
+        final List<WantedJobDetailResponse> jobDetailList = wantedJdClient.getJdList(jobPosition,
             jobListFetchManager.getOffset());
 
         jobListFetchManager.incrementOffset();

--- a/module-batch/src/main/java/kernel/jdon/modulebatch/job/jd/reader/PartBackendWantedJdItemReader.java
+++ b/module-batch/src/main/java/kernel/jdon/modulebatch/job/jd/reader/PartBackendWantedJdItemReader.java
@@ -35,7 +35,7 @@ public class PartBackendWantedJdItemReader implements ItemReader<WantedJobDetail
         }
 
         final JobSearchJobPosition jobPosition = JobSearchJobPosition.JOB_POSITION_SERVER;
-        final PartJobDetailListInfo info = wantedJdClient.getPartJobDetailList(jobPosition,
+        final PartJobDetailListInfo info = wantedJdClient.getPartJdList(jobPosition,
             jobListFetchManager.getOffset());
 
         isLimit = info.isMaxDuplicate();

--- a/module-batch/src/main/java/kernel/jdon/modulebatch/job/jd/reader/PartFrontendWantedJdItemReader.java
+++ b/module-batch/src/main/java/kernel/jdon/modulebatch/job/jd/reader/PartFrontendWantedJdItemReader.java
@@ -35,7 +35,7 @@ public class PartFrontendWantedJdItemReader implements ItemReader<WantedJobDetai
         }
 
         final JobSearchJobPosition jobPosition = JobSearchJobPosition.JOB_POSITION_FRONTEND;
-        final PartJobDetailListInfo info = wantedJdClient.getPartJobDetailList(jobPosition,
+        final PartJobDetailListInfo info = wantedJdClient.getPartJdList(jobPosition,
             jobListFetchManager.getOffset());
 
         isLimit = info.isMaxDuplicate();

--- a/module-batch/src/main/java/kernel/jdon/modulebatch/job/jd/reader/WantedJdClient.java
+++ b/module-batch/src/main/java/kernel/jdon/modulebatch/job/jd/reader/WantedJdClient.java
@@ -36,7 +36,7 @@ public class WantedJdClient {
     private final JobCategoryRepository jobCategoryRepository;
     private final WantedJdRepository wantedJdRepository;
 
-    public List<WantedJobDetailResponse> getJobDetailList(final JobSearchJobPosition jobPosition, final int offset) {
+    public List<WantedJobDetailResponse> getJdList(final JobSearchJobPosition jobPosition, final int offset) {
         final WantedJobListResponse jobList = fetchJobList(jobPosition, offset);
         final Set<Long> jobIdSet = jobList.toLinkedHashSet();
 
@@ -49,17 +49,17 @@ public class WantedJdClient {
             .toList();
     }
 
-    public PartJobDetailListInfo getPartJobDetailList(final JobSearchJobPosition jobPosition,
+    public PartJobDetailListInfo getPartJdList(final JobSearchJobPosition jobPosition,
         final int offset) {
         final WantedJobListResponse jobList = fetchJobList(jobPosition, offset);
         final Set<Long> jobIdSet = jobList.toLinkedHashSet();
 
-        return getJobDetailList(jobPosition, jobIdSet);
+        return getPartJobDetailList(jobPosition, jobIdSet);
     }
 
-    private PartJobDetailListInfo getJobDetailList(final JobSearchJobPosition jobPosition,
+    private PartJobDetailListInfo getPartJobDetailList(final JobSearchJobPosition jobPosition,
         final Set<Long> jobIdSet) {
-        List<WantedJobDetailResponse> jobDetailList = new ArrayList<>();
+        final List<WantedJobDetailResponse> jobDetailList = new ArrayList<>();
         int duplicateCount = 0;
         boolean isMaxDuplicate = false;
         for (Long jobDetailId : jobIdSet) {

--- a/module-batch/src/main/java/kernel/jdon/modulebatch/job/jd/reader/WantedJdClient.java
+++ b/module-batch/src/main/java/kernel/jdon/modulebatch/job/jd/reader/WantedJdClient.java
@@ -40,9 +40,14 @@ public class WantedJdClient {
         final WantedJobListResponse jobList = fetchJobList(jobPosition, offset);
         final Set<Long> jobIdSet = jobList.toLinkedHashSet();
 
+        return getJobDetailList(jobPosition, jobIdSet);
+    }
+
+    private List<WantedJobDetailResponse> getJobDetailList(final JobSearchJobPosition jobPosition,
+        final Set<Long> jobIdSet) {
         return jobIdSet.stream()
             .map(jobId -> {
-                WantedJobDetailResponse jobDetail = getJobDetail(jobPosition, jobId);
+                final WantedJobDetailResponse jobDetail = getJobDetail(jobPosition, jobId);
                 jobDetailFetchManager.incrementSleepCounter();
                 return jobDetail;
             })
@@ -69,7 +74,7 @@ public class WantedJdClient {
                 return new PartJobDetailListInfo(isMaxDuplicate, jobDetailList); // 중복된 채용공고 스크래핑 시 Reader 종료
             }
 
-            WantedJobDetailResponse jobDetail = getJobDetail(jobPosition, jobDetailId);
+            final WantedJobDetailResponse jobDetail = getJobDetail(jobPosition, jobDetailId);
 
             if (isJobDetailExist(jobDetail.getJobCategory(), jobDetail.getDetailJobId())) {
                 duplicateCount++;
@@ -84,7 +89,7 @@ public class WantedJdClient {
     }
 
     private WantedJobDetailResponse getJobDetail(final JobSearchJobPosition jobPosition, final Long jobDetailId) {
-        WantedJobDetailResponse jobDetail = fetchJobDetail(jobDetailId);
+        final WantedJobDetailResponse jobDetail = fetchJobDetail(jobDetailId);
         addJobDetailInfo(jobDetail, jobPosition);
 
         return jobDetail;

--- a/module-batch/src/main/java/kernel/jdon/modulebatch/job/jd/reader/WantedJdClient.java
+++ b/module-batch/src/main/java/kernel/jdon/modulebatch/job/jd/reader/WantedJdClient.java
@@ -3,10 +3,8 @@ package kernel.jdon.modulebatch.job.jd.reader;
 import static kernel.jdon.modulecommon.util.StringUtil.*;
 
 import java.util.ArrayList;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestTemplate;
@@ -40,7 +38,7 @@ public class WantedJdClient {
 
     public List<WantedJobDetailResponse> getJobDetailList(final JobSearchJobPosition jobPosition, final int offset) {
         final WantedJobListResponse jobList = fetchJobList(jobPosition, offset);
-        final Set<Long> jobIdSet = getUniqueJobIdSet(jobList);
+        final Set<Long> jobIdSet = jobList.toLinkedHashSet();
 
         return jobIdSet.stream()
             .map(jobId -> {
@@ -54,7 +52,7 @@ public class WantedJdClient {
     public PartJobDetailListInfo getPartJobDetailList(final JobSearchJobPosition jobPosition,
         final int offset) {
         final WantedJobListResponse jobList = fetchJobList(jobPosition, offset);
-        final Set<Long> jobIdSet = getUniqueJobIdSet(jobList);
+        final Set<Long> jobIdSet = jobList.toLinkedHashSet();
 
         return getJobDetailList(jobPosition, jobIdSet);
     }
@@ -125,12 +123,6 @@ public class WantedJdClient {
             createQueryString("limit", String.valueOf(limit)),
             createQueryString("offset", String.valueOf(offset))
         );
-    }
-
-    private Set<Long> getUniqueJobIdSet(WantedJobListResponse jobList) {
-        return jobList.getData().stream()
-            .map(WantedJobListResponse.Data::getId)
-            .collect(Collectors.toCollection(LinkedHashSet::new));
     }
 
     private JobCategory findByJobPosition(final JobSearchJobPosition jobPosition) {

--- a/module-batch/src/main/java/kernel/jdon/modulebatch/job/jd/reader/dto/WantedJobDetailResponse.java
+++ b/module-batch/src/main/java/kernel/jdon/modulebatch/job/jd/reader/dto/WantedJobDetailResponse.java
@@ -55,7 +55,7 @@ public class WantedJobDetailResponse {
 
     @Getter
     @NoArgsConstructor(access = AccessLevel.PRIVATE)
-    public static class JobDetail {
+    private static class JobDetail {
         private Long id;
         @JsonProperty("position")
         private String title;
@@ -75,7 +75,7 @@ public class WantedJobDetailResponse {
 
     @Getter
     @NoArgsConstructor(access = AccessLevel.PRIVATE)
-    public static class Detail {
+    private static class Detail {
         private String requirements;
         @JsonProperty("main_tasks")
         private String mainTasks;
@@ -94,14 +94,14 @@ public class WantedJobDetailResponse {
 
     @Getter
     @NoArgsConstructor(access = AccessLevel.PRIVATE)
-    public static class Company {
+    private static class Company {
         private String id;
         private String name;
     }
 
     @Getter
     @NoArgsConstructor(access = AccessLevel.PRIVATE)
-    public static class CompanyImages {
+    private static class CompanyImages {
         private String url;
     }
 }

--- a/module-batch/src/main/java/kernel/jdon/modulebatch/job/jd/reader/dto/WantedJobListResponse.java
+++ b/module-batch/src/main/java/kernel/jdon/modulebatch/job/jd/reader/dto/WantedJobListResponse.java
@@ -1,6 +1,9 @@
 package kernel.jdon.modulebatch.job.jd.reader.dto;
 
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -11,6 +14,12 @@ import lombok.NoArgsConstructor;
 public class WantedJobListResponse {
 
     private List<Data> data;
+
+    public Set<Long> toLinkedHashSet() {
+        return this.data.stream()
+            .map(Data::getId)
+            .collect(Collectors.toCollection(LinkedHashSet::new));
+    }
 
     @Getter
     @NoArgsConstructor(access = AccessLevel.PRIVATE)

--- a/module-crawler/src/main/java/kernel/jdon/modulecrawler/domain/jd/core/JdServiceImpl.java
+++ b/module-crawler/src/main/java/kernel/jdon/modulecrawler/domain/jd/core/JdServiceImpl.java
@@ -3,10 +3,8 @@ package kernel.jdon.modulecrawler.domain.jd.core;
 import static kernel.jdon.modulecommon.util.StringUtil.*;
 
 import java.util.ArrayList;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -71,7 +69,7 @@ public class JdServiceImpl implements JdService {
     public PartJobDetailListInfo getPartJobDetailList(final JobSearchJobPosition jobPosition,
         final int offset) {
         final WantedJobListResponse jobList = fetchJobList(jobPosition, offset);
-        final Set<Long> jobIdSet = getUniqueJobIdSet(jobList);
+        final Set<Long> jobIdSet = jobList.toLinkedHashSet();
 
         return getJobDetailList(jobPosition, jobIdSet);
     }
@@ -96,12 +94,6 @@ public class JdServiceImpl implements JdService {
             createQueryString("limit", String.valueOf(limit)),
             createQueryString("offset", String.valueOf(offset))
         );
-    }
-
-    private Set<Long> getUniqueJobIdSet(WantedJobListResponse jobList) {
-        return jobList.getData().stream()
-            .map(WantedJobListResponse.Data::getId)
-            .collect(Collectors.toCollection(LinkedHashSet::new));
     }
 
     private PartJobDetailListInfo getJobDetailList(final JobSearchJobPosition jobPosition,

--- a/module-crawler/src/main/java/kernel/jdon/modulecrawler/domain/jd/core/JdServiceImpl.java
+++ b/module-crawler/src/main/java/kernel/jdon/modulecrawler/domain/jd/core/JdServiceImpl.java
@@ -52,15 +52,17 @@ public class JdServiceImpl implements JdService {
 
     private void scrapeJobPositionWantedJd(final JobSearchJobPosition jobPosition) {
         final JobListFetchManager jobListFetchManager = new JobListFetchManager(scrapingWantedProperties);
-        boolean continueFetching = false;
+        boolean isContinueFetch = false;
 
-        while (!continueFetching) {
+        while (!isContinueFetch) {
             final PartJobDetailListInfo partJobDetailList = getPartJobDetailList(jobPosition,
                 jobListFetchManager.getOffset());
 
             createJobDetail(partJobDetailList.getJobDetailList());
 
-            continueFetching = partJobDetailList.isMaxDuplicate();
+            if (partJobDetailList.isMaxDuplicate() || partJobDetailList.getJobDetailList().isEmpty()) {
+                isContinueFetch = true;
+            }
 
             jobListFetchManager.incrementOffset();
         }

--- a/module-crawler/src/main/java/kernel/jdon/modulecrawler/domain/jd/core/JdServiceImpl.java
+++ b/module-crawler/src/main/java/kernel/jdon/modulecrawler/domain/jd/core/JdServiceImpl.java
@@ -109,7 +109,7 @@ public class JdServiceImpl implements JdService {
                 return new PartJobDetailListInfo(isMaxDuplicate, jobDetailList); // 중복된 채용공고 스크래핑 시 Reader 종료
             }
 
-            WantedJobDetailResponse jobDetail = getJobDetail(jobPosition, jobDetailId);
+            final WantedJobDetailResponse jobDetail = getJobDetail(jobPosition, jobDetailId);
 
             if (isJobDetailExist(jobDetail.getJobCategory(), jobDetail.getDetailJobId())) {
                 duplicateCount++;
@@ -124,7 +124,7 @@ public class JdServiceImpl implements JdService {
     }
 
     private WantedJobDetailResponse getJobDetail(final JobSearchJobPosition jobPosition, final Long jobDetailId) {
-        WantedJobDetailResponse jobDetail = fetchJobDetail(jobDetailId);
+        final WantedJobDetailResponse jobDetail = fetchJobDetail(jobDetailId);
         addJobDetailInfo(jobDetail, jobPosition);
 
         return jobDetail;

--- a/module-crawler/src/main/java/kernel/jdon/modulecrawler/domain/jd/core/dto/WantedJobListResponse.java
+++ b/module-crawler/src/main/java/kernel/jdon/modulecrawler/domain/jd/core/dto/WantedJobListResponse.java
@@ -23,7 +23,7 @@ public class WantedJobListResponse {
 
     @Getter
     @NoArgsConstructor(access = AccessLevel.PRIVATE)
-    public static class Data {
+    private static class Data {
         private Long id;
     }
 }

--- a/module-crawler/src/main/java/kernel/jdon/modulecrawler/domain/jd/core/dto/WantedJobListResponse.java
+++ b/module-crawler/src/main/java/kernel/jdon/modulecrawler/domain/jd/core/dto/WantedJobListResponse.java
@@ -1,6 +1,9 @@
 package kernel.jdon.modulecrawler.domain.jd.core.dto;
 
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -11,6 +14,12 @@ import lombok.NoArgsConstructor;
 public class WantedJobListResponse {
 
     private List<Data> data;
+
+    public Set<Long> toLinkedHashSet() {
+        return this.data.stream()
+            .map(Data::getId)
+            .collect(Collectors.toCollection(LinkedHashSet::new));
+    }
 
     @Getter
     @NoArgsConstructor(access = AccessLevel.PRIVATE)


### PR DESCRIPTION
## 개요

### 요약
- 원티드 수동 스크래핑 API의 무한루프 현상을 방지하는 조건을 추가했습니다.
- 코드의 가독성을 위해 메서드 분리가 필요한 코드에 분리 적용했습니다.
- 원티드 API의 json 데이터 바인딩 역할의 DTO내 존재하는 내부클래스의 접근제어자를 변경했습니다.
- 변경가능성 없는 인스턴스에 `final` 키워드를 추가했습니다.
- 모호하거나 중복된 메서드 이름을 더 명확하게 수정했습니다.

### 변경한 부분
- 원티드 수동 스크래핑 API에서 스크래핑 중단 조건에 스크래핑한 데이터가 0개라면 중지하는 조건을 추가했습니다.
- 기존에는 module-batch 내의 WantedJdClient 클래스와 module-crawler 내의 JdServiceImpl 클래스에서 WantedJobListResponse의 내부 클래스인 Data에 의존하고 있었습니다. 이는 getUniqueJobIdSet 메서드를 통해 WantedJobListResponse의 내부 필드인 List<Data>를 LinkedHashSet<Data>으로 캐스팅하는 역할을 수행하기 위해서였습니다. 이로 인해 Data 클래스의 접근 제어자를 public으로 열어두어야 했습니다.
`WantedJobListResponse`내부에서 `List<Data>`를 `LinkedHashSet<Data>`으로 캐스팅하여 제공한다면 더이상 `Data`에 의존할 필요가 없게되고, 비즈니스로직 상 원티드 채용공고의 id의 `List`를 스크래핑하여 항상 `LinkedHashSet`으로 캐스팅 해야하기 때문에, `WantedJobListResponse`가 자신의 데이터를 캐스팅해서 반환하는 책임을 갖는것이 적절하다고 생각했습니다.
이에따라 `WantedJobDetailResponse` 자체에서 캐스팅할 수 있도록 `getUniqueJobIdSet` 메서드를 `WantedJobDetailResponse` 내부의 `toLinkedHashSet` 메서드를 생성하여 이동시켰습니다.
따라서 `WantedJobDetailResponse`는 `WantedJobListResponse`의 내부 구현 세부 사항에 대한 의존성을 줄이고, `WantedJobListResponse`는 원하는 형식으로 데이터를 적절하게 변환하는 책임을 갖도록 구현했습니다.
- 원티드 API의 json 데이터 바인딩 역할의 `WantedJobListResponse`, `WantedJobDetailResponse` DTO 내 외부에서 사용하지 않아도 되는 내부클래스의 접근제어자를 `private` 으로 변경했습니다.
- 코드 내 변경가능성 없는 인스턴스에 `final` 키워드를 추가했습니다.
- 모호하거나 중복된 메서드 이름을 더 명확하게 수정했습니다.

### 변경한 결과
- 원티드 채용공고 수동 API 정상작동 확인했습니다. 
<img width="664" alt="image" src="https://github.com/Kernel360/f1-JDON-Backend/assets/59242594/6d36a25d-2260-4089-b9a8-cff234654ae2">

### 이슈

- closes: #603

---

## PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경, 주석 변경)
- [x] 코드 리팩토링
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 파일 혹은 폴더명 수정, 삭제
- [ ] 배포 관련